### PR TITLE
Move keyboard shortcuts and feedback sections to homepage

### DIFF
--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -181,10 +181,10 @@ export function Navigation({ onLinkClick, isLoggedIn }: NavigationProps) {
       {/* Fixed bottom: load more/show less */}
       <Box style={{ flexShrink: 0 }}>
         {isLoggedIn && friendsData?.friends && friendsData.friends.length > FRIENDS_PAGE_SIZE && (
-          <Box pt={4} pb="xs">
+          <Box pt="xs" pb="xs">
             {friendsData.friends.length > friendsVisible && (
               <Anchor
-                size="xs"
+                size="sm"
                 c="blue"
                 fw={500}
                 style={{ display: "block", cursor: "pointer" }}
@@ -195,10 +195,10 @@ export function Navigation({ onLinkClick, isLoggedIn }: NavigationProps) {
             )}
             {friendsVisible > FRIENDS_PAGE_SIZE && (
               <Anchor
-                size="xs"
+                size="sm"
                 c="blue"
                 fw={500}
-                mt={friendsData.friends.length > friendsVisible ? 4 : 0}
+                mt={friendsData.friends.length > friendsVisible ? 6 : 0}
                 style={{ display: "block", cursor: "pointer" }}
                 onClick={() => setFriendsVisible(FRIENDS_PAGE_SIZE)}
               >

--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -2,7 +2,6 @@ import {
   IconHome,
   IconMessage,
   IconLogin,
-  IconButterfly,
   IconSettings,
 } from "@tabler/icons-react";
 import { useLocation, Link, useNavigate } from "react-router-dom";
@@ -70,22 +69,6 @@ export function Navigation({ onLinkClick, isLoggedIn }: NavigationProps) {
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [isLoggedIn, navigate, onLinkClick]);
-
-  const ShortcutHint = ({ label, hint }: { label: string; hint: string }) => (
-    <Box
-      visibleFrom="sm"
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-        width: "100%",
-      }}
-    >
-      <Text size="xs">{label}</Text>
-      <Text size="xs" c="dimmed">
-        {hint.replace("Alt", "Alt/Cmd")}
-      </Text>
-    </Box>
-  );
 
   return (
     <Box style={{ display: "flex", flexDirection: "column", height: "100%" }}>
@@ -195,7 +178,7 @@ export function Navigation({ onLinkClick, isLoggedIn }: NavigationProps) {
       {/* Spacer when logged out keeps the bottom section pinned */}
       {!isLoggedIn && <Box style={{ flex: 1 }} />}
 
-      {/* Fixed bottom: load more/show less, keyboard shortcuts, Bluesky link */}
+      {/* Fixed bottom: load more/show less */}
       <Box style={{ flexShrink: 0 }}>
         {isLoggedIn && friendsData?.friends && friendsData.friends.length > FRIENDS_PAGE_SIZE && (
           <Box pt={4} pb="xs">
@@ -224,36 +207,6 @@ export function Navigation({ onLinkClick, isLoggedIn }: NavigationProps) {
             )}
           </Box>
         )}
-        <Divider visibleFrom="sm" mt="md" />
-        <Box mt="md" mb="md" visibleFrom="sm">
-          <Text size="sm" c="dimmed" mb="xs">
-            Keyboard Shortcuts:
-          </Text>
-          <ShortcutHint label="Home" hint="Alt+H" />
-          {isLoggedIn ? (
-            <>
-              <ShortcutHint label="Messages" hint="Alt+M" />
-              <ShortcutHint label="Settings" hint="Alt+S" />
-              <ShortcutHint label="Focus/Cycle Cards" hint="Alt+R" />
-              <ShortcutHint label="Navigate Cards" hint="↑/↓" />
-            </>
-          ) : (
-            <ShortcutHint label="Login" hint="Alt+L" />
-          )}
-        </Box>
-        <Divider />
-        <Text size="xs" my="md" ta="center">
-          Questions? Feedback? Reach out on Bluesky
-        </Text>
-        <NavLink
-          label="@navyfragen.app"
-          component="a"
-          href="https://bsky.app/profile/navyfragen.app"
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={handleClick}
-          leftSection={<IconButterfly size="1rem" stroke={1.5} />}
-        />
       </Box>
     </Box>
   );

--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -5,7 +5,7 @@ import {
   IconSettings,
 } from "@tabler/icons-react";
 import { useLocation, Link, useNavigate } from "react-router-dom";
-import { Divider, NavLink, Text, Box, Skeleton, Stack, Avatar, Group, Anchor } from "@mantine/core";
+import { Divider, NavLink, Text, Box, Skeleton, Stack, Avatar, Group, Button } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { useFriends } from "./api/profileService";
 
@@ -183,27 +183,25 @@ export function Navigation({ onLinkClick, isLoggedIn }: NavigationProps) {
         {isLoggedIn && friendsData?.friends && friendsData.friends.length > FRIENDS_PAGE_SIZE && (
           <Box pt="xs" pb="xs">
             {friendsData.friends.length > friendsVisible && (
-              <Anchor
-                size="sm"
-                c="blue"
-                fw={500}
-                style={{ display: "block", cursor: "pointer" }}
+              <Button
+                variant="subtle"
+                size="xs"
+                fullWidth
                 onClick={() => setFriendsVisible((v) => v + FRIENDS_PAGE_SIZE)}
               >
                 ↓ Load {friendsData.friends.length - friendsVisible} more
-              </Anchor>
+              </Button>
             )}
             {friendsVisible > FRIENDS_PAGE_SIZE && (
-              <Anchor
-                size="sm"
-                c="blue"
-                fw={500}
-                mt={friendsData.friends.length > friendsVisible ? 6 : 0}
-                style={{ display: "block", cursor: "pointer" }}
+              <Button
+                variant="subtle"
+                size="xs"
+                fullWidth
+                mt={friendsData.friends.length > friendsVisible ? 4 : 0}
                 onClick={() => setFriendsVisible(FRIENDS_PAGE_SIZE)}
               >
                 ↑ Show less
-              </Anchor>
+              </Button>
             )}
           </Box>
         )}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,14 +10,26 @@ import {
   Box,
   Loader,
   Skeleton,
+  SimpleGrid,
+  Group,
+  Anchor,
 } from "@mantine/core";
+import { IconButterfly } from "@tabler/icons-react";
 import { useSession } from "../api/authService";
 import React from "react";
 import { useSyncMessages } from "../api/messageService";
 
+const ShortcutHint = ({ label, hint }: { label: string; hint: string }) => (
+  <Box style={{ display: "flex", justifyContent: "space-between", width: "100%" }}>
+    <Text size="xs">{label}</Text>
+    <Text size="xs" c="dimmed">{hint.replace("Alt", "Alt/Cmd")}</Text>
+  </Box>
+);
+
 export default function Home() {
   const { data: sessionData, isLoading } = useSession();
   const syncMessagesMutation = useSyncMessages();
+  const isLoggedIn = !!sessionData?.isLoggedIn;
 
   React.useEffect(() => {
     if (sessionData?.did) {
@@ -108,6 +120,45 @@ export default function Home() {
           </Center>
         </Paper>
       )}
+
+      <SimpleGrid cols={{ base: 1, sm: 2 }} mt="xl">
+        <Paper p="lg" radius="md" withBorder shadow="xs">
+          <Text size="sm" fw={600} c="dimmed" mb="sm" tt="uppercase" style={{ letterSpacing: "0.05em" }}>
+            Keyboard Shortcuts
+          </Text>
+          <Stack gap={6}>
+            <ShortcutHint label="Home" hint="Alt+H" />
+            {isLoggedIn ? (
+              <>
+                <ShortcutHint label="Messages" hint="Alt+M" />
+                <ShortcutHint label="Settings" hint="Alt+S" />
+                <ShortcutHint label="Focus/Cycle Cards" hint="Alt+R" />
+                <ShortcutHint label="Navigate Cards" hint="↑/↓" />
+              </>
+            ) : (
+              <ShortcutHint label="Login" hint="Alt+L" />
+            )}
+          </Stack>
+        </Paper>
+
+        <Paper p="lg" radius="md" withBorder shadow="xs">
+          <Text size="sm" fw={600} c="dimmed" mb="sm" tt="uppercase" style={{ letterSpacing: "0.05em" }}>
+            Questions? Feedback?
+          </Text>
+          <Text size="sm" mb="md">Reach out to us on Bluesky</Text>
+          <Anchor
+            href="https://bsky.app/profile/navyfragen.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+          >
+            <Group gap="xs">
+              <IconButterfly size="1rem" stroke={1.5} />
+              @navyfragen.app
+            </Group>
+          </Anchor>
+        </Paper>
+      </SimpleGrid>
     </>
   );
 }

--- a/client/src/tests/pages/Home.test.tsx
+++ b/client/src/tests/pages/Home.test.tsx
@@ -29,7 +29,7 @@ describe("Home page", () => {
   it("shows skeleton while session is loading", () => {
     mockUseSession.mockReturnValue({ data: undefined, isLoading: true } as any);
     renderWithProviders(<Home />);
-    expect(screen.getByText(/navyfragen/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /navyfragen/i })).toBeInTheDocument();
     expect(screen.queryByText(/get started/i)).toBeNull();
     expect(screen.queryByText(/view your messages/i)).toBeNull();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2569,9 +2569,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2587,9 +2584,6 @@
             "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2607,9 +2601,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2625,9 +2616,6 @@
             "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2645,9 +2633,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2663,9 +2648,6 @@
             "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2683,9 +2665,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2702,9 +2681,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2720,9 +2696,6 @@
             "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2746,9 +2719,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2770,9 +2740,6 @@
             "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2796,9 +2763,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2820,9 +2784,6 @@
             "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2846,9 +2807,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2871,9 +2829,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2895,9 +2850,6 @@
             "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removed the "Keyboard Shortcuts" and "Questions? Feedback?" sections from the sidebar (`Navigation.tsx`)
- Added both sections to the homepage (`Home.tsx`) in a responsive `SimpleGrid` — 2 columns on `sm`+ screens, 1 column on mobile
- Shortcuts are now visible on all screen sizes (previously hidden on mobile since the sidebar collapses)
- Keyboard navigation event listener stays in `Navigation.tsx` — only the display was moved

## Test plan

- [ ] Visit the homepage logged out — verify "Keyboard Shortcuts" (Home, Login) and "Questions? Feedback?" cards appear below the landing content
- [ ] Visit the homepage logged in — verify shortcuts update to show Messages, Settings, Focus/Cycle Cards, Navigate Cards
- [ ] Check on a narrow (mobile) viewport — both cards stack vertically
- [ ] Check on a wide (desktop) viewport — both cards appear side by side
- [ ] Confirm the sidebar no longer shows the shortcuts or feedback sections
- [ ] Verify keyboard shortcuts (Alt+H, Alt+M, etc.) still function correctly

https://claude.ai/code/session_01AeKXXyjd7TaujLMXGg7R3d
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeKXXyjd7TaujLMXGg7R3d)_