### PR TITLE
Add Navyfragen Feed and Daily Notifications settings cards

### DIFF
--- a/client/src/api/profileService.ts
+++ b/client/src/api/profileService.ts
@@ -37,6 +37,10 @@ export interface FriendsResponse {
   friends: Friend[];
 }
 
+export interface BotFollowResponse {
+  following: boolean;
+}
+
 // Query keys
 export const profileKeys = {
   all: ["profiles"] as const,
@@ -45,6 +49,7 @@ export const profileKeys = {
   resolveHandle: (handle: string) =>
     [...profileKeys.all, "resolve", handle] as const,
   friends: () => [...profileKeys.all, "friends"] as const,
+  botFollow: () => [...profileKeys.all, "bot-follow"] as const,
 };
 
 // API Services
@@ -67,6 +72,10 @@ export const profileService = {
       `/user-exists/${encodeURIComponent(did)}`
     );
   },
+
+  // Check if the logged-in user follows the notification bot
+  checkBotFollow: (): Promise<BotFollowResponse> =>
+    apiClient.get<BotFollowResponse>("/check-bot-follow"),
 
   // Resolve handle to DID
   resolveHandle: (handle: string): Promise<ResolveHandleResponse> => {
@@ -106,6 +115,16 @@ export function useFriends(enabled: boolean) {
     enabled,
     staleTime: ONE_DAY,
     refetchOnWindowFocus: false,
+    retry: false,
+  });
+}
+
+export function useBotFollow(enabled: boolean) {
+  return useQuery({
+    queryKey: profileKeys.botFollow(),
+    queryFn: () => profileService.checkBotFollow(),
+    enabled,
+    staleTime: 5 * 60 * 1000,
     retry: false,
   });
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -29,6 +29,7 @@ import {
 } from "../api/settingsService";
 import { useInstallPrompt } from "../components/InstallPromptContext";
 import { themes } from "../lib/themes";
+import { useBotFollow } from "../api/profileService";
 
 export default function Settings() {
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);
@@ -59,6 +60,9 @@ export default function Settings() {
   const { data: userStats, isLoading: statsLoading } = useUserStats();
   const { data: pdsInfo, isLoading: pdsLoading } = usePdsInfo();
   const { installPrompt, setInstallPrompt } = useInstallPrompt();
+  const { data: botFollowData, isLoading: botFollowLoading } = useBotFollow(
+    Boolean(session?.isLoggedIn)
+  );
 
   const handleInstallClick = async () => {
     if (!installPrompt) {
@@ -320,6 +324,88 @@ export default function Settings() {
                       disabled={updateSettings.isPending}
                     />
                   </Box>
+                )}
+              </Paper>
+            </Grid.Col>
+            <Grid.Col
+              span={{ base: 12, md: 6, lg: 4 }}
+              style={{ display: "flex" }}
+            >
+              <Paper
+                shadow="sm"
+                p="lg"
+                radius="md"
+                withBorder
+                style={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <Box style={{ flexGrow: 1 }}>
+                  <Title order={3}>Navyfragen Feed</Title>
+                  <Text mt="sm" c="dimmed">
+                    Browse anonymous questions and answers posted by everyone on
+                    Navyfragen worldwide. This feed may contain content intended
+                    for adults — view at your own discretion.
+                  </Text>
+                  <Divider my="md" />
+                </Box>
+                <Button
+                  component="a"
+                  href="https://bsky.app/profile/navyfragen.app/feed/navyfragen"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  fullWidth
+                  mt="auto"
+                  variant="outline"
+                >
+                  Open Feed on Bluesky
+                </Button>
+              </Paper>
+            </Grid.Col>
+            <Grid.Col
+              span={{ base: 12, md: 6, lg: 4 }}
+              style={{ display: "flex" }}
+            >
+              <Paper
+                shadow="sm"
+                p="lg"
+                radius="md"
+                withBorder
+                style={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <Box style={{ flexGrow: 1 }}>
+                  <Title order={3}>Daily Notifications</Title>
+                  <Text mt="sm" c="dimmed">
+                    Follow the Navyfragen notification bot on Bluesky to receive
+                    a daily alert when you have new messages in your inbox.
+                  </Text>
+                  <Divider my="md" />
+                </Box>
+                {botFollowLoading ? (
+                  <Skeleton height={36} radius="sm" mt="auto" />
+                ) : botFollowData?.following ? (
+                  <Alert color="green" title="Notifications enabled" mt="auto">
+                    You are following the notification bot and will receive daily
+                    alerts for new messages.
+                  </Alert>
+                ) : (
+                  <Button
+                    component="a"
+                    href="https://bsky.app/profile/did:plc:3d4awubjiftylwrhhyp5vl7i"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    fullWidth
+                    mt="auto"
+                    variant="outline"
+                  >
+                    Follow Notification Bot
+                  </Button>
                 )}
               </Paper>
             </Grid.Col>

--- a/server/src/controllers/profile-controller.ts
+++ b/server/src/controllers/profile-controller.ts
@@ -5,6 +5,8 @@ import { Logger } from "pino";
 import { initializeAgentFromSession } from "#/auth/session-agent";
 import type { AppContext } from "../index";
 
+const BOT_DID = "did:plc:3d4awubjiftylwrhhyp5vl7i";
+
 export class ProfileController {
   constructor(
     private profileService: ProfileService,
@@ -86,6 +88,32 @@ export class ProfileController {
     } catch (err) {
       this.logger.error({ err, did: userDid }, "Failed to fetch friends on app");
       return res.status(500).json({ error: "Failed to fetch friends" });
+    }
+  };
+
+  /**
+   * Check if the logged-in user follows the notification bot
+   */
+  checkBotFollow = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<express.Response> => {
+    const userDid = req.session?.did;
+    if (!userDid) {
+      return res.status(403).json({ error: "Not authenticated" });
+    }
+
+    const agent = await initializeAgentFromSession(req, this.ctx);
+    if (!agent) {
+      return res.status(401).json({ error: "Session expired" });
+    }
+
+    try {
+      const following = await this.profileService.checkFollowsBot(agent, BOT_DID);
+      return res.json({ following });
+    } catch (err) {
+      this.logger.error({ err, did: userDid }, "Failed to check bot follow status");
+      return res.status(500).json({ error: "Failed to check bot follow status" });
     }
   };
 

--- a/server/src/routes/profile-routes.ts
+++ b/server/src/routes/profile-routes.ts
@@ -31,6 +31,8 @@ export function profileRoutes(
 
   router.get("/friends", handler(profileController.getFriends));
 
+  router.get("/check-bot-follow", handler(profileController.checkBotFollow));
+
   router.get(
     "/resolve-handle/:handle",
     profileController.validateResolveHandle,

--- a/server/src/services/profile-service.ts
+++ b/server/src/services/profile-service.ts
@@ -119,6 +119,17 @@ export class ProfileService {
     return followed.filter((f) => appUserDids.has(f.did));
   }
 
+  async checkFollowsBot(agent: Agent, botDid: string): Promise<boolean> {
+    try {
+      const res = await agent.getProfile({ actor: botDid });
+      if (!res.success) return false;
+      return !!res.data.viewer?.following;
+    } catch (err) {
+      this.logger.error({ err, botDid }, "Failed to check bot follow status");
+      return false;
+    }
+  }
+
   async resolveHandleToDid(handle: string): Promise<string> {
     let did: string | undefined;
     try {


### PR DESCRIPTION
## Summary

- **Navyfragen Feed card**: Links to the global Bluesky feed (`https://bsky.app/profile/navyfragen.app/feed/navyfragen`) with an inline NSFW disclaimer in the description text
- **Daily Notifications card**: Uses a new `GET /check-bot-follow` endpoint to check if the logged-in user follows the notification bot (`did:plc:3d4awubjiftylwrhhyp5vl7i`); shows a green confirmation alert when already following, or a "Follow Notification Bot" button that links to the bot's Bluesky profile
- Server-side: `ProfileService.checkFollowsBot` calls `agent.getProfile()` on the bot DID and checks `viewer.following`; wired up via `ProfileController.checkBotFollow` and a new `GET /check-bot-follow` route
- Client-side: `BotFollowResponse` interface, `profileService.checkBotFollow()`, `profileKeys.botFollow()` query key, and `useBotFollow(enabled)` React Query hook added to `profileService.ts`

## Test plan

- [ ] Log in and navigate to Settings
- [ ] Verify the Navyfragen Feed card appears with the NSFW disclaimer and "Open Feed on Bluesky" button that opens the correct URL in a new tab
- [ ] Verify the Daily Notifications card appears; if not following the bot, the "Follow Notification Bot" button shows and links to the correct Bluesky profile
- [ ] Follow the bot account on Bluesky, reload Settings, and verify the card now shows the green "Notifications enabled" alert

https://claude.ai/code/session_012YKWT3LUuxmgcJZTqnmwVj

---
_Generated by [Claude Code](https://claude.ai/code/session_012YKWT3LUuxmgcJZTqnmwVj)_