### PR TITLE
Enlarge delete button in inbox messages

### DIFF
--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -625,7 +625,7 @@ export default function Messages() {
                               variant="subtle"
                               loading={deletingTid === msg.tid}
                             >
-                              <IconTrash size={20} />
+                              <IconTrash size={16} />
                             </ActionIcon>
                           </Group>
                           <Center py="xs">
@@ -645,10 +645,7 @@ export default function Messages() {
                           </Center>
                           {respondingTid === msg.tid && (
                             <Stack gap="xs">
-                              <Divider
-                                color="rgba(255,255,255,0.15)"
-                                my={2}
-                              />
+                              <Divider color="rgba(255,255,255,0.15)" my={2} />
                               <Textarea
                                 ref={textareaRef}
                                 value={responseText}

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -616,7 +616,7 @@ export default function Messages() {
                               )}
                             </Text>
                             <ActionIcon
-                              size="sm"
+                              size="lg"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleDeleteRequest(msg.tid);
@@ -625,7 +625,7 @@ export default function Messages() {
                               variant="subtle"
                               loading={deletingTid === msg.tid}
                             >
-                              <IconTrash size={14} />
+                              <IconTrash size={20} />
                             </ActionIcon>
                           </Group>
                           <Center py="xs">


### PR DESCRIPTION
## Summary
- Increased `ActionIcon` size from `sm` to `lg`
- Increased `IconTrash` icon size from `14` to `20`

## Test plan
- [ ] Open the inbox/messages page
- [ ] Verify the delete (trash) button on each message card is visibly larger
- [ ] Confirm the button still triggers delete correctly

https://claude.ai/code/session_013LnvYBgeZd7BAEQBjpt8ra

---
_Generated by [Claude Code](https://claude.ai/code/session_013LnvYBgeZd7BAEQBjpt8ra)_