### PR TITLE
Add skeleton loading state to PublicProfile; fix ESLint v9 and TypeScript config

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,0 +1,68 @@
+import js from "@eslint/js";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import importPlugin from "eslint-plugin-import";
+import prettier from "eslint-config-prettier";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
+
+  // TypeScript — flat/recommended covers .ts/.tsx and sets the parser
+  ...tseslint.configs["flat/recommended"],
+
+  // React flat config
+  react.configs.flat.recommended,
+
+  // React hooks flat config (v5+ format)
+  reactHooks.configs["recommended-latest"],
+
+  // Per-file overrides: browser globals, import plugin, project-specific rules
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    plugins: {
+      import: importPlugin,
+    },
+    languageOptions: {
+      globals: Object.fromEntries(
+        Object.entries({ ...globals.browser, ...globals.es2021 }).map(
+          ([k, v]) => [k.trim(), v]
+        )
+      ),
+    },
+    settings: {
+      react: { version: "detect" },
+    },
+    rules: {
+      "no-console": "warn",
+      "react/react-in-jsx-scope": "off",
+      "import/order": [
+        "error",
+        {
+          groups: [
+            "builtin",
+            "external",
+            "internal",
+            "parent",
+            "sibling",
+            "index",
+            "object",
+            "type",
+          ],
+          "newlines-between": "always",
+          alphabetize: { order: "asc", caseInsensitive: true },
+        },
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+    },
+  },
+
+  // Prettier must be last — disables formatting-related rules
+  { rules: prettier.rules },
+];

--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -1,12 +1,4 @@
 import {
-  IconHome,
-  IconMessage,
-  IconLogin,
-  IconSettings,
-  IconUser,
-} from "@tabler/icons-react";
-import { useLocation, Link, useNavigate } from "react-router-dom";
-import {
   NavLink,
   Text,
   Box,
@@ -17,7 +9,16 @@ import {
   Button,
   CopyButton,
 } from "@mantine/core";
+import {
+  IconHome,
+  IconMessage,
+  IconLogin,
+  IconSettings,
+  IconUser,
+} from "@tabler/icons-react";
 import { useEffect } from "react";
+import { useLocation, Link, useNavigate } from "react-router-dom";
+
 import { useFriends } from "./api/profileService";
 import { useUserStats } from "./api/settingsService";
 import { WinkMark } from "./components/WinkMark";

--- a/client/src/api/authService.ts
+++ b/client/src/api/authService.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, UseQueryResult } from "@tanstack/react-query";
+
 import { apiClient, ApiError } from "./apiClient";
 import { queryClient } from "./queryClient";
 

--- a/client/src/api/messageService.ts
+++ b/client/src/api/messageService.ts
@@ -4,6 +4,7 @@ import {
   UseQueryOptions,
   UseQueryResult,
 } from "@tanstack/react-query";
+
 import { apiClient, ApiError } from "./apiClient";
 import { queryClient } from "./queryClient";
 import { settingsKeys } from "./settingsService";

--- a/client/src/api/profileService.ts
+++ b/client/src/api/profileService.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+
 import { apiClient } from "./apiClient";
 
 /**

--- a/client/src/api/settingsService.ts
+++ b/client/src/api/settingsService.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+
 import { apiClient, ApiError } from "./apiClient";
 import { queryClient } from "./queryClient";
 

--- a/client/src/components/Wordmark.tsx
+++ b/client/src/components/Wordmark.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@mantine/core";
+
 import { WinkMark } from "./WinkMark";
 
 interface WordmarkProps {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,44 +1,46 @@
-import React, { useEffect, useRef } from "react";
-import ReactDOM from "react-dom/client";
 import {
+  ActionIcon,
   AppShell,
+  Avatar,
+  Box,
   Burger,
-  MantineProvider,
-  Group,
+  Button,
   Container,
   Flex,
-  Avatar,
-  Text,
-  Menu,
-  Button,
-  ActionIcon,
-  useMantineColorScheme,
-  useComputedColorScheme,
-  Box,
+  Group,
   Loader,
+  MantineProvider,
+  Menu,
   Paper,
+  Text,
   Title,
+  useComputedColorScheme,
+  useMantineColorScheme,
 } from "@mantine/core";
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { Notifications } from "@mantine/notifications";
+import { IconLogout, IconMoon, IconSun, IconUser } from "@tabler/icons-react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { queryClient } from "./api/queryClient";
+import React, { useEffect, useRef } from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
+
 import { useSession, useLogout } from "./api/authService";
+import { queryClient } from "./api/queryClient";
+import { InstallPromptProvider } from "./components/InstallPromptContext";
+import { WinkMark } from "./components/WinkMark";
+import { Wordmark } from "./components/Wordmark";
+import { Navigation } from "./Navigation";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Messages from "./pages/Messages";
-import Settings from "./pages/Settings";
-import PublicProfile from "./pages/PublicProfile";
 import OAuthCallback from "./pages/OAuthCallback";
+import PublicProfile from "./pages/PublicProfile";
+import Settings from "./pages/Settings";
+import navyfragenTheme from "./Theme";
+
 import "@mantine/core/styles.css";
 import "./index.css";
-import { IconMoon, IconSun, IconUser, IconLogout } from "@tabler/icons-react";
-import { Notifications } from "@mantine/notifications";
-import navyfragenTheme from "./Theme";
-import { Navigation } from "./Navigation";
-import { InstallPromptProvider } from "./components/InstallPromptContext";
-import { Wordmark } from "./components/Wordmark";
-import { WinkMark } from "./components/WinkMark";
 
 function AppLayout() {
   const [opened, setOpened] = React.useState(false);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import {
   Button,
   List,
@@ -13,8 +12,10 @@ import {
   useComputedColorScheme,
 } from "@mantine/core";
 import { IconBrandGithub } from "@tabler/icons-react";
-import { useSession } from "../api/authService";
 import React from "react";
+import { Link } from "react-router-dom";
+
+import { useSession } from "../api/authService";
 import { useSyncMessages } from "../api/messageService";
 import { WinkMark } from "../components/WinkMark";
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -99,6 +99,9 @@ export default function Login() {
               value={handle}
               onChange={(e) => setHandle(e.target.value)}
               required
+              autoCorrect="off"
+              autoCapitalize="none"
+              spellCheck={false}
               styles={{
                 label: { color: "rgba(253,248,255,0.8)", fontWeight: 600 },
                 input: {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import {
   Button,
   TextInput,
@@ -10,8 +9,10 @@ import {
   Stack,
   Notification,
 } from "@mantine/core";
+import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { z } from "zod";
+
 import { useLogin } from "../api/authService";
 import { WinkMark } from "../components/WinkMark";
 

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState, useRef } from "react";
 import {
   Title,
   Text,
@@ -18,6 +17,11 @@ import {
   SimpleGrid,
   useComputedColorScheme,
 } from "@mantine/core";
+import { useLocalStorage } from "@mantine/hooks";
+import { IconClipboard, IconSend2, IconTrash } from "@tabler/icons-react";
+import { useEffect, useState, useRef } from "react";
+
+import { ApiError } from "../api/apiClient";
 import { useSession } from "../api/authService";
 import {
   useMessages,
@@ -27,13 +31,12 @@ import {
   Message,
 } from "../api/messageService";
 import { useUserSettings, useUpdateUserSettings } from "../api/settingsService";
-import { ApiError } from "../api/apiClient";
-import { themes } from "../lib/themes";
-import { IconClipboard, IconSend2, IconTrash } from "@tabler/icons-react";
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import ShareButton from "../components/ShareButton";
-import { useLocalStorage } from "@mantine/hooks";
 import { WinkMark } from "../components/WinkMark";
+import { themes } from "../lib/themes";
+
+
 
 const shortlinkurl =
   import.meta.env.VITE_SHORTLINK_URL || "localhost:5173/profile";
@@ -1033,9 +1036,11 @@ export default function Messages() {
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
-                          isExpanded
-                            ? setRespondingTid(null)
-                            : handlePrepareResponse(msg.tid);
+                          if (isExpanded) {
+                            setRespondingTid(null);
+                          } else {
+                            handlePrepareResponse(msg.tid);
+                          }
                         }
                       }}
                       style={{
@@ -1052,9 +1057,11 @@ export default function Messages() {
                         cursor: "pointer",
                       }}
                       onClick={() => {
-                        isExpanded
-                          ? setRespondingTid(null)
-                          : handlePrepareResponse(msg.tid);
+                        if (isExpanded) {
+                          setRespondingTid(null);
+                        } else {
+                          handlePrepareResponse(msg.tid);
+                        }
                       }}
                     >
                       <Stack gap="sm">
@@ -1231,7 +1238,7 @@ export default function Messages() {
             </>
           ) : (
             <Alert color="royal" title="No messages">
-              You don't have any messages yet. Share your profile link to
+              You don&apos;t have any messages yet. Share your profile link to
               receive anonymous questions.
             </Alert>
           )}

--- a/client/src/pages/OAuthCallback.tsx
+++ b/client/src/pages/OAuthCallback.tsx
@@ -1,6 +1,3 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   Box,
   Center,
@@ -11,7 +8,11 @@ import {
   Paper,
   Button,
 } from "@mantine/core";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { Link } from "react-router-dom";
+
 import { apiClient } from "../api/apiClient";
 import { authKeys } from "../api/authService";
 import { WinkMark } from "../components/WinkMark";

--- a/client/src/pages/PublicProfile.tsx
+++ b/client/src/pages/PublicProfile.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef, useEffect } from "react";
 import {
   Container,
   Text,
@@ -9,22 +8,23 @@ import {
   Group,
   Textarea,
   Avatar,
-  Loader,
-  Center,
   Box,
   Alert,
+  Skeleton,
   useComputedColorScheme,
 } from "@mantine/core";
+import { IconSend, IconX, IconWorld, IconLock } from "@tabler/icons-react";
+import { useState, useRef, useEffect } from "react";
 import { useParams } from "react-router-dom";
+
+import { useSendMessage } from "../api/messageService";
 import {
   useResolveHandle,
   usePublicProfile,
 } from "../api/profileService";
-import { useSendMessage } from "../api/messageService";
 import { ConfirmationModal } from "../components/ConfirmationModal";
-import { IconSend, IconX, IconWorld, IconLock } from "@tabler/icons-react";
-import { parseRichText } from "../utils/parseRichText";
 import { WinkMark } from "../components/WinkMark";
+import { parseRichText } from "../utils/parseRichText";
 
 const MAX_MESSAGE_LENGTH = 150;
 
@@ -120,7 +120,7 @@ export default function PublicProfile() {
     );
   };
 
-  const isLoading = handleLoading || profileLoading || sendLoading;
+  const isLoading = handleLoading || profileLoading;
 
   useEffect(() => {
     const handleFocus = () => {
@@ -157,7 +157,7 @@ export default function PublicProfile() {
               No Bluesky account found
             </Text>
             <Text>
-              <strong>@{handle}</strong> doesn't exist on Bluesky. Check the
+              <strong>@{handle}</strong> doesn&apos;t exist on Bluesky. Check the
               handle and try again.
             </Text>
           </Paper>
@@ -185,9 +185,49 @@ export default function PublicProfile() {
   if (isLoading) {
     return (
       <Container>
-        <Center style={{ minHeight: "200px" }}>
-          <Loader />
-        </Center>
+        {/* URL breadcrumb pill skeleton */}
+        <Skeleton height={28} width={180} radius={999} mb="sm" />
+
+        {/* Profile card skeleton */}
+        <Paper mb="lg" withBorder style={{ borderRadius: 16, overflow: "hidden" }}>
+          {/* Banner */}
+          <Skeleton height={160} radius={0} />
+          <Box style={{ padding: "0 24px 18px", position: "relative" }}>
+            {/* Avatar overlapping banner */}
+            <Skeleton
+              circle
+              height={84}
+              width={84}
+              style={{ position: "absolute", top: -42, left: 16, border: "4px solid var(--mantine-color-body)" }}
+            />
+            <Group justify="space-between" align="flex-start" pt={52}>
+              <Box>
+                <Skeleton height={28} width={180} mb={6} />
+                <Skeleton height={14} width={120} />
+              </Box>
+              <Skeleton height={28} width={130} radius={999} />
+            </Group>
+            <Skeleton height={14} mt="sm" />
+            <Skeleton height={14} mt={6} width="75%" />
+          </Box>
+        </Paper>
+
+        {/* Ask card skeleton */}
+        <Paper
+          style={{
+            borderRadius: 18,
+            padding: 28,
+            background: "linear-gradient(135deg, #1E1B4B 0%, #3B2E78 55%, #6B3FD4 100%)",
+            border: "2px solid rgba(255,255,255,0.06)",
+          }}
+        >
+          <Skeleton height={26} width="70%" mx="auto" mb="lg" />
+          <Skeleton height={80} radius="md" mb="xs" />
+          <Group justify="flex-end" gap="xs">
+            <Skeleton height={36} width={36} radius="md" />
+            <Skeleton height={36} width={90} radius={999} />
+          </Group>
+        </Paper>
       </Container>
     );
   }
@@ -200,7 +240,7 @@ export default function PublicProfile() {
             Not on Navyfragen
           </Text>
           <Text>
-            <strong>@{handle}</strong> has a Bluesky account but hasn't set up
+            <strong>@{handle}</strong> has a Bluesky account but hasn&apos;t set up
             their Navyfragen inbox yet.
           </Text>
         </Paper>
@@ -509,7 +549,7 @@ export default function PublicProfile() {
             />
             <Text size="xs" c="dimmed">
               Your message will be sent anonymously to the user. They may post
-              it publicly on Bluesky, so please don't share any personal
+              it publicly on Bluesky, so please don&apos;t share any personal
               information or passwords. Be curious, but respectful and kind!
             </Text>
           </Group>

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   Title,
   Grid,
@@ -16,18 +15,20 @@ import {
   useComputedColorScheme,
 } from "@mantine/core";
 import { IconX } from "@tabler/icons-react";
-import { ConfirmationModal } from "../components/ConfirmationModal";
+import { useState } from "react";
+
 import { apiClient, ApiError } from "../api/apiClient";
 import { useSession } from "../api/authService";
+import { useBotFollow } from "../api/profileService";
 import {
   useUserSettings,
   useUpdateUserSettings,
   useUserStats,
   usePdsInfo,
 } from "../api/settingsService";
+import { ConfirmationModal } from "../components/ConfirmationModal";
 import { useInstallPrompt } from "../components/InstallPromptContext";
 import { themes } from "../lib/themes";
-import { useBotFollow } from "../api/profileService";
 
 export default function Settings() {
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);
@@ -299,7 +300,7 @@ export default function Settings() {
                 <Text c="dimmed" style={cardBodyStyle}>
                   By default, Navyfragen syncs your anonymous messages with your
                   Bluesky PDS (Personal Data Server). Disable this if you wish
-                  to keep your data on Navyfragen's servers. Will not change
+                  to keep your data on Navyfragen&apos;s servers. Will not change
                   your ability to post to Bluesky directly.
                 </Text>
                 {settingsLoading ? (

--- a/client/src/tests/Navigation.test.tsx
+++ b/client/src/tests/Navigation.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
-import { Navigation } from "../Navigation";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import * as profileService from "../api/profileService";
 import * as settingsService from "../api/settingsService";
+import { Navigation } from "../Navigation";
+
 import { renderWithProviders } from "./testUtils";
 
 vi.mock("../api/profileService", async (importOriginal) => {

--- a/client/src/tests/apiClient.test.ts
+++ b/client/src/tests/apiClient.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import { apiClient, ApiError } from "../api/apiClient";
 
 const originalFetch = window.fetch;

--- a/client/src/tests/authService.test.ts
+++ b/client/src/tests/authService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import { apiClient } from "../api/apiClient";
 import {
   authService,

--- a/client/src/tests/messageService.test.ts
+++ b/client/src/tests/messageService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import { apiClient } from "../api/apiClient";
 import { messageService } from "../api/messageService";
 

--- a/client/src/tests/pages/Home.test.tsx
+++ b/client/src/tests/pages/Home.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
-import Home from "../../pages/Home";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import * as authService from "../../api/authService";
 import * as messageService from "../../api/messageService";
+import Home from "../../pages/Home";
 import { renderWithProviders } from "../testUtils";
 
 vi.mock("../../api/authService", async (importOriginal) => {

--- a/client/src/tests/pages/Login.test.tsx
+++ b/client/src/tests/pages/Login.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent, waitFor, act } from "@testing-library/react";
-import Login from "../../pages/Login";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import * as authService from "../../api/authService";
+import Login from "../../pages/Login";
 import { renderWithProviders } from "../testUtils";
 
 vi.mock("../../api/authService", async (importOriginal) => {

--- a/client/src/tests/pages/OAuthCallback.test.tsx
+++ b/client/src/tests/pages/OAuthCallback.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import OAuthCallback from "../../pages/OAuthCallback";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import * as apiClientModule from "../../api/apiClient";
+import OAuthCallback from "../../pages/OAuthCallback";
 import { renderWithProviders } from "../testUtils";
 
 const mockNavigate = vi.fn();

--- a/client/src/tests/pages/PublicProfile.test.tsx
+++ b/client/src/tests/pages/PublicProfile.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
-import PublicProfile from "../../pages/PublicProfile";
-import * as profileService from "../../api/profileService";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import * as messageService from "../../api/messageService";
+import * as profileService from "../../api/profileService";
+import PublicProfile from "../../pages/PublicProfile";
 import { renderWithProviders } from "../testUtils";
 
 vi.mock("react-router-dom", async (importOriginal) => {

--- a/client/src/tests/pages/Settings.test.tsx
+++ b/client/src/tests/pages/Settings.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
-import Settings from "../../pages/Settings";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import * as authService from "../../api/authService";
-import * as settingsService from "../../api/settingsService";
 import * as profileService from "../../api/profileService";
+import * as settingsService from "../../api/settingsService";
 import * as installPromptContext from "../../components/InstallPromptContext";
+import Settings from "../../pages/Settings";
 import { renderWithProviders } from "../testUtils";
 
 vi.mock("../../api/authService", async (importOriginal) => {

--- a/client/src/tests/profileService.test.ts
+++ b/client/src/tests/profileService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import { apiClient } from "../api/apiClient";
 import { profileService, FriendsResponse } from "../api/profileService";
 

--- a/client/src/tests/queryClient.test.ts
+++ b/client/src/tests/queryClient.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
-import { queryClient } from "../api/queryClient";
 import { QueryClient } from "@tanstack/react-query";
+import { describe, it, expect, vi } from "vitest";
+
+import { queryClient } from "../api/queryClient";
 
 describe("queryClient", () => {
   it("should be an instance of QueryClient", () => {
     expect(queryClient).toBeInstanceOf(QueryClient);
   });
   it("should have the correct default options", () => {
-    // @ts-ignore - Accessing private property for testing
     const defaultOptions = queryClient.getDefaultOptions();
 
     expect(defaultOptions.queries).toEqual({

--- a/client/src/tests/settingsService.test.ts
+++ b/client/src/tests/settingsService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
 import { apiClient } from "../api/apiClient";
 import { settingsService, UserSettings, UserStats } from "../api/settingsService";
 

--- a/client/src/tests/testUtils.tsx
+++ b/client/src/tests/testUtils.tsx
@@ -1,8 +1,8 @@
-import { render, type RenderOptions } from "@testing-library/react";
 import { MantineProvider } from "@mantine/core";
-import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, type RenderOptions } from "@testing-library/react";
 import React from "react";
+import { MemoryRouter } from "react-router-dom";
 
 interface Options extends Omit<RenderOptions, "wrapper"> {
   route?: string;

--- a/client/src/utils/parseRichText.tsx
+++ b/client/src/utils/parseRichText.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { tokenize } from "@atcute/bluesky-richtext-parser";
+import React from "react";
 
 const WHITESPACE_REGEX = /^\s+|\s+$| +(?=\n)|\n(?=(?: *\n){2}) */g;
 const TRIM_HOST_RE = /^www\./;
@@ -104,7 +104,7 @@ export const parseRichText = (text: string): React.ReactNode => {
         /((?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[\w\-._~:/?#[\]@!$&'()*+,;=]*)?)/g;
       let lastIndex = 0;
       let match;
-      let text = segment.text;
+      const text = segment.text;
       let keyOffset = 0;
       while ((match = domainRegex.exec(text)) !== null) {
         const matchText = match[0];

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,9 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": "./src",
-    "types": ["vite/client"]
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- **PublicProfile skeleton**: Replaces the full-page spinner with a structured skeleton layout matching the actual banner / avatar / profile card / ask-card shape. Also fixes `isLoading` to exclude `sendLoading` — the send button already shows its own loading state, so the whole page was incorrectly replaced by a spinner while a message was being sent.
- **Friends list**: Already had skeleton loading states in `Navigation.tsx` — confirmed no changes needed there.
- **ESLint v9 flat config**: Adds `eslint.config.js` to replace the old `.eslintrc.json` (ESLint 9 requires flat config). Migrates all plugins (`@typescript-eslint`, `react`, `react-hooks`, `import`, `prettier`) to the new format. Downgrades `no-explicit-any` back to `warn` (matching the original recommended config behavior).
- **ESLint errors fixed**: Import ordering across all files (auto-fixed), unescaped apostrophes in JSX (`&apos;`), ternary-as-statement in `Messages.tsx` converted to `if/else`, and `@ts-ignore` cleaned up in tests.
- **TypeScript config**: Adds `src/vite-env.d.ts` with `/// <reference types="vite/client" />` (the standard Vite approach); removes `"types": ["vite/client"]` and the deprecated `baseUrl` from `tsconfig.json`.

## Test plan

- [ ] `npm run test` in client — all 77 tests pass
- [ ] `eslint src` — 0 errors, 76 warnings (all pre-existing `no-explicit-any` / `no-unused-vars`)
- [ ] `tsc --noEmit` — clean output
- [ ] Visit a public profile page (e.g. `/profile/some.handle`) and confirm skeleton layout appears during load, replacing the plain spinner

https://claude.ai/code/session_01GLQHb4Sh1N3USp2t57L5td

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLQHb4Sh1N3USp2t57L5td)_