### PR TITLE
Fix auto-scroll, narrow profile menu, collapsible image theme panel

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -125,7 +125,7 @@ function AppLayout() {
             ) : isLoggedIn && userProfile ? (
               <Menu
                 shadow="md"
-                width={240}
+                width={180}
                 position="bottom-end"
                 middlewares={{ shift: true, flip: true }}
                 styles={{ item: { padding: "12px 16px", fontSize: "var(--mantine-font-size-sm)" } }}

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -565,13 +565,18 @@ export default function Messages() {
   }, [messagesData]);
 
   useEffect(() => {
-    const count = messagesData?.messages?.length ?? 0;
+    const messages = messagesData?.messages;
+    const count = messages?.length ?? 0;
     const prev = prevMsgCountRef.current;
     prevMsgCountRef.current = count;
-    if (count > prev && prev > 0 && messagesTopRef.current) {
-      const rect = messagesTopRef.current.getBoundingClientRect();
-      if (rect.top < 0 || rect.top > window.innerHeight) {
-        messagesTopRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    if (count > prev && prev > 0 && messages?.[0]) {
+      const newestCard = document.getElementById(`message-card-${messages[0].tid}`);
+      const target = newestCard ?? messagesTopRef.current;
+      if (target) {
+        const { top, bottom } = target.getBoundingClientRect();
+        if (top >= window.innerHeight || bottom <= 0) {
+          (messagesTopRef.current ?? target).scrollIntoView({ behavior: "smooth", block: "start" });
+        }
       }
     }
   }, [messagesData]);
@@ -928,98 +933,123 @@ export default function Messages() {
                 {/* Image theme visual picker */}
                 <Paper
                   withBorder
-                  p="md"
+                  p={0}
                   style={{
                     borderRadius: 16,
+                    overflow: "hidden",
                     background:
                       computedColorScheme === "dark"
                         ? "rgba(255,255,255,0.06)"
                         : "#F2EBFF",
                   }}
                 >
-                  <Text
-                    style={{
-                      fontFamily: "Inter",
-                      fontWeight: 700,
-                      fontSize: 15,
-                    }}
-                    mb="sm"
-                  >
-                    Image theme
-                  </Text>
-                  <Group grow gap="sm">
-                    {Object.entries(themes).map(([value, label]) => (
-                      <ThemeCard
-                        key={value}
-                        value={value}
-                        label={label as string}
-                        selected={
-                          settingsLoading
-                            ? value === "default"
-                            : (userSettings?.imageTheme || "default") === value
-                        }
-                        onClick={() => {
-                          if (!settingsLoading && !updateSettings.isPending) {
-                            updateSettings.mutate({
-                              imageTheme: value,
-                              pdsSyncEnabled: Boolean(
-                                userSettings?.pdsSyncEnabled,
-                              ),
-                            });
-                          }
-                        }}
-                      />
-                    ))}
-                  </Group>
-
-                  <Box
-                    mt="md"
-                    pt="md"
-                    style={{
-                      borderTop:
-                        "1px solid var(--mantine-color-default-border)",
-                    }}
-                  >
-                    <Text
-                      ff="monospace"
-                      fw={700}
-                      tt="uppercase"
-                      c="dimmed"
-                      mb="xs"
-                      style={{ fontSize: 10, letterSpacing: "0.1em" }}
+                  <details open>
+                    <summary
+                      style={{
+                        listStyle: "none",
+                        cursor: "pointer",
+                        padding: "14px 20px",
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        fontFamily: "Inter",
+                        fontWeight: 700,
+                        fontSize: 15,
+                      }}
                     >
-                      Keyboard Shortcuts
-                    </Text>
-                    <Stack gap={2}>
-                      {[
-                        { label: "Focus / cycle cards", hint: "Alt+R" },
-                        { label: "Navigate cards", hint: "↑ / ↓" },
-                        { label: "Close expanded card", hint: "Esc" },
-                      ].map(({ label, hint }) => (
-                        <Box
-                          key={label}
-                          style={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            padding: "3px 0",
-                          }}
-                        >
-                          <Text style={{ fontFamily: "Inter", fontSize: 12 }}>
-                            {label}
-                          </Text>
-                          <Text
-                            style={{
-                              fontFamily: "JetBrains Mono, monospace",
-                              fontSize: 11,
-                              color: "var(--mantine-color-dimmed)",
+                      <Text
+                        style={{
+                          fontFamily: "Inter",
+                          fontWeight: 700,
+                          fontSize: 15,
+                        }}
+                      >
+                        Image theme &amp; shortcuts
+                      </Text>
+                    </summary>
+                    <Box
+                      px="md"
+                      pb="md"
+                      style={{
+                        borderTop:
+                          "1px solid var(--mantine-color-default-border)",
+                      }}
+                    >
+                      <Group grow gap="sm" mt="sm">
+                        {Object.entries(themes).map(([value, label]) => (
+                          <ThemeCard
+                            key={value}
+                            value={value}
+                            label={label as string}
+                            selected={
+                              settingsLoading
+                                ? value === "default"
+                                : (userSettings?.imageTheme || "default") === value
+                            }
+                            onClick={() => {
+                              if (!settingsLoading && !updateSettings.isPending) {
+                                updateSettings.mutate({
+                                  imageTheme: value,
+                                  pdsSyncEnabled: Boolean(
+                                    userSettings?.pdsSyncEnabled,
+                                  ),
+                                });
+                              }
                             }}
-                          >
-                            {hint.replace("Alt", "Alt/⌘")}
-                          </Text>
-                        </Box>
-                      ))}
-                    </Stack>
-                  </Box>
+                          />
+                        ))}
+                      </Group>
+
+                      <Box
+                        mt="md"
+                        pt="md"
+                        style={{
+                          borderTop:
+                            "1px solid var(--mantine-color-default-border)",
+                        }}
+                      >
+                        <Text
+                          ff="monospace"
+                          fw={700}
+                          tt="uppercase"
+                          c="dimmed"
+                          mb="xs"
+                          style={{ fontSize: 10, letterSpacing: "0.1em" }}
+                        >
+                          Keyboard Shortcuts
+                        </Text>
+                        <Stack gap={2}>
+                          {[
+                            { label: "Focus / cycle cards", hint: "Alt+R" },
+                            { label: "Navigate cards", hint: "↑ / ↓" },
+                            { label: "Close expanded card", hint: "Esc" },
+                          ].map(({ label, hint }) => (
+                            <Box
+                              key={label}
+                              style={{
+                                display: "flex",
+                                justifyContent: "space-between",
+                                padding: "3px 0",
+                              }}
+                            >
+                              <Text style={{ fontFamily: "Inter", fontSize: 12 }}>
+                                {label}
+                              </Text>
+                              <Text
+                                style={{
+                                  fontFamily: "JetBrains Mono, monospace",
+                                  fontSize: 11,
+                                  color: "var(--mantine-color-dimmed)",
+                                }}
+                              >
+                                {hint.replace("Alt", "Alt/⌘")}
+                              </Text>
+                            </Box>
+                          ))}
+                        </Stack>
+                      </Box>
+                    </Box>
+                  </details>
                 </Paper>
               </SimpleGrid>
 

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -848,6 +848,7 @@ export default function Messages() {
                       }}
                     >
                       <Text
+                        component="span"
                         style={{
                           fontFamily: "Inter",
                           fontWeight: 700,
@@ -856,7 +857,7 @@ export default function Messages() {
                       >
                         Posting preferences
                       </Text>
-                      <Text ff="monospace" size="xs" c="dimmed">
+                      <Text component="span" ff="monospace" size="xs" c="dimmed">
                         {
                           [
                             appendProfileLink,
@@ -958,6 +959,7 @@ export default function Messages() {
                       }}
                     >
                       <Text
+                        component="span"
                         style={{
                           fontFamily: "Inter",
                           fontWeight: 700,

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -569,7 +569,7 @@ export default function Messages() {
     const count = messages?.length ?? 0;
     const prev = prevMsgCountRef.current;
     prevMsgCountRef.current = count;
-    if (count > prev && prev > 0 && messages?.[0]) {
+    if (count > prev && messages?.[0]) {
       const newestCard = document.getElementById(`message-card-${messages[0].tid}`);
       const target = newestCard ?? messagesTopRef.current;
       if (target) {

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -18,7 +18,7 @@ import {
   useComputedColorScheme,
 } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
-import { IconClipboard, IconSend2, IconTrash } from "@tabler/icons-react";
+import { IconChevronDown, IconClipboard, IconSend2, IconTrash } from "@tabler/icons-react";
 import { useEffect, useState, useRef } from "react";
 
 import { ApiError } from "../api/apiClient";
@@ -324,6 +324,8 @@ export default function Messages() {
   const [respondingTid, setRespondingTid] = useState<string | null>(null);
   const [responseText, setResponseText] = useState<string>("");
   const [focusedCardIndex, setFocusedCardIndex] = useState<number>(-1);
+  const [postingPrefsOpen, setPostingPrefsOpen] = useState(true);
+  const [imageThemeOpen, setImageThemeOpen] = useState(true);
   const messageCardRefs = useRef<(HTMLDivElement | null)[]>([]);
   const computedColorScheme = useComputedColorScheme("light", {
     getInitialValueInEffect: true,
@@ -833,7 +835,7 @@ export default function Messages() {
                         : "#F2EBFF",
                   }}
                 >
-                  <details open>
+                  <details open={postingPrefsOpen} onToggle={(e) => setPostingPrefsOpen((e.currentTarget as HTMLDetailsElement).open)}>
                     <summary
                       style={{
                         listStyle: "none",
@@ -845,6 +847,7 @@ export default function Messages() {
                         fontFamily: "Inter",
                         fontWeight: 700,
                         fontSize: 15,
+                        userSelect: "none",
                       }}
                     >
                       <Text
@@ -857,17 +860,27 @@ export default function Messages() {
                       >
                         Posting preferences
                       </Text>
-                      <Text component="span" ff="monospace" size="xs" c="dimmed">
-                        {
-                          [
-                            appendProfileLink,
-                            useGradients,
-                            includeQuestionAsImage,
-                            confirmBeforeDelete,
-                          ].filter(Boolean).length
-                        }{" "}
-                        of 4 on
-                      </Text>
+                      <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                        <Text component="span" ff="monospace" size="xs" c="dimmed">
+                          {
+                            [
+                              appendProfileLink,
+                              useGradients,
+                              includeQuestionAsImage,
+                              confirmBeforeDelete,
+                            ].filter(Boolean).length
+                          }{" "}
+                          of 4 on
+                        </Text>
+                        <IconChevronDown
+                          size={16}
+                          style={{
+                            transition: "transform 200ms ease",
+                            transform: postingPrefsOpen ? "rotate(180deg)" : "rotate(0deg)",
+                            color: "var(--mantine-color-dimmed)",
+                          }}
+                        />
+                      </span>
                     </summary>
                     <Box
                       px="md"
@@ -944,7 +957,7 @@ export default function Messages() {
                         : "#F2EBFF",
                   }}
                 >
-                  <details open>
+                  <details open={imageThemeOpen} onToggle={(e) => setImageThemeOpen((e.currentTarget as HTMLDetailsElement).open)}>
                     <summary
                       style={{
                         listStyle: "none",
@@ -956,6 +969,7 @@ export default function Messages() {
                         fontFamily: "Inter",
                         fontWeight: 700,
                         fontSize: 15,
+                        userSelect: "none",
                       }}
                     >
                       <Text
@@ -968,6 +982,14 @@ export default function Messages() {
                       >
                         Image theme &amp; shortcuts
                       </Text>
+                      <IconChevronDown
+                        size={16}
+                        style={{
+                          transition: "transform 200ms ease",
+                          transform: imageThemeOpen ? "rotate(180deg)" : "rotate(0deg)",
+                          color: "var(--mantine-color-dimmed)",
+                        }}
+                      />
                     </summary>
                     <Box
                       px="md"


### PR DESCRIPTION
## Summary

- **Auto-scroll fix**: The previous implementation checked the zero-height sentinel div's viewport position, which was always considered "in view" even when the message cards were off-screen. Now checks the newest message card directly via `getElementById`, scrolling to it only when it's fully outside the viewport.
- **Profile menu width**: Reduced from 240px to 180px — enough for "View Profile" and "Logout".
- **Collapsible image theme panel**: Wrapped the image theme + keyboard shortcuts panel in a `<details>` element (same pattern as the existing Posting preferences panel), so it can be collapsed to save space on mobile.

## Test plan

- [ ] With messages loaded, scroll away from the message list, then trigger a new message — confirm the page auto-scrolls to the top of the message cards
- [ ] Confirm no auto-scroll when already viewing messages
- [ ] Open profile menu and confirm it doesn't feel too narrow for the labels
- [ ] Collapse and expand the "Image theme & shortcuts" panel on mobile and desktop

https://claude.ai/code/session_01XxsQKWVJmejGocxS64xTUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxsQKWVJmejGocxS64xTUw)_