### PR TITLE
Scroll newest message to bottom of viewport instead of top

### DIFF
--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -577,7 +577,7 @@ export default function Messages() {
       if (target) {
         const { top, bottom } = target.getBoundingClientRect();
         if (top >= window.innerHeight || bottom <= 0) {
-          (messagesTopRef.current ?? target).scrollIntoView({ behavior: "smooth", block: "start" });
+          target.scrollIntoView({ behavior: "smooth", block: "end" });
         }
       }
     }


### PR DESCRIPTION
## Summary

- Changes `block: "start"` → `block: "end"` on the auto-scroll target, so the newest message card's bottom aligns with the viewport bottom — one message peeks into view rather than the message jumping to the top of the page.

## Test plan

- [ ] Navigate to the messages page with content below the fold — confirm the first message scrolls to the bottom of the screen, not the top
- [ ] Trigger a new message via polling — same behavior

https://claude.ai/code/session_01XxsQKWVJmejGocxS64xTUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxsQKWVJmejGocxS64xTUw)_