### PR TITLE
fix: make message cards equal height with vertically centered text

### DIFF
--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -1088,7 +1088,6 @@ export default function Messages() {
               <SimpleGrid
                 cols={{ base: 1, sm: 2 }}
                 spacing="md"
-                style={{ alignItems: "start" }}
               >
                 {messagesData?.messages.map((msg: Message, index: number) => {
                   const isExpanded = respondingTid === msg.tid;
@@ -1128,6 +1127,8 @@ export default function Messages() {
                         padding: "8px 20px 20px",
                         transition: "border-color 0.15s ease, box-shadow 0.15s ease",
                         cursor: "pointer",
+                        display: "flex",
+                        flexDirection: "column",
                       }}
                       onClick={() => {
                         if (isExpanded) {
@@ -1137,7 +1138,7 @@ export default function Messages() {
                         }
                       }}
                     >
-                      <Stack gap="sm">
+                      <Stack gap="sm" style={{ flex: 1 }}>
                         {/* Timestamp row */}
                         <Group justify="space-between" align="center">
                           <Group gap={8} align="center">
@@ -1174,22 +1175,25 @@ export default function Messages() {
                         </Group>
 
                         {/* Message text */}
-                        <Text
-                          c="white"
-                          fw={600}
-                          style={
-                            {
-                              fontSize: 20,
-                              lineHeight: 1.35,
-                              wordBreak: "break-word",
-                              whiteSpace: "pre-wrap",
-                              textAlign: "center",
-                              textWrap: "balance",
-                            } as React.CSSProperties
-                          }
-                        >
-                          {msg.message}
-                        </Text>
+                        <Box style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                          <Text
+                            c="white"
+                            fw={600}
+                            style={
+                              {
+                                fontSize: 20,
+                                lineHeight: 1.35,
+                                wordBreak: "break-word",
+                                whiteSpace: "pre-wrap",
+                                textAlign: "center",
+                                textWrap: "balance",
+                                width: "100%",
+                              } as React.CSSProperties
+                            }
+                          >
+                            {msg.message}
+                          </Text>
+                        </Box>
 
                         {/* Action area */}
                         {isExpanded ? (


### PR DESCRIPTION
Fixes #99

All message cards in a row now stretch to the same height. The message text is centered vertically in the available space, with action buttons anchored to the bottom.

**Root cause:** The `SimpleGrid` had `alignItems: "start"`, which caused each card to shrink to its content height.

**Fix:**
- Removed `alignItems: "start"` from `SimpleGrid`
- Made card `Paper` a flex column container
- Gave the inner `Stack` `flex: 1` to fill the card
- Wrapped message text in a flex `Box` with `flex: 1` so it grows and centers vertically

Generated with [Claude Code](https://claude.ai/code)