### PR TITLE
Remove gray padding from Twitter image theme export

### DIFF
--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -213,12 +213,12 @@ function ThemeCard({
     return (
       <div
         style={{
-          background: "#f7f9f9",
+          background: "#ffffff",
           height: "100%",
           borderRadius: 5,
           display: "flex",
           alignItems: "center",
-          padding: 8,
+          padding: 0,
         }}
       >
         <div

--- a/image-theme-preview.html
+++ b/image-theme-preview.html
@@ -162,13 +162,12 @@
        TWITTER THEME
     ════════════════════════════════ */
     .twitter-outer {
-      background: #f7f9f9;
-      padding: 10px;
+      background: #ffffff;
+      padding: 0;
       display: flex;
       align-items: center;
       justify-content: center;
       width: 420px;
-      border-radius: 4px;
     }
     .twitter-card {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', 'Noto Color Emoji', sans-serif;

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -140,12 +140,12 @@ function compressedHeight(length: number): number {
 }
 
 function twitterHeight(length: number): number {
-  if (length <= 40) return 170;
-  if (length <= 80) return 195;
-  if (length <= 130) return 218;
-  if (length <= 200) return 255;
-  if (length <= 300) return 288;
-  return 318;
+  if (length <= 40) return 150;
+  if (length <= 80) return 175;
+  if (length <= 130) return 198;
+  if (length <= 200) return 235;
+  if (length <= 300) return 268;
+  return 298;
 }
 
 // Default theme: NGL-style — vivid purple gradient, large prominent white bubble
@@ -328,8 +328,8 @@ function generateTwitterHtml(
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', ${NOTO_STACK};
     }
     body {
-      background: #f7f9f9;
-      padding: 10px;
+      background: #ffffff;
+      padding: 0;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removed the `10px` body padding and gray `#f7f9f9` background from the Twitter card image generator so the exported image is flush with the card (no top/bottom whitespace)
- Reduced `twitterHeight` by 20px across all message-length breakpoints to compensate for the removed padding, keeping card content dimensions the same
- Updated `image-theme-preview.html` and the `Messages.tsx` ThemeCard preview to reflect the same change

## Test plan

- [ ] Generate a Twitter-theme image and confirm no gray padding appears above/below the card
- [ ] Check all message-length tiers (short ≤40, medium ≤80, long ≤130, very long ≤200, max >300) produce correctly sized images
- [ ] Open `image-theme-preview.html` in a browser and verify the Twitter cards render flush (no outer gray background)
- [ ] Verify the Twitter ThemeCard preview in Messages page shows correctly (white background, card flush with preview bounds)

https://claude.ai/code/session_016CAon5GLmZFQoQ6UuLveML
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016CAon5GLmZFQoQ6UuLveML)_