### PR TITLE
Retry image service for up to 10s on network errors (serverless cold start)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12855,6 +12855,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12871,6 +12872,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12887,6 +12889,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12903,6 +12906,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12919,6 +12923,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12935,6 +12940,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12951,6 +12957,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12967,6 +12974,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12983,6 +12991,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12999,6 +13008,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13015,6 +13025,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13031,6 +13042,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13047,6 +13059,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13063,6 +13076,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13079,6 +13093,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13095,6 +13110,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13111,6 +13127,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13127,6 +13144,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13143,6 +13161,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13159,6 +13178,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13175,6 +13195,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13191,6 +13212,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13207,6 +13229,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13223,6 +13246,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13239,6 +13263,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -13255,6 +13280,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -26,6 +26,30 @@ const BASE_CSS = `
   body { overflow: hidden; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-synthesis: none; }
 `;
 
+// Retries a fetch on network errors (ECONNREFUSED, ETIMEDOUT, etc.) for up to
+// timeoutMs. Does not retry HTTP error responses — those mean the service is up.
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  let lastError: unknown;
+  while (true) {
+    try {
+      return await fetch(url, init);
+    } catch (err) {
+      lastError = err;
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(delay, remaining)));
+    delay = Math.min(Math.ceil(delay * 1.5), 2000);
+  }
+  throw lastError;
+}
+
 export async function generateQuestionImage(
   originalMessage: string,
   logger: Logger,
@@ -57,16 +81,6 @@ export async function generateQuestionImage(
   );
 
   try {
-    try {
-      await fetch(env.EXPORT_HTML_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ source: "<html><body></body></html>", format: "png", options: { width: 1, height: 1 } }),
-      });
-    } catch {
-      // ignore — warmup just needs to knock on the door
-    }
-
     logger.info(`Attempting to generate image via service at: ${env.EXPORT_HTML_URL}`);
     const payload = {
       source: html,
@@ -76,11 +90,15 @@ export async function generateQuestionImage(
         height: height * 4,
       },
     };
-    const response = await fetch(env.EXPORT_HTML_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
+    const response = await fetchWithRetry(
+      env.EXPORT_HTML_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      },
+      10_000
+    );
 
     if (response.ok) {
       const raw = Buffer.from(await response.arrayBuffer());

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -28,7 +28,7 @@ const BASE_CSS = `
 
 // Retries a fetch on network errors (ECONNREFUSED, ETIMEDOUT, etc.) for up to
 // timeoutMs. Does not retry HTTP error responses — those mean the service is up.
-async function fetchWithRetry(
+export async function fetchWithRetry(
   url: string,
   init: RequestInit,
   timeoutMs: number

--- a/server/src/tests/image-generator.test.ts
+++ b/server/src/tests/image-generator.test.ts
@@ -1,0 +1,74 @@
+import { test, describe, mock, afterEach } from "node:test";
+import assert from "node:assert";
+import { fetchWithRetry } from "../lib/image-generator";
+
+describe("fetchWithRetry", () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  test("returns response immediately on first successful attempt", async () => {
+    const mockResponse = new Response("ok", { status: 200 });
+    mock.method(globalThis, "fetch", async () => mockResponse);
+
+    const result = await fetchWithRetry("http://test/", {}, 5000);
+
+    assert.strictEqual(result, mockResponse);
+    assert.strictEqual((globalThis.fetch as any).mock.calls.length, 1);
+  });
+
+  test("retries on network error and returns response when service comes up", async () => {
+    const mockResponse = new Response("ok", { status: 200 });
+    let callCount = 0;
+    mock.method(globalThis, "fetch", async () => {
+      callCount++;
+      if (callCount < 3) throw new Error("ECONNREFUSED");
+      return mockResponse;
+    });
+
+    const result = await fetchWithRetry("http://test/", {}, 5000);
+
+    assert.strictEqual(result, mockResponse);
+    assert.strictEqual(callCount, 3);
+  });
+
+  test("throws the last network error after timeout is exhausted", async () => {
+    const networkError = new Error("connect ECONNREFUSED 127.0.0.1:3033");
+    mock.method(globalThis, "fetch", async () => {
+      throw networkError;
+    });
+
+    await assert.rejects(
+      () => fetchWithRetry("http://test/", {}, 50),
+      networkError
+    );
+  });
+
+  test("does not retry on HTTP error responses", async () => {
+    let callCount = 0;
+    mock.method(globalThis, "fetch", async () => {
+      callCount++;
+      return new Response("internal error", { status: 500 });
+    });
+
+    const result = await fetchWithRetry("http://test/", {}, 5000);
+
+    assert.strictEqual(result.status, 500);
+    assert.strictEqual(callCount, 1);
+  });
+
+  test("passes url and init options through to fetch", async () => {
+    const mockResponse = new Response("ok", { status: 200 });
+    const capturedArgs: any[] = [];
+    mock.method(globalThis, "fetch", async (...args: any[]) => {
+      capturedArgs.push(args);
+      return mockResponse;
+    });
+
+    const init = { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" };
+    await fetchWithRetry("http://test/endpoint", init, 5000);
+
+    assert.strictEqual(capturedArgs[0][0], "http://test/endpoint");
+    assert.deepStrictEqual(capturedArgs[0][1], init);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the warmup-POST approach with a proper `fetchWithRetry()` helper that retries on any network error (ECONNREFUSED, ETIMEDOUT) for up to 10 seconds. HTTP error responses are **not** retried — those mean the service is up and returning a real error.

Retry schedule: 500ms → 750ms → 1125ms → 1688ms → 2000ms → 2000ms → ... covering ~7–8 attempts across the 10s window, enough to survive a serverless cold start.

## Test plan

- [ ] With image service stopped, trigger image generation — confirm it retries for ~10s then fails gracefully
- [ ] With image service running normally, confirm image generation succeeds on the first attempt with no added latency
- [ ] With image service cold (first request after idle), confirm it recovers within 10s and the image is attached

https://claude.ai/code/session_015m9gj67Y3B5VNcWC17nVUw

---
_Generated by [Claude Code](https://claude.ai/code/session_015m9gj67Y3B5VNcWC17nVUw)_