### PR TITLE
Fix mid-card gap in compressed and default image themes

### DIFF
--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -169,8 +169,8 @@ function compressedHeight(length: number): number {
   // message area: 380px − 24px body padding − 4px border − 27px card padding (13px+14px)
   const lines = estimateLines(length, fontSize, 325);
   const textH = Math.ceil(lines * fontSize * 1.45);
-  // fixed chrome: 24 body pad + 24 card pad + 9 label + 6 label-margin + 8 footer-margin + 10 footer = 81
-  return Math.max(textH + 81, 100);
+  // fixed chrome: 24 body pad + 24 card pad + 11 label (9px×1.2lh) + 6 label-margin + 8 footer-margin + 12 footer (10px×1.2lh) = 85
+  return Math.max(textH + 85, 100);
 }
 
 function twitterHeight(length: number, handle?: string): number {
@@ -212,7 +212,7 @@ function generateDefaultHtml(
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      justify-content: space-between;
+      gap: 10px;
     }
     .header {
       color: rgba(255, 255, 255, 0.90);
@@ -298,7 +298,6 @@ function generateCompressedHtml(
       width: 100%;
       display: flex;
       flex-direction: column;
-      justify-content: space-between;
     }
     .label {
       font-size: 9px;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause**: Both the compressed and default themes used `justify-content: space-between` on their flex container. When the line count estimator predicts one more line than actually renders (common with word-wrapping), the extra height is distributed as a gap *between the message text and the footer* — exactly in the middle of the visible card, making the spacing look broken.
- **Compressed fix**: Removed `justify-content: space-between` from `.card`. The footer's existing `margin-top: 8px` keeps it visually separated from the message; any excess space now falls to the bottom of the card (dark background, invisible).
- **Default fix**: Replaced `justify-content: space-between` with `gap: 10px` on `body`. The fixed 10px gaps match what the height formula already assumes, and excess space goes to the bottom gradient.
- **Twitter theme**: Already uses natural flex flow with `margin-top` on footer — unaffected.
- **Height constant correction** (compressed): Updated the fixed chrome total from 81 → 85 to account for the actual rendered height of the label (`9px × 1.2 line-height ≈ 11px`) and footer (`10px × 1.2 ≈ 12px`), which were previously counted only by their `font-size`.

## Test plan

- [ ] Generate an image with the compressed theme using a short message (~50 chars, 2 rendered lines) — verify no gap between message and footer
- [ ] Generate an image with a medium message (~80 chars) in compressed — verify consistent spacing
- [ ] Generate an image with the default theme — verify header/bubble/footer spacing is consistent
- [ ] Generate an image with the twitter theme — verify unaffected

https://claude.ai/code/session_01AeJsH6zmzimmbwJd5Zk8gJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeJsH6zmzimmbwJd5Zk8gJ)_