### PR TITLE
Fix image generator fallback: AbortController timeout + toggle initial state

### DIFF
--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -376,7 +376,7 @@ export default function Messages() {
   const [includeQuestionAsImage, setIncludeQuestionAsImage] = useLocalStorage({
     key: "includeQuestionAsImage",
     defaultValue: true,
-    getInitialValueInEffect: true,
+    getInitialValueInEffect: false,
   });
   const [confirmBeforeDelete, setConfirmBeforeDelete] = useLocalStorage({
     key: "confirmBeforeDelete",

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -28,6 +28,8 @@ const BASE_CSS = `
 
 // Retries a fetch on network errors (ECONNREFUSED, ETIMEDOUT, etc.) for up to
 // timeoutMs. Does not retry HTTP error responses — those mean the service is up.
+// Each individual request is bounded by an AbortController so a hanging
+// connection cannot block the loop past the overall deadline.
 export async function fetchWithRetry(
   url: string,
   init: RequestInit,
@@ -37,14 +39,21 @@ export async function fetchWithRetry(
   let delay = 500;
   let lastError: unknown;
   while (true) {
-    try {
-      return await fetch(url, init);
-    } catch (err) {
-      lastError = err;
-    }
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
-    await new Promise((r) => setTimeout(r, Math.min(delay, remaining)));
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(), remaining);
+    try {
+      const response = await fetch(url, { ...init, signal: controller.signal });
+      clearTimeout(abortTimer);
+      return response;
+    } catch (err) {
+      clearTimeout(abortTimer);
+      lastError = err;
+    }
+    const remainingAfter = deadline - Date.now();
+    if (remainingAfter <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(delay, remainingAfter)));
     delay = Math.min(Math.ceil(delay * 1.5), 2000);
   }
   throw lastError;

--- a/server/src/tests/image-generator.test.ts
+++ b/server/src/tests/image-generator.test.ts
@@ -57,7 +57,7 @@ describe("fetchWithRetry", () => {
     assert.strictEqual(callCount, 1);
   });
 
-  test("passes url and init options through to fetch", async () => {
+  test("passes url and init options through to fetch, adding an AbortSignal", async () => {
     const mockResponse = new Response("ok", { status: 200 });
     const capturedArgs: any[] = [];
     mock.method(globalThis, "fetch", async (...args: any[]) => {
@@ -69,6 +69,10 @@ describe("fetchWithRetry", () => {
     await fetchWithRetry("http://test/endpoint", init, 5000);
 
     assert.strictEqual(capturedArgs[0][0], "http://test/endpoint");
-    assert.deepStrictEqual(capturedArgs[0][1], init);
+    const passedInit = capturedArgs[0][1];
+    assert.strictEqual(passedInit.method, init.method);
+    assert.deepStrictEqual(passedInit.headers, init.headers);
+    assert.strictEqual(passedInit.body, init.body);
+    assert.ok(passedInit.signal instanceof AbortSignal, "Should include an AbortSignal");
   });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Backend (`fetchWithRetry`)**: The retry loop called `await fetch()` with no per-request timeout. A service that accepted the TCP connection but never sent a response would block the loop indefinitely — the 10-second deadline in the outer loop has no way to interrupt a running `await`. Fixed by passing an `AbortSignal` tied to the remaining deadline budget into each individual `fetch` call, so a hanging connection is aborted on schedule and retries can proceed normally.

- **Frontend (toggle initial state)**: `useLocalStorage` for `includeQuestionAsImage` was using `getInitialValueInEffect: true`, which initializes the hook to the `defaultValue` (`true`) and then overwrites it from localStorage in a `useEffect`. This creates a brief window where the rendered value differs from the stored preference — if a user had toggled it off, the first render would show it as on and pass `true` to any submit in that window. Changed to `getInitialValueInEffect: false` so the correct localStorage value is read synchronously on the first render.

## Test plan

- [ ] Run server tests: `cd server && npm test` — all 5 `fetchWithRetry` tests pass including new AbortSignal assertion
- [ ] Verify image generation works end-to-end when `monkeyphysics/html-to-image` is running (`docker run --rm -p 3033:3033 monkeyphysics/html-to-image`)
- [ ] Toggle image attachment off, submit a response — confirm the stored off-state is respected on page reload without any flash

https://claude.ai/code/session_01GPwV6Nhqs2n1umwdSaGq6V
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPwV6Nhqs2n1umwdSaGq6V)_