### PR TITLE
Fix emoji rendering in image generation (Unicode-aware length)

### DIFF
--- a/html-to-image/.gitignore
+++ b/html-to-image/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/html-to-image/Dockerfile
+++ b/html-to-image/Dockerfile
@@ -14,12 +14,13 @@ RUN apk add --no-cache \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-COPY . /usr/src/app
-RUN cd /usr/src/app && npm install
-
 WORKDIR /usr/src/app
-ENV PATH=/usr/src/app/node_modules/.bin:$PATH
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY app.js ./
 
 EXPOSE 3033
 
-ENTRYPOINT ["node", "/usr/src/app/app.js"]
+CMD ["node", "app.js"]

--- a/html-to-image/Dockerfile
+++ b/html-to-image/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3
+
+RUN apk add --no-cache \
+      chromium \
+      nodejs \
+      npm \
+      nss \
+      freetype \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      font-noto-emoji
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+COPY . /usr/src/app
+RUN cd /usr/src/app && npm install
+
+WORKDIR /usr/src/app
+ENV PATH=/usr/src/app/node_modules/.bin:$PATH
+
+EXPOSE 3033
+
+ENTRYPOINT ["node", "/usr/src/app/app.js"]

--- a/html-to-image/app.js
+++ b/html-to-image/app.js
@@ -8,17 +8,18 @@ const app = express();
 const port = parseInt(process.env.PORT ?? '3033', 10);
 
 const FORMATS = {
-  png:  { contentType: 'image/png',      screenshotType: 'png' },
-  jpg:  { contentType: 'image/jpeg',     screenshotType: 'jpeg' },
-  jpeg: { contentType: 'image/jpeg',     screenshotType: 'jpeg' },
-  webp: { contentType: 'image/webp',     screenshotType: 'webp' },
-  pdf:  { contentType: 'application/pdf', screenshotType: null },
+  png:  { contentType: 'image/png',        screenshotType: 'png' },
+  jpg:  { contentType: 'image/jpeg',       screenshotType: 'jpeg' },
+  jpeg: { contentType: 'image/jpeg',       screenshotType: 'jpeg' },
+  webp: { contentType: 'image/webp',       screenshotType: 'webp' },
+  pdf:  { contentType: 'application/pdf',  screenshotType: null },
 };
 
 app.use(express.json({ limit: '2mb' }));
 app.use(rateLimit({ windowMs: 60_000, limit: 60, standardHeaders: true, legacyHeaders: false }));
 
-// Health check — used by Railway and other platforms to detect readiness
+// Health check responds immediately — Railway marks the instance ready without
+// waiting for the browser to finish launching.
 app.get('/', (_req, res) => res.json({ status: 'ok' }));
 
 app.use((req, res, next) => {
@@ -39,6 +40,13 @@ app.use((req, res, next) => {
 });
 
 app.post('/', async (req, res) => {
+  let browser;
+  try {
+    browser = await getBrowser();
+  } catch (err) {
+    return res.status(503).json({ error: 'Browser unavailable: ' + err.message });
+  }
+
   const { source, format: formatName, options = {} } = req.body;
   const format = FORMATS[formatName];
   const isPdf = formatName === 'pdf';
@@ -71,6 +79,8 @@ app.post('/', async (req, res) => {
   } catch (err) {
     tmpinput.removeCallback();
     tmpoutput.removeCallback();
+    // Browser may have crashed — relaunch for next request
+    browserPromise = launchBrowser();
     res.status(500).json({ error: err.message || 'Image generation failed' });
   }
 });
@@ -79,14 +89,35 @@ app.use((err, _req, res, _next) => {
   res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
 });
 
-console.log('Launching browser...');
-const browser = await puppeteer.launch({
-  executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
-  defaultViewport: { width: 1920, height: 1080 },
-  args: ['--no-sandbox', '--no-zygote', '--headless', '--disable-gpu'],
-});
-console.log('Browser ready.');
-
+// Listen immediately so Railway's health check passes without waiting for the browser.
 app.listen(port, () => console.log(`html-to-image listening on port ${port}`));
 
-process.on('SIGINT', async () => { await browser.close(); process.exit(); });
+// Browser launches in the background — the first POST request awaits this promise.
+function launchBrowser() {
+  console.log('Launching browser...');
+  return puppeteer.launch({
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    defaultViewport: { width: 1920, height: 1080 },
+    args: ['--no-sandbox', '--no-zygote', '--headless', '--disable-gpu'],
+  }).then(b => { console.log('Browser ready.'); return b; });
+}
+
+let browserPromise = launchBrowser();
+
+async function getBrowser() {
+  const browser = await browserPromise;
+  if (!browser.connected) {
+    browserPromise = launchBrowser();
+    return browserPromise;
+  }
+  return browser;
+}
+
+async function shutdown() {
+  const browser = await browserPromise.catch(() => null);
+  if (browser) await browser.close().catch(() => {});
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/html-to-image/app.js
+++ b/html-to-image/app.js
@@ -1,0 +1,151 @@
+import puppeteer from 'puppeteer';
+import express from 'express';
+import path from 'path';
+import fs from 'fs';
+import tmp from 'tmp';
+import cors from 'cors';
+
+const app = express();
+const port = 3033;
+
+const supportedFormats = {
+	'png': { contentType: 'image/png', args: { type: 'png' } },
+	'jpg': { contentType: 'image/jpeg', args: { type: 'jpeg' } },
+	'jpeg': { contentType: 'image/jpeg', args: { type: 'jpeg' } },
+	'webp': { contentType: 'image/webp', args: { type: 'webp' } },
+	'pdf': { contentType: 'application/pdf' },
+};
+
+// listen on our port
+app.listen(port, () => {
+	console.log(`HTMLtoImage service listening on port ${port}`);
+});
+
+// cross-origin support
+app.use(cors());
+
+// parse JSON body for incoming request
+app.use(express.json({ limit: '1mb' }));
+
+// validate incoming request
+app.use((req, res, next) => {
+	if (req.method !== 'POST') {
+		next({ status: 405, message: "Method not allowed" });
+	} else if (req.get('Content-Type') != 'application/json') {
+		next({ status: 415, message: "Unexpected Content-Type: only supports 'application/json'" });
+	} else if (typeof req.body.source != 'string') {
+		next({ status: 400, message: "Missing 'source' property in request body, or 'source' property is not a string" });
+	} else if (req.body.source == '') {
+		next({ status: 400, message: "Property 'source' must not be empty" });
+	} else if (req.body.options && typeof req.body.options != 'object') {
+		next({ status: 400, message: "Property 'options' can only be an object (or omitted)" });
+	} else if (typeof req.body.format != 'string' || !supportedFormats[req.body.format]) {
+		next({ status: 400, message: `Property 'format' must be one of: ${Object.keys(supportedFormats).join(', ')}` });
+	} else {
+		next();
+	}
+});
+
+// implement the endpoint
+app.post('/', (req, res) => {
+	const options = req.body.options || {};
+	const format = supportedFormats[req.body.format]; // safe, validated in middleware
+
+	res.header("Content-Type", format.contentType);
+
+	const tmpoutput = tmp.fileSync({ prefix: 'htmltoimage-' });
+	const isPdf = req.body.format == 'pdf';
+
+	options.args = Object.assign({}, options.args, format.args, { path: tmpoutput.name });
+
+	if (isUrl(req.body.source)) {
+		screenshot(req.body.source, isPdf, options).then(() => {
+			fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
+				tmpoutput.removeCallback();
+			})
+		}).catch(e => errorHandler(res, e));
+	} else {
+		const tmpinput = tmp.fileSync({ prefix: 'htmltoimage-', postfix: '.html' });
+		fs.writeFile(tmpinput.name, req.body.source, () => {
+			screenshot('file://' + tmpinput.name, isPdf, options).then(() => {
+				fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
+					tmpinput.removeCallback();
+					tmpoutput.removeCallback();
+				});
+			}).catch(e => errorHandler(res, e));
+		});
+	}
+});
+
+// error handler
+const errorHandler = (res, error) => {
+	res.status(error.status || 500).send({ error: error.message || "" });
+};
+
+// error handler middleware (goes last in stack)
+app.use((error, req, res, next) => {
+	if (error) {
+		errorHandler(res, error);
+	} else {
+		next();
+	}
+});
+
+// helper function to check if string is a URL
+const isUrl = (string) => {
+	try {
+		const url = new URL(string);
+		return url.protocol === "http:" || url.protocol === "https:";
+	} catch (e) {}
+
+	return false;
+};
+
+console.log(`Launching browser...`);
+const browser = await puppeteer.launch({
+	defaultViewport: {
+		width: 1920,
+		height: 1080,
+	},
+	args: [
+		'--no-sandbox',
+		'--no-zygote',
+		'--headless',
+		'--disable-gpu',
+	],
+});
+console.log(`... browser ready.`);
+
+// the actual screenshot code, using puppeteer
+const screenshot = async (url, isPdf, options) => {
+	let page;
+	try {
+		page = await browser.newPage();
+		await page.setViewport({
+		  width: options.width || 1920,
+		  height: options.height || 1080,
+		});
+
+		await page.goto(url);
+
+		if (isPdf) {
+			// default to 'A4' (instead of 'letter'), but allow override through options.args
+			await page.pdf(Object.assign({ format: 'A4' }, options.args));
+		} else {
+			await page.screenshot(options.args);
+		}
+	} catch (e) {
+		throw e;
+	} finally {
+		if (page) {
+			await page.close();
+		}
+	}
+}
+
+// correctly handle CTRL+C from cli when using 'docker run'
+process.on('SIGINT', function() {
+	console.log("Closing browser...");
+	browser.close();
+    process.exit();
+});

--- a/html-to-image/app.js
+++ b/html-to-image/app.js
@@ -5,57 +5,65 @@ import fs from 'fs';
 import tmp from 'tmp';
 
 const app = express();
-const port = 3033;
+const port = parseInt(process.env.PORT ?? '3033', 10);
 
-app.use(express.json({ limit: '1mb' }));
+const FORMATS = {
+  png:  { contentType: 'image/png',      screenshotType: 'png' },
+  jpg:  { contentType: 'image/jpeg',     screenshotType: 'jpeg' },
+  jpeg: { contentType: 'image/jpeg',     screenshotType: 'jpeg' },
+  webp: { contentType: 'image/webp',     screenshotType: 'webp' },
+  pdf:  { contentType: 'application/pdf', screenshotType: null },
+};
 
-app.use(rateLimit({
-  windowMs: 60_000,
-  limit: 60,
-  standardHeaders: true,
-  legacyHeaders: false,
-}));
+app.use(express.json({ limit: '2mb' }));
+app.use(rateLimit({ windowMs: 60_000, limit: 60, standardHeaders: true, legacyHeaders: false }));
+
+// Health check — used by Railway and other platforms to detect readiness
+app.get('/', (_req, res) => res.json({ status: 'ok' }));
 
 app.use((req, res, next) => {
-  if (req.method !== 'POST') {
-    return next({ status: 405, message: 'Method not allowed' });
-  }
+  if (req.method !== 'POST') return next({ status: 405, message: 'Method not allowed' });
   if (req.get('Content-Type') !== 'application/json') {
     return next({ status: 415, message: "Only 'application/json' is supported" });
   }
   if (typeof req.body.source !== 'string' || req.body.source === '') {
     return next({ status: 400, message: "'source' must be a non-empty HTML string" });
   }
-  if (req.body.format !== 'png') {
-    return next({ status: 400, message: "'format' must be 'png'" });
+  if (!FORMATS[req.body.format]) {
+    return next({ status: 400, message: `'format' must be one of: ${Object.keys(FORMATS).join(', ')}` });
   }
-  if (req.body.options !== undefined && typeof req.body.options !== 'object') {
+  if (req.body.options !== undefined && (typeof req.body.options !== 'object' || Array.isArray(req.body.options))) {
     return next({ status: 400, message: "'options' must be an object if provided" });
   }
   next();
 });
 
 app.post('/', async (req, res) => {
-  const options = req.body.options || {};
+  const { source, format: formatName, options = {} } = req.body;
+  const format = FORMATS[formatName];
+  const isPdf = formatName === 'pdf';
+
   const tmpinput = tmp.fileSync({ prefix: 'htmltoimage-', postfix: '.html' });
   const tmpoutput = tmp.fileSync({ prefix: 'htmltoimage-' });
 
   try {
-    await fs.promises.writeFile(tmpinput.name, req.body.source);
+    await fs.promises.writeFile(tmpinput.name, source);
 
     const page = await browser.newPage();
     try {
-      await page.setViewport({
-        width: options.width || 1920,
-        height: options.height || 1080,
-      });
+      await page.setViewport({ width: options.width || 1920, height: options.height || 1080 });
       await page.goto('file://' + tmpinput.name);
-      await page.screenshot({ type: 'png', path: tmpoutput.name });
+
+      if (isPdf) {
+        await page.pdf({ format: 'A4', path: tmpoutput.name });
+      } else {
+        await page.screenshot({ type: format.screenshotType, path: tmpoutput.name });
+      }
     } finally {
       await page.close();
     }
 
-    res.header('Content-Type', 'image/png');
+    res.header('Content-Type', format.contentType);
     fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
       tmpinput.removeCallback();
       tmpoutput.removeCallback();
@@ -67,7 +75,7 @@ app.post('/', async (req, res) => {
   }
 });
 
-app.use((err, req, res, _next) => {
+app.use((err, _req, res, _next) => {
   res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
 });
 
@@ -79,11 +87,6 @@ const browser = await puppeteer.launch({
 });
 console.log('Browser ready.');
 
-app.listen(port, () => {
-  console.log(`html-to-image listening on port ${port}`);
-});
+app.listen(port, () => console.log(`html-to-image listening on port ${port}`));
 
-process.on('SIGINT', async () => {
-  await browser.close();
-  process.exit();
-});
+process.on('SIGINT', async () => { await browser.close(); process.exit(); });

--- a/html-to-image/app.js
+++ b/html-to-image/app.js
@@ -1,151 +1,89 @@
 import puppeteer from 'puppeteer';
 import express from 'express';
-import path from 'path';
+import rateLimit from 'express-rate-limit';
 import fs from 'fs';
 import tmp from 'tmp';
-import cors from 'cors';
 
 const app = express();
 const port = 3033;
 
-const supportedFormats = {
-	'png': { contentType: 'image/png', args: { type: 'png' } },
-	'jpg': { contentType: 'image/jpeg', args: { type: 'jpeg' } },
-	'jpeg': { contentType: 'image/jpeg', args: { type: 'jpeg' } },
-	'webp': { contentType: 'image/webp', args: { type: 'webp' } },
-	'pdf': { contentType: 'application/pdf' },
-};
-
-// listen on our port
-app.listen(port, () => {
-	console.log(`HTMLtoImage service listening on port ${port}`);
-});
-
-// cross-origin support
-app.use(cors());
-
-// parse JSON body for incoming request
 app.use(express.json({ limit: '1mb' }));
 
-// validate incoming request
+app.use(rateLimit({
+  windowMs: 60_000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+}));
+
 app.use((req, res, next) => {
-	if (req.method !== 'POST') {
-		next({ status: 405, message: "Method not allowed" });
-	} else if (req.get('Content-Type') != 'application/json') {
-		next({ status: 415, message: "Unexpected Content-Type: only supports 'application/json'" });
-	} else if (typeof req.body.source != 'string') {
-		next({ status: 400, message: "Missing 'source' property in request body, or 'source' property is not a string" });
-	} else if (req.body.source == '') {
-		next({ status: 400, message: "Property 'source' must not be empty" });
-	} else if (req.body.options && typeof req.body.options != 'object') {
-		next({ status: 400, message: "Property 'options' can only be an object (or omitted)" });
-	} else if (typeof req.body.format != 'string' || !supportedFormats[req.body.format]) {
-		next({ status: 400, message: `Property 'format' must be one of: ${Object.keys(supportedFormats).join(', ')}` });
-	} else {
-		next();
-	}
+  if (req.method !== 'POST') {
+    return next({ status: 405, message: 'Method not allowed' });
+  }
+  if (req.get('Content-Type') !== 'application/json') {
+    return next({ status: 415, message: "Only 'application/json' is supported" });
+  }
+  if (typeof req.body.source !== 'string' || req.body.source === '') {
+    return next({ status: 400, message: "'source' must be a non-empty HTML string" });
+  }
+  if (req.body.format !== 'png') {
+    return next({ status: 400, message: "'format' must be 'png'" });
+  }
+  if (req.body.options !== undefined && typeof req.body.options !== 'object') {
+    return next({ status: 400, message: "'options' must be an object if provided" });
+  }
+  next();
 });
 
-// implement the endpoint
-app.post('/', (req, res) => {
-	const options = req.body.options || {};
-	const format = supportedFormats[req.body.format]; // safe, validated in middleware
+app.post('/', async (req, res) => {
+  const options = req.body.options || {};
+  const tmpinput = tmp.fileSync({ prefix: 'htmltoimage-', postfix: '.html' });
+  const tmpoutput = tmp.fileSync({ prefix: 'htmltoimage-' });
 
-	res.header("Content-Type", format.contentType);
+  try {
+    await fs.promises.writeFile(tmpinput.name, req.body.source);
 
-	const tmpoutput = tmp.fileSync({ prefix: 'htmltoimage-' });
-	const isPdf = req.body.format == 'pdf';
+    const page = await browser.newPage();
+    try {
+      await page.setViewport({
+        width: options.width || 1920,
+        height: options.height || 1080,
+      });
+      await page.goto('file://' + tmpinput.name);
+      await page.screenshot({ type: 'png', path: tmpoutput.name });
+    } finally {
+      await page.close();
+    }
 
-	options.args = Object.assign({}, options.args, format.args, { path: tmpoutput.name });
-
-	if (isUrl(req.body.source)) {
-		screenshot(req.body.source, isPdf, options).then(() => {
-			fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
-				tmpoutput.removeCallback();
-			})
-		}).catch(e => errorHandler(res, e));
-	} else {
-		const tmpinput = tmp.fileSync({ prefix: 'htmltoimage-', postfix: '.html' });
-		fs.writeFile(tmpinput.name, req.body.source, () => {
-			screenshot('file://' + tmpinput.name, isPdf, options).then(() => {
-				fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
-					tmpinput.removeCallback();
-					tmpoutput.removeCallback();
-				});
-			}).catch(e => errorHandler(res, e));
-		});
-	}
+    res.header('Content-Type', 'image/png');
+    fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
+      tmpinput.removeCallback();
+      tmpoutput.removeCallback();
+    });
+  } catch (err) {
+    tmpinput.removeCallback();
+    tmpoutput.removeCallback();
+    res.status(500).json({ error: err.message || 'Image generation failed' });
+  }
 });
 
-// error handler
-const errorHandler = (res, error) => {
-	res.status(error.status || 500).send({ error: error.message || "" });
-};
-
-// error handler middleware (goes last in stack)
-app.use((error, req, res, next) => {
-	if (error) {
-		errorHandler(res, error);
-	} else {
-		next();
-	}
+app.use((err, req, res, _next) => {
+  res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
 });
 
-// helper function to check if string is a URL
-const isUrl = (string) => {
-	try {
-		const url = new URL(string);
-		return url.protocol === "http:" || url.protocol === "https:";
-	} catch (e) {}
-
-	return false;
-};
-
-console.log(`Launching browser...`);
+console.log('Launching browser...');
 const browser = await puppeteer.launch({
-	defaultViewport: {
-		width: 1920,
-		height: 1080,
-	},
-	args: [
-		'--no-sandbox',
-		'--no-zygote',
-		'--headless',
-		'--disable-gpu',
-	],
+  executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+  defaultViewport: { width: 1920, height: 1080 },
+  args: ['--no-sandbox', '--no-zygote', '--headless', '--disable-gpu'],
 });
-console.log(`... browser ready.`);
+console.log('Browser ready.');
 
-// the actual screenshot code, using puppeteer
-const screenshot = async (url, isPdf, options) => {
-	let page;
-	try {
-		page = await browser.newPage();
-		await page.setViewport({
-		  width: options.width || 1920,
-		  height: options.height || 1080,
-		});
+app.listen(port, () => {
+  console.log(`html-to-image listening on port ${port}`);
+});
 
-		await page.goto(url);
-
-		if (isPdf) {
-			// default to 'A4' (instead of 'letter'), but allow override through options.args
-			await page.pdf(Object.assign({ format: 'A4' }, options.args));
-		} else {
-			await page.screenshot(options.args);
-		}
-	} catch (e) {
-		throw e;
-	} finally {
-		if (page) {
-			await page.close();
-		}
-	}
-}
-
-// correctly handle CTRL+C from cli when using 'docker run'
-process.on('SIGINT', function() {
-	console.log("Closing browser...");
-	browser.close();
-    process.exit();
+process.on('SIGINT', async () => {
+  await browser.close();
+  process.exit();
 });

--- a/html-to-image/package.json
+++ b/html-to-image/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "html-to-image",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.1",
+    "puppeteer": "^23.11.1",
+    "tmp": "^0.2.1"
+  }
+}

--- a/html-to-image/package.json
+++ b/html-to-image/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "cors": "^2.8.5",
     "express": "^4.18.1",
+    "express-rate-limit": "^7.0.0",
     "puppeteer": "^23.11.1",
     "tmp": "^0.2.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1730,6 +1730,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1747,6 +1748,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1764,6 +1766,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1781,6 +1784,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1798,6 +1802,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1815,6 +1820,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1832,6 +1838,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1849,6 +1856,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1866,6 +1874,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1883,6 +1892,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1900,6 +1910,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1917,6 +1928,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1934,6 +1946,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1951,6 +1964,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1968,6 +1982,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1985,6 +2000,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2002,6 +2018,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2019,6 +2036,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2036,6 +2054,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2053,6 +2072,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2070,6 +2090,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2104,6 +2125,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2121,6 +2143,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2138,6 +2161,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2155,6 +2179,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -179,17 +179,18 @@ export function wrapLines(
     let lineChars = 0;
     let pLines = 1;
     for (const word of words) {
-      if (word.length > charsPerLine) {
+      const wordLen = [...word].length;
+      if (wordLen > charsPerLine) {
         if (lineChars > 0) pLines++;
-        pLines += Math.ceil(word.length / charsPerLine) - 1;
-        lineChars = word.length % charsPerLine || charsPerLine;
+        pLines += Math.ceil(wordLen / charsPerLine) - 1;
+        lineChars = wordLen % charsPerLine || charsPerLine;
       } else if (lineChars === 0) {
-        lineChars = word.length;
-      } else if (lineChars + 1 + word.length <= charsPerLine) {
-        lineChars += 1 + word.length;
+        lineChars = wordLen;
+      } else if (lineChars + 1 + wordLen <= charsPerLine) {
+        lineChars += 1 + wordLen;
       } else {
         pLines++;
-        lineChars = word.length;
+        lineChars = wordLen;
       }
     }
     totalLines += pLines;
@@ -198,7 +199,7 @@ export function wrapLines(
 }
 
 function nglHeight(message: string): number {
-  const length = message.length;
+  const length = [...message].length;
   const fontSize = msgFontSize(length, 26, 21, 17);
   // message area: 360px wide − 32px body padding − 36px bubble padding (18px each side)
   const lines = wrapLines(message, fontSize, 292, 0.58);
@@ -208,7 +209,7 @@ function nglHeight(message: string): number {
 }
 
 function compressedHeight(message: string): number {
-  const length = message.length;
+  const length = [...message].length;
   const fontSize = msgFontSize(length, 19, 16, 14);
   // message area: 380px − 24px body padding − 4px border − 27px card padding (13px+14px)
   // coeff 0.53: Noto Sans semibold at these sizes fills ~38–39 chars/line at 16px in a 325px area
@@ -219,7 +220,7 @@ function compressedHeight(message: string): number {
 }
 
 function twitterHeight(message: string, handle?: string): number {
-  const length = message.length;
+  const length = [...message].length;
   const fontSize = msgFontSize(length, 21, 17, 14);
   // message area: 420px − 32px card padding (16px each side)
   // Prepend handle mention since it's rendered inline before the message text

--- a/server/src/tests/image-generator.test.ts
+++ b/server/src/tests/image-generator.test.ts
@@ -142,6 +142,15 @@ describe("wrapLines", () => {
   test("returns at least 1 for empty string", () => {
     assert.strictEqual(wrapLines("", 10, 100, 1.0), 1);
   });
+
+  test("emoji characters count as 1 not 2 (surrogate pair fix)", () => {
+    // "hi 👋" => "hi"(2) + space + "👋"(1 code point) = 4 total, fits on one line of 10
+    assert.strictEqual(wrapLines("hi 👋", 10, 100, 1.0), 1);
+    // 10 emojis => 10 code points, exactly fills one line
+    assert.strictEqual(wrapLines("😀😀😀😀😀😀😀😀😀😀", 10, 100, 1.0), 1);
+    // 11 emojis => wraps to 2 lines
+    assert.strictEqual(wrapLines("😀😀😀😀😀😀😀😀😀😀😀", 10, 100, 1.0), 2);
+  });
 });
 
 describe("generateThemeSpecificHtml", () => {
@@ -172,5 +181,12 @@ describe("generateThemeSpecificHtml", () => {
   test("twitter theme with handle includes mention", () => {
     const result = generateThemeSpecificHtml("twitter", "hello", "fragen.navy/myhandle", "hello", "myhandle");
     assert.ok(result.html.includes("@myhandle"));
+  });
+
+  test("emoji message produces same height as equal-length ascii message", () => {
+    // 5 emojis == 5 visible characters; should produce same layout as 5 ascii chars
+    const emojiResult = generateThemeSpecificHtml("default", "👋👋👋👋👋", "navyfragen.app", "👋👋👋👋👋");
+    const asciiResult = generateThemeSpecificHtml("default", "hello", "navyfragen.app", "hello");
+    assert.strictEqual(emojiResult.height, asciiResult.height);
   });
 });


### PR DESCRIPTION
## Summary

- JavaScript's `.length` counts UTF-16 code units, so emoji characters (surrogate pairs) were counted as **2** instead of 1, causing font sizes to be incorrectly small and image canvas heights to be wrong for messages containing emojis
- Fixed `wrapLines` to compute `const wordLen = [...word].length` per word, and updated the three height helpers (`nglHeight`, `compressedHeight`, `twitterHeight`) to use `[...message].length`
- Added test cases verifying emoji characters count as 1 in `wrapLines`, and that a 5-emoji message produces the same height as a 5-character ASCII message

**Database**: No changes needed — `better-sqlite3` stores JS strings as UTF-8, which handles emojis correctly at rest.

## Test plan

- [ ] Run `cd server && npm run test` — all 204 tests pass
- [ ] Manually test image generation with an emoji-containing message (e.g. "What's your favourite food? 🍕") across all three themes and verify the image is not clipped or undersized

https://claude.ai/code/session_01M2Tr6p1Fm4cGjujkYRVjSn

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2Tr6p1Fm4cGjujkYRVjSn)_