### PR TITLE
fix: tone down nav active gradient for light mode accessibility

### DIFF
--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -33,12 +33,12 @@ interface NavigationProps {
   did?: string;
 }
 
-// Active nav item: mark gradient background + subtle shadow
+// Active nav item: mode-aware — subtle tint in light mode, brand gradient in dark
 const activeNavStyle = {
-  background: "var(--nf-grad-mark)",
+  background: "var(--nf-nav-active-bg)",
   borderRadius: 12,
-  color: "var(--mantine-white)",
-  boxShadow: "0 6px 16px -8px rgba(107,63,212,0.6)",
+  color: "var(--nf-nav-active-color)",
+  boxShadow: "var(--nf-nav-active-shadow)",
 };
 
 const inactiveNavStyle = {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -41,6 +41,11 @@ body {
   --nf-dur-fast: 120ms;
   --nf-dur-base: 200ms;
 
+  /* Nav active state — default (dark mode) */
+  --nf-nav-active-bg:     linear-gradient(135deg, #3349E0 0%, #6B3FD4 55%, #4F1FA6 100%);
+  --nf-nav-active-color:  #FDF8FF;
+  --nf-nav-active-shadow: 0 4px 12px -6px rgba(107,63,212,0.45);
+
   /* Promo card (Spread the word) — light mode */
   --nf-promo-bg:     #F2EBFF;
   --nf-promo-border: #E6DDFF;
@@ -51,6 +56,11 @@ body {
   --mantine-color-body:           #FDF8FF;
   --mantine-color-default:        #FFFFFF;
   --mantine-color-default-border: #E6DDFF;
+
+  /* Nav active state — light mode: subtle tint with dark text for accessibility */
+  --nf-nav-active-bg:     #EDE9FF;
+  --nf-nav-active-color:  #1E1B4B;
+  --nf-nav-active-shadow: none;
 }
 
 /* ── Dark mode ── */


### PR DESCRIPTION
Fixes #140

The active nav item now uses mode-aware CSS variables:
- **Light mode**: soft lavender tint (#EDE9FF) with dark midnight text (~14:1 contrast, WCAG AAA), no shadow
- **Dark mode**: original brand gradient retained, shadow slightly reduced

The `--nf-grad-mark` variable is unchanged so the Messages hero card is unaffected.

Generated with [Claude Code](https://claude.ai/code)