### PR TITLE
Unify gradients: use message card gradient consistently, remove gradient from nav and text

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -42,9 +42,9 @@ body {
   --nf-dur-base: 200ms;
 
   /* Nav active state — default (dark mode) */
-  --nf-nav-active-bg:     linear-gradient(135deg, #3349E0 0%, #6B3FD4 55%, #4F1FA6 100%);
+  --nf-nav-active-bg:     rgba(107, 63, 212, 0.22);
   --nf-nav-active-color:  #FDF8FF;
-  --nf-nav-active-shadow: 0 4px 12px -6px rgba(107,63,212,0.45);
+  --nf-nav-active-shadow: none;
 
   /* Promo card (Spread the word) — light mode */
   --nf-promo-bg:     #F2EBFF;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -21,12 +21,8 @@ import { useSyncMessages } from "../api/messageService";
 import { WinkMark } from "../components/WinkMark";
 import { surfaceBg } from "../styles/tokens";
 
-// Gradient text — reused for the page title and the greeting name span
 const gradientTextStyle = {
-  background: "var(--nf-grad-hero)",
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  backgroundClip: "text",
+  color: "var(--nf-royal)",
 } as const;
 
 function ShortcutHint({ label, hint }: { label: string; hint: string }) {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -78,7 +78,7 @@ export default function Login() {
         radius="lg"
         p="xl"
         style={{
-          background: "var(--nf-grad-dark)",
+          background: "var(--nf-grad-mark)",
           border: "1px solid var(--mantine-color-default-border)",
           color: "var(--mantine-white)",
           position: "relative",

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -1077,7 +1077,7 @@ export default function Messages() {
                       }}
                       style={{
                         borderRadius: 18,
-                        background: useGradients ? "var(--nf-grad-dark)" : surfaceBg(isDark),
+                        background: useGradients ? "var(--nf-grad-mark)" : surfaceBg(isDark),
                         border: isFocused
                           ? "2px solid var(--nf-purple)"
                           : "2px solid rgba(255,255,255,0.06)",

--- a/client/src/pages/OAuthCallback.tsx
+++ b/client/src/pages/OAuthCallback.tsx
@@ -52,7 +52,7 @@ export default function OAuthCallback() {
         radius="lg"
         p="xl"
         style={{
-          background: "linear-gradient(135deg, #1E1B4B 0%, #3B2E78 50%, #6B3FD4 100%)",
+          background: "var(--nf-grad-mark)",
           border: "1px solid rgba(255,255,255,0.08)",
           color: "#FDF8FF",
           position: "relative",

--- a/client/src/pages/PublicProfile.tsx
+++ b/client/src/pages/PublicProfile.tsx
@@ -187,7 +187,7 @@ export default function PublicProfile() {
           style={{
             borderRadius: 18,
             padding: 28,
-            background: "var(--nf-grad-dark)",
+            background: "var(--nf-grad-mark)",
             border: "2px solid var(--mantine-color-default-border)",
           }}
         >
@@ -301,7 +301,7 @@ export default function PublicProfile() {
                 height: 160,
                 background: profile.banner
                   ? `url(${profile.banner}) center/cover no-repeat`
-                  : "var(--nf-grad-dark)",
+                  : "var(--nf-grad-mark)",
                 position: "relative",
               }}
             >
@@ -369,7 +369,7 @@ export default function PublicProfile() {
             style={{
               borderRadius: 18,
               padding: 28,
-              background: "var(--nf-grad-dark)",
+              background: "var(--nf-grad-mark)",
               border: "2px solid var(--mantine-color-default-border)",
               cursor: "text",
               position: "relative",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Card backgrounds**: Replace `--nf-grad-dark` (midnight→purple) with `--nf-grad-mark` (blue→purple) on Login, OAuthCallback, PublicProfile (skeleton, banner fallback, ask card), and Messages question cards — so all interactive gradient cards share the same look as the inbox hero card
- **Nav active state**: Flatten dark-mode active nav item from a gradient background to a semi-transparent solid tint (`rgba(107,63,212,0.22)`), matching the light-mode solid-tint approach — no more gradient on nav items
- **Gradient text**: Remove CSS background-clip gradient effect from the Home page title and greeting name; replaced with solid royal blue (`--nf-royal`) — no more gradients on text

The ThemeCard miniature preview in Messages intentionally keeps `--nf-grad-dark` since it's accurately representing that specific image-export theme option, not a UI gradient.

## Test plan

- [ ] Light mode sidebar: active nav item shows subtle tint, no gradient
- [ ] Dark mode sidebar: active nav item shows solid purple tint, no gradient (was a full blue→purple gradient before)
- [ ] Home page title and greeting name use solid royal blue instead of gradient text
- [ ] Login page card uses the brighter blue→purple gradient
- [ ] OAuthCallback card uses the brighter blue→purple gradient
- [ ] PublicProfile ask card and banner fallback use the brighter blue→purple gradient
- [ ] Messages question cards (gradient theme enabled) use the brighter blue→purple gradient
- [ ] ThemeCard "default" theme preview still shows the dark gradient (unchanged)

https://claude.ai/code/session_01XZYuEkRrqUgsWfyfZVfQtY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZYuEkRrqUgsWfyfZVfQtY)_