### PR TITLE
Add web push notification skeleton (stubbed, inactive)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4253,6 +4253,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/web-push": {
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+            "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/whatwg-mimetype": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
@@ -4796,6 +4805,15 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.15.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -5058,6 +5076,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5250,6 +5280,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "1.20.5",
@@ -5511,6 +5547,12 @@
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
             }
+        },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/bundle-require": {
             "version": "5.1.0",
@@ -6498,6 +6540,15 @@
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "license": "MIT"
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -8109,6 +8160,15 @@
                 "entities": "^4.5.0"
             }
         },
+        "node_modules/http_ece": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+            "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -8123,6 +8183,19 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -8906,6 +8979,27 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/jwa": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-equal-constant-time": "^1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+            "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+            "license": "MIT",
+            "dependencies": {
+                "jwa": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/keygrip": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -9198,6 +9292,12 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "license": "ISC"
         },
         "node_modules/minimatch": {
             "version": "9.0.9",
@@ -13988,6 +14088,25 @@
                 "node": ">=18"
             }
         },
+        "node_modules/web-push": {
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+            "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "asn1.js": "^5.3.0",
+                "http_ece": "1.2.0",
+                "https-proxy-agent": "^7.0.0",
+                "jws": "^4.0.0",
+                "minimist": "^1.2.5"
+            },
+            "bin": {
+                "web-push": "src/cli.js"
+            },
+            "engines": {
+                "node": ">= 16"
+            }
+        },
         "node_modules/whatwg-mimetype": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -14348,6 +14467,7 @@
                 "@types/cookie-parser": "^1.4.10",
                 "@types/cookie-session": "^2.0.49",
                 "@types/cryptr": "^4.0.3",
+                "@types/web-push": "^3.6.4",
                 "better-sqlite3": "^11.10.0",
                 "cookie-parser": "^1.4.7",
                 "cookie-session": "^2.1.1",
@@ -14364,7 +14484,8 @@
                 "pg": "^8.21.0",
                 "pino": "^9.14.0",
                 "sharp": "^0.34.5",
-                "uhtml": "^4.7.1"
+                "uhtml": "^4.7.1",
+                "web-push": "^3.6.7"
             },
             "devDependencies": {
                 "@atproto/lex-cli": "^0.9.9",

--- a/server/.env.template
+++ b/server/.env.template
@@ -13,3 +13,9 @@ POSTGRESQL_URL=""      # PostgreSQL connection string, e.g. "postgres://user:pas
 # Axiom (optional — set both to enable log ingestion in production)
 # AXIOM_TOKEN=""
 # AXIOM_DATASET=""
+
+# Web Push / VAPID (optional — set all three to enable push notifications)
+# Generate a key pair with: npx web-push generate-vapid-keys
+# VAPID_PUBLIC_KEY=""
+# VAPID_PRIVATE_KEY=""
+# VAPID_SUBJECT="mailto:you@example.com"

--- a/server/package.json
+++ b/server/package.json
@@ -20,8 +20,13 @@
     "test:coverage": "c8 node --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts"
   },
   "c8": {
-    "reporter": ["text", "lcov"],
-    "include": ["src/**"],
+    "reporter": [
+      "text",
+      "lcov"
+    ],
+    "include": [
+      "src/**"
+    ],
     "exclude": [
       "src/lexicon/**",
       "src/index.ts",
@@ -48,6 +53,7 @@
     "@types/cookie-parser": "^1.4.10",
     "@types/cookie-session": "^2.0.49",
     "@types/cryptr": "^4.0.3",
+    "@types/web-push": "^3.6.4",
     "better-sqlite3": "^11.10.0",
     "cookie-parser": "^1.4.7",
     "cookie-session": "^2.1.1",
@@ -64,7 +70,8 @@
     "pg": "^8.21.0",
     "pino": "^9.14.0",
     "sharp": "^0.34.5",
-    "uhtml": "^4.7.1"
+    "uhtml": "^4.7.1",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@atproto/lex-cli": "^0.9.9",

--- a/server/src/controllers/message-controller.ts
+++ b/server/src/controllers/message-controller.ts
@@ -145,6 +145,8 @@ export class MessageController {
     try {
       const result = await this.messageService.sendMessage(recipient, message);
       this.logger.info({ recipient }, "Anonymous message sent");
+      // TODO: trigger web push notification to recipient when enabled
+      // await notificationService.sendNewMessageNotification(recipient);
       return res.json(result);
     } catch (err: any) {
       this.logger.error({ err, recipient }, "Failed to send message");

--- a/server/src/controllers/notification-controller.ts
+++ b/server/src/controllers/notification-controller.ts
@@ -1,0 +1,108 @@
+import express from "express";
+import { body } from "express-validator";
+import { Logger } from "pino";
+import { NotificationService } from "../services/notification-service";
+// import webpush from "web-push";
+
+export class NotificationController {
+  constructor(
+    private notificationService: NotificationService,
+    private logger: Logger
+  ) {}
+
+  /**
+   * Return the server's VAPID public key so the client can subscribe.
+   * The actual key is read from VAPID_PUBLIC_KEY env var.
+   *
+   * GET /notifications/vapid-public-key
+   */
+  getVapidPublicKey = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<express.Response> => {
+    // const vapidPublicKey = process.env.VAPID_PUBLIC_KEY;
+    // if (!vapidPublicKey) {
+    //   return res.status(500).json({ error: "VAPID public key not configured" });
+    // }
+    // return res.json({ vapidPublicKey });
+
+    return res.status(501).json({ error: "Web push not yet enabled" });
+  };
+
+  /**
+   * Validation rules for POST /notifications/subscribe
+   */
+  validateSubscribe = [
+    body("endpoint").isURL().withMessage("endpoint must be a valid URL"),
+    body("keys.p256dh").isString().notEmpty().withMessage("keys.p256dh is required"),
+    body("keys.auth").isString().notEmpty().withMessage("keys.auth is required"),
+  ];
+
+  /**
+   * Save a push subscription for the authenticated user.
+   *
+   * POST /notifications/subscribe
+   * Body: { endpoint: string; keys: { p256dh: string; auth: string } }
+   */
+  subscribe = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<express.Response> => {
+    const did = req.session?.did;
+    if (!did) {
+      return res.status(403).json({ error: "Not authenticated" });
+    }
+
+    // const { endpoint, keys } = req.body as {
+    //   endpoint: string;
+    //   keys: { p256dh: string; auth: string };
+    // };
+
+    // try {
+    //   await this.notificationService.saveSubscription(did, endpoint, keys.p256dh, keys.auth);
+    //   this.logger.info({ did }, "Push subscription registered");
+    //   return res.status(201).json({ ok: true });
+    // } catch (err) {
+    //   this.logger.error({ err, did }, "Failed to save push subscription");
+    //   return res.status(500).json({ error: "Failed to save subscription" });
+    // }
+
+    return res.status(501).json({ error: "Web push not yet enabled" });
+  };
+
+  /**
+   * Validation rules for DELETE /notifications/subscribe
+   */
+  validateUnsubscribe = [
+    body("endpoint").isURL().withMessage("endpoint must be a valid URL"),
+  ];
+
+  /**
+   * Remove a push subscription for the authenticated user.
+   *
+   * DELETE /notifications/subscribe
+   * Body: { endpoint: string }
+   */
+  unsubscribe = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<express.Response> => {
+    const did = req.session?.did;
+    if (!did) {
+      return res.status(403).json({ error: "Not authenticated" });
+    }
+
+    // const { endpoint } = req.body as { endpoint: string };
+
+    // try {
+    //   await this.notificationService.deleteSubscription(did, endpoint);
+    //   this.logger.info({ did }, "Push subscription removed");
+    //   return res.json({ ok: true });
+    // } catch (err) {
+    //   this.logger.error({ err, did }, "Failed to delete push subscription");
+    //   return res.status(500).json({ error: "Failed to delete subscription" });
+    // }
+
+    return res.status(501).json({ error: "Web push not yet enabled" });
+  };
+}

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -20,6 +20,7 @@ export type DatabaseSchema = {
   user_profile: UserProfile; // Add user_profile table
   sessions: Sessions; // NOT USED, to remove later
   user_settings: UserSettings; // Add user_settings table
+  push_subscription: PushSubscription; // Web push subscriptions
 };
 
 // Unused, to remove later
@@ -65,6 +66,16 @@ export type Sessions = {
   sid: string; // Session ID
   sess: string; // Session data (JSON)
   expire: string; // Expiration timestamp
+};
+
+// Web push subscription row — one row per browser/device per user
+export type PushSubscription = {
+  id: number;       // auto-increment surrogate key (serial in Postgres, integer in SQLite)
+  did: string;      // owner DID
+  endpoint: string; // push service endpoint URL (unique per subscription)
+  p256dh: string;   // client public key
+  auth: string;     // client auth secret
+  createdAt: string;
 };
 
 type AuthStateJson = string;
@@ -197,6 +208,30 @@ migrations["006"] = {
   },
   async down(db: Kysely<any>) {
     await db.schema.alterTable("user_settings").dropColumn("imageTheme").execute();
+  },
+};
+
+migrations["007"] = {
+  async up(db: Kysely<any>) {
+    await db.schema
+      .createTable("push_subscription")
+      .addColumn("id", "serial", (col) => col.primaryKey())
+      .addColumn("did", "varchar", (col) => col.notNull())
+      .addColumn("endpoint", "varchar", (col) => col.notNull().unique())
+      .addColumn("p256dh", "varchar", (col) => col.notNull())
+      .addColumn("auth", "varchar", (col) => col.notNull())
+      .addColumn("createdAt", "varchar", (col) => col.notNull())
+      .execute();
+    // Index so lookups by recipient DID (on new message) are fast
+    await db.schema
+      .createIndex("push_subscription_did_idx")
+      .on("push_subscription")
+      .column("did")
+      .execute();
+  },
+  async down(db: Kysely<unknown>) {
+    await db.schema.dropIndex("push_subscription_did_idx").execute();
+    await db.schema.dropTable("push_subscription").ifExists().execute();
   },
 };
 

--- a/server/src/lib/env.ts
+++ b/server/src/lib/env.ts
@@ -27,4 +27,9 @@ export const env = cleanEnv(process.env, {
   }),
   AXIOM_TOKEN: str({ default: "" }),
   AXIOM_DATASET: str({ default: "" }),
+  // Web push (VAPID) — generate a key pair with: npx web-push generate-vapid-keys
+  // Leave empty to keep web push disabled (feature is stubbed out, not yet active).
+  VAPID_PUBLIC_KEY: str({ default: "" }),
+  VAPID_PRIVATE_KEY: str({ default: "" }),
+  VAPID_SUBJECT: str({ default: "" }), // mailto: or https: URL identifying the sender
 });

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -5,6 +5,7 @@ import { messageRoutes } from "./routes/message-routes";
 import { profileRoutes } from "./routes/profile-routes";
 import type { AppContext } from "#/index";
 import { settingsRoutes } from "./routes/settings-routes";
+import { notificationRoutes } from "./routes/notification-routes";
 
 // Helper function for defining routes
 const handler =
@@ -42,5 +43,6 @@ export const createRouter = (ctx: AppContext) => {
   router.use(messageRoutes(ctx, handler, checkValidation));
   router.use(profileRoutes(ctx, handler, checkValidation));
   router.use(settingsRoutes(ctx, handler, checkValidation));
+  router.use(notificationRoutes(ctx, handler, checkValidation));
   return router;
 };

--- a/server/src/routes/notification-routes.ts
+++ b/server/src/routes/notification-routes.ts
@@ -1,0 +1,42 @@
+import express from "express";
+import type { AppContext } from "../index";
+import { NotificationController } from "../controllers/notification-controller";
+import { NotificationService } from "../services/notification-service";
+
+export function notificationRoutes(
+  ctx: AppContext,
+  handler: any,
+  checkValidation: any
+) {
+  const notificationService = new NotificationService(ctx.db, ctx.logger);
+  const notificationController = new NotificationController(
+    notificationService,
+    ctx.logger
+  );
+
+  const router = express.Router();
+
+  // Return the VAPID public key for client-side subscription setup
+  router.get(
+    "/notifications/vapid-public-key",
+    handler(notificationController.getVapidPublicKey)
+  );
+
+  // Register a push subscription
+  router.post(
+    "/notifications/subscribe",
+    notificationController.validateSubscribe,
+    checkValidation,
+    handler(notificationController.subscribe)
+  );
+
+  // Remove a push subscription
+  router.delete(
+    "/notifications/subscribe",
+    notificationController.validateUnsubscribe,
+    checkValidation,
+    handler(notificationController.unsubscribe)
+  );
+
+  return router;
+}

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -1,0 +1,114 @@
+import type { Database } from "../database/db";
+import { Logger } from "pino";
+// import webpush from "web-push";
+
+// Placeholder types matching what would be stored in the DB
+export interface PushSubscription {
+  did: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  createdAt: string;
+}
+
+export class NotificationService {
+  constructor(
+    private db: Database,
+    private logger: Logger
+  ) {}
+
+  /**
+   * Save or update a push subscription for a user.
+   * Upserts by endpoint so re-subscribing doesn't duplicate rows.
+   */
+  async saveSubscription(
+    did: string,
+    endpoint: string,
+    p256dh: string,
+    auth: string
+  ): Promise<void> {
+    // const existing = await this.db
+    //   .selectFrom("push_subscription")
+    //   .selectAll()
+    //   .where("endpoint", "=", endpoint)
+    //   .executeTakeFirst();
+
+    // if (existing) {
+    //   await this.db
+    //     .updateTable("push_subscription")
+    //     .set({ did, p256dh, auth })
+    //     .where("endpoint", "=", endpoint)
+    //     .execute();
+    // } else {
+    //   await this.db
+    //     .insertInto("push_subscription")
+    //     .values({ did, endpoint, p256dh, auth, createdAt: new Date().toISOString() })
+    //     .execute();
+    // }
+
+    this.logger.info({ did }, "Push subscription saved (stub)");
+  }
+
+  /**
+   * Remove a specific push subscription by endpoint (called on unsubscribe).
+   */
+  async deleteSubscription(did: string, endpoint: string): Promise<void> {
+    // await this.db
+    //   .deleteFrom("push_subscription")
+    //   .where("did", "=", did)
+    //   .where("endpoint", "=", endpoint)
+    //   .execute();
+
+    this.logger.info({ did }, "Push subscription deleted (stub)");
+  }
+
+  /**
+   * Remove all push subscriptions for a user (called on account deletion).
+   */
+  async deleteAllSubscriptionsForUser(did: string): Promise<void> {
+    // await this.db
+    //   .deleteFrom("push_subscription")
+    //   .where("did", "=", did)
+    //   .execute();
+
+    this.logger.info({ did }, "All push subscriptions deleted (stub)");
+  }
+
+  /**
+   * Send a push notification to every subscription registered for a recipient.
+   * Automatically removes subscriptions that the push service reports as expired/gone.
+   */
+  async sendNewMessageNotification(recipientDid: string): Promise<void> {
+    // const subscriptions = await this.db
+    //   .selectFrom("push_subscription")
+    //   .selectAll()
+    //   .where("did", "=", recipientDid)
+    //   .execute();
+
+    // const payload = JSON.stringify({
+    //   title: "New anonymous question",
+    //   body: "Someone sent you an anonymous question on Navyfragen!",
+    // });
+
+    // await Promise.allSettled(
+    //   subscriptions.map(async (sub) => {
+    //     try {
+    //       await webpush.sendNotification(
+    //         { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+    //         payload
+    //       );
+    //     } catch (err: any) {
+    //       // 410 Gone / 404 Not Found → subscription is no longer valid; clean it up
+    //       if (err.statusCode === 410 || err.statusCode === 404) {
+    //         await this.deleteSubscription(recipientDid, sub.endpoint);
+    //         this.logger.info({ did: recipientDid }, "Removed expired push subscription");
+    //       } else {
+    //         this.logger.error({ err, did: recipientDid }, "Failed to send push notification");
+    //       }
+    //     }
+    //   })
+    // );
+
+    this.logger.info({ did: recipientDid }, "sendNewMessageNotification called (stub)");
+  }
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `web-push` (VAPID) notification infrastructure to the server, fully stubbed out — nothing fires in production until deliberately enabled
- New DB migration (`007`) creates `push_subscription` table with a unique index on `endpoint` and a DID lookup index
- Three new files following the existing routes → controllers → services pattern:
  - `NotificationService` — `saveSubscription`, `deleteSubscription`, `deleteAllSubscriptionsForUser`, `sendNewMessageNotification` (all business logic commented out)
  - `NotificationController` — `GET /notifications/vapid-public-key`, `POST /notifications/subscribe`, `DELETE /notifications/subscribe` (all return 501 until enabled)
  - `notification-routes.ts` — wired into the main router

## To activate later

1. Generate VAPID keys: `npx web-push generate-vapid-keys`
2. Set `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT` in `.env`
3. Uncomment the logic blocks in `notification-service.ts` and `notification-controller.ts`
4. Wire `webpush.setVapidDetails(...)` into server startup (`index.ts`)
5. Uncomment the `sendNewMessageNotification` call in `message-controller.ts`

## Test plan

- [ ] Server starts without errors with VAPID vars unset
- [ ] `GET /notifications/vapid-public-key` returns 501
- [ ] `POST /notifications/subscribe` returns 501
- [ ] `DELETE /notifications/subscribe` returns 501
- [ ] Migration 007 runs cleanly on both SQLite (dev) and PostgreSQL (prod)

https://claude.ai/code/session_01R1vRA1ZBSN2JLZb26FEwU6
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1vRA1ZBSN2JLZb26FEwU6)_