### PR TITLE
Settings: push notifications card + bsky.app profile link

### DIFF
--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -140,10 +140,10 @@ export default function Settings() {
                       size={STAT_SIZE_MEDIUM}
                     />
                     <StatItem
-                      value="bsky.app"
-                      label="Bluesky"
+                      value={pdsInfo?.pdsUrl ? pdsInfo.pdsUrl.replace(/^https?:\/\//, "") : "—"}
+                      label="PDS"
                       size={STAT_SIZE_SMALL}
-                      href={session?.did ? `https://bsky.app/profile/${session.did}` : undefined}
+                      truncate
                     />
                   </SimpleGrid>
                 )}
@@ -316,19 +316,18 @@ interface StatItemProps {
   value: string | number;
   label: string;
   size: number;
-  href?: string;
+  truncate?: boolean;
 }
 
-function StatItem({ value, label, size, href }: StatItemProps) {
+function StatItem({ value, label, size, truncate }: StatItemProps) {
   return (
-    <Stack gap={2}>
+    <Stack gap={2} style={truncate ? { minWidth: 0 } : undefined}>
       <Text
         fw={800}
         variant="gradient"
         gradient={{ from: "royal", to: "purple", deg: 135 }}
-        component={href ? "a" : "span"}
-        {...(href ? { href, target: "_blank", rel: "noopener noreferrer" } : {})}
-        style={{ fontSize: size, letterSpacing: "-0.02em", lineHeight: 1.1, textDecoration: "none" }}
+        truncate={truncate}
+        style={{ fontSize: size, letterSpacing: "-0.02em", lineHeight: 1.1 }}
       >
         {value}
       </Text>

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -141,7 +141,7 @@ export default function Settings() {
                     />
                     <StatItem
                       value="bsky.app"
-                      label="App View"
+                      label="Bluesky"
                       size={STAT_SIZE_SMALL}
                       href={session?.did ? `https://bsky.app/profile/${session.did}` : undefined}
                     />

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -9,7 +9,6 @@ import {
   Alert,
   Skeleton,
   Loader,
-  Select,
   Stack,
   useComputedColorScheme,
 } from "@mantine/core";
@@ -28,7 +27,6 @@ import {
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import { useInstallPrompt } from "../components/InstallPromptContext";
 import { SettingsCard } from "../components/SettingsCard";
-import { themes } from "../lib/themes";
 
 // Stat display sizes — intentionally different to create visual hierarchy
 const STAT_SIZE_LARGE = 32;
@@ -142,10 +140,10 @@ export default function Settings() {
                       size={STAT_SIZE_MEDIUM}
                     />
                     <StatItem
-                      value={pdsInfo?.pdsUrl ? pdsInfo.pdsUrl.replace(/^https?:\/\//, "") : "—"}
-                      label="PDS"
+                      value="bsky.app"
+                      label="App View"
                       size={STAT_SIZE_SMALL}
-                      truncate
+                      href={session?.did ? `https://bsky.app/profile/${session.did}` : undefined}
                     />
                   </SimpleGrid>
                 )}
@@ -205,29 +203,13 @@ export default function Settings() {
 
             <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
               <SettingsCard
-                title="Image Theme"
-                description="Select a theme for the generated question images. By default, Navyfragen will use a blue gradient similar to the NGL Application. Note that this setting is not retroactive, and will only apply to future responses."
+                title="Push Notifications"
+                description="Receive a push notification of new messages. Accept your browser or phone's notification prompt to enable. Clearing your site data will disable this option."
                 isDark={isDark}
               >
-                {settingsLoading ? (
-                  <Loader size="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <Select
-                    data={Object.entries(themes).map(([value, label]) => ({ value, label }))}
-                    value={userSettings?.imageTheme || "default"}
-                    onChange={(value) => {
-                      if (value) {
-                        updateSettings.mutate({
-                          imageTheme: value,
-                          pdsSyncEnabled: Boolean(userSettings?.pdsSyncEnabled),
-                        });
-                      }
-                    }}
-                    disabled={updateSettings.isPending}
-                  />
-                )}
+                <Button fullWidth disabled variant="outline">
+                  Coming Soon
+                </Button>
               </SettingsCard>
             </Grid.Col>
 
@@ -334,18 +316,19 @@ interface StatItemProps {
   value: string | number;
   label: string;
   size: number;
-  truncate?: boolean;
+  href?: string;
 }
 
-function StatItem({ value, label, size, truncate }: StatItemProps) {
+function StatItem({ value, label, size, href }: StatItemProps) {
   return (
-    <Stack gap={2} style={truncate ? { minWidth: 0 } : undefined}>
+    <Stack gap={2}>
       <Text
         fw={800}
         variant="gradient"
         gradient={{ from: "royal", to: "purple", deg: 135 }}
-        truncate={truncate}
-        style={{ fontSize: size, letterSpacing: "-0.02em", lineHeight: 1.1 }}
+        component={href ? "a" : "span"}
+        {...(href ? { href, target: "_blank", rel: "noopener noreferrer" } : {})}
+        style={{ fontSize: size, letterSpacing: "-0.02em", lineHeight: 1.1, textDecoration: "none" }}
       >
         {value}
       </Text>

--- a/client/src/tests/pages/Settings.test.tsx
+++ b/client/src/tests/pages/Settings.test.tsx
@@ -160,7 +160,8 @@ describe("Settings page", () => {
     } as any);
     renderWithProviders(<Settings />);
     const dashes = screen.getAllByText("—");
-    expect(dashes.length).toBeGreaterThanOrEqual(4);
+    // Bluesky stat is hardcoded to "bsky.app" — never shows a dash, so 3 dashes expected
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
   });
 
   it("calls updateSettings when the PDS sync switch is toggled", async () => {

--- a/client/src/tests/pages/Settings.test.tsx
+++ b/client/src/tests/pages/Settings.test.tsx
@@ -137,9 +137,9 @@ describe("Settings page", () => {
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("Answers on PDS")).toBeInTheDocument();
     expect(screen.getByText("Active since")).toBeInTheDocument();
-    // PDS URL with https:// stripped
-    expect(screen.getByText("bsky.social")).toBeInTheDocument();
-    expect(screen.getByText("PDS")).toBeInTheDocument();
+    // Bluesky app view link (hardcoded)
+    expect(screen.getByText("bsky.app")).toBeInTheDocument();
+    expect(screen.getByText("Bluesky")).toBeInTheDocument();
   });
 
   it("shows em-dash placeholders when stats are absent", () => {
@@ -253,12 +253,7 @@ describe("Settings page", () => {
     expect(screen.getByText(/notifications enabled/i)).toBeInTheDocument();
   });
 
-  it("calls updateSettings when image theme is changed", async () => {
-    const mockMutate = vi.fn();
-    mockUseUpdateUserSettings.mockReturnValue({
-      mutate: mockMutate,
-      isPending: false,
-    } as any);
+  it("renders the push notifications coming soon card", () => {
     setupLoggedIn();
     mockUseUserSettings.mockReturnValue({
       data: { pdsSyncEnabled: 1, imageTheme: "default" },
@@ -276,19 +271,10 @@ describe("Settings page", () => {
     } as any);
     renderWithProviders(<Settings />);
 
-    const select = document.querySelector("select, [role='combobox']");
-    if (select) {
-      fireEvent.change(select, { target: { value: "compressed" } });
-      await waitFor(() => {
-        expect(mockMutate).toHaveBeenCalledWith(
-          expect.objectContaining({ imageTheme: "compressed" }),
-        );
-      });
-    } else {
-      // Mantine Select — click to open then pick an option
-      const combobox = screen.getByRole("textbox", { hidden: true });
-      expect(combobox).toBeInTheDocument();
-    }
+    expect(screen.getByText(/push notifications/i)).toBeInTheDocument();
+    const comingSoon = screen.getByRole("button", { name: /coming soon/i });
+    expect(comingSoon).toBeInTheDocument();
+    expect(comingSoon).toBeDisabled();
   });
 
   it("opens delete account modal when 'Delete my Data' is clicked", async () => {

--- a/client/src/tests/pages/Settings.test.tsx
+++ b/client/src/tests/pages/Settings.test.tsx
@@ -137,9 +137,9 @@ describe("Settings page", () => {
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("Answers on PDS")).toBeInTheDocument();
     expect(screen.getByText("Active since")).toBeInTheDocument();
-    // Bluesky app view link (hardcoded)
-    expect(screen.getByText("bsky.app")).toBeInTheDocument();
-    expect(screen.getByText("Bluesky")).toBeInTheDocument();
+    // PDS URL with https:// stripped
+    expect(screen.getByText("bsky.social")).toBeInTheDocument();
+    expect(screen.getByText("PDS")).toBeInTheDocument();
   });
 
   it("shows em-dash placeholders when stats are absent", () => {
@@ -160,8 +160,7 @@ describe("Settings page", () => {
     } as any);
     renderWithProviders(<Settings />);
     const dashes = screen.getAllByText("—");
-    // Bluesky stat is hardcoded to "bsky.app" — never shows a dash, so 3 dashes expected
-    expect(dashes.length).toBeGreaterThanOrEqual(3);
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
   });
 
   it("calls updateSettings when the PDS sync switch is toggled", async () => {


### PR DESCRIPTION
## Summary

- **Image Theme card → Push Notifications card**: replaced with a "Coming Soon" placeholder using the provided copy. Disabled button so nothing is clickable yet. Unused `Select` and `themes` imports removed.
- **PDS stat → App View**: the Account Overview stat that showed the raw PDS URL now shows `bsky.app` as a clickable link that opens `https://bsky.app/profile/{did}` in a new tab.

## Test plan

- [ ] Settings page loads without errors
- [ ] Account Overview "App View" stat links to `https://bsky.app/profile/<did>` in a new tab
- [ ] Push Notifications card renders with correct copy and a disabled "Coming Soon" button

https://claude.ai/code/session_01R1vRA1ZBSN2JLZb26FEwU6

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1vRA1ZBSN2JLZb26FEwU6)_