### PR TITLE
Make Moots/Following/Oomfs section headers sticky while scrolling

### DIFF
--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -307,7 +307,17 @@ function FriendSection({
         mt="lg"
         mb="xs"
         px={2}
-        style={{ display: "flex", alignItems: "center", gap: 4, width: "100%", cursor: "pointer" }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          width: "100%",
+          cursor: "pointer",
+          position: "sticky",
+          top: 0,
+          zIndex: 1,
+          background: "var(--mantine-color-body)",
+        }}
       >
         <Text
           size="xs"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `position: sticky; top: 0; z-index: 1` to the section header buttons (Moots, Following, Oomfs) in the nav sidebar
- Uses `background: var(--mantine-color-body)` so the header masks scrolling content in both light and dark mode

## Test plan

- [x] Log in and ensure the friends list has enough entries to scroll
- [x] Scroll down through a section — the section label (e.g. "Moots") should remain pinned at the top of the sidebar scroll area
- [x] Confirm the collapse/expand chevron still works while the header is sticky
- [x] Verify the background matches the sidebar in both light and dark mode (no bleed-through of content behind the header)

https://claude.ai/code/session_013F4yq1rERLXy6XQRUHehVE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013F4yq1rERLXy6XQRUHehVE)_