### PR TITLE
Fix sticky section header bounce on scroll

### DIFF
--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -304,7 +304,6 @@ function FriendSection({
     <>
       <UnstyledButton
         onClick={handleToggle}
-        mt="lg"
         mb="xs"
         px={2}
         style={{
@@ -317,6 +316,7 @@ function FriendSection({
           top: 0,
           zIndex: 1,
           background: "var(--mantine-color-body)",
+          paddingTop: "var(--mantine-spacing-lg)",
         }}
       >
         <Text


### PR DESCRIPTION
## Summary

- Replaces `mt="lg"` (margin-top) with `paddingTop: "var(--mantine-spacing-lg)"` on the sticky section header button
- Margins are outside the sticky box, causing a visual jump as they scroll off before the sticky threshold fires; padding is inside the box, so sticking is seamless

## Test plan

- [ ] Scroll through a long friends list — Moots/Following/Oomfs headers should pin to the top with no bounce or jump
- [ ] Spacing between sections should look the same as before

https://claude.ai/code/session_013F4yq1rERLXy6XQRUHehVE

---
_Generated by [Claude Code](https://claude.ai/code/session_013F4yq1rERLXy6XQRUHehVE)_