### PR TITLE
test(server): add tests for notification service/controller and fix c…

### DIFF
--- a/server/src/tests/auth-service.test.ts
+++ b/server/src/tests/auth-service.test.ts
@@ -157,7 +157,13 @@ describe("AuthService", () => {
   describe("createOrConfirmUserProfile", () => {
     test("calls insertInto user_profile with did and createdAt", async () => {
       const executesMock = mock.fn(async () => ({}));
-      const onConflictMock = mock.fn(function (this: any) { return this as any; });
+      const onConflictMock = mock.fn(function (this: any, cb?: (oc: any) => any) {
+        if (typeof cb === "function") {
+          const oc = { column: (_col: string) => ({ doNothing: () => this }) };
+          cb(oc);
+        }
+        return this as any;
+      });
       const valuesMock = mock.fn(function (this: any) {
         (this as any).execute = executesMock;
         (this as any).onConflict = onConflictMock;

--- a/server/src/tests/message-service.test.ts
+++ b/server/src/tests/message-service.test.ts
@@ -664,4 +664,19 @@ describe("MessageService", () => {
       /Failed to delete message from PDS/
     );
   });
+
+  test("deleteMessage outer catch uses fallback when db.execute throws non-Error", async () => {
+    mockSelectBuilder.executeTakeFirst.mock.mockImplementationOnce(
+      async () => ({ tid: "t1", recipient: "did:foo" })
+    );
+    mockAgent.com.atproto.repo.deleteRecord.mock.mockImplementationOnce(async () => ({}));
+    mockDb.deleteFrom = mock.fn(() => ({
+      where: mock.fn(function (this: any) { return this; }),
+      execute: mock.fn(async () => { throw "db-non-error"; }),
+    }));
+    await assert.rejects(
+      () => messageService.deleteMessage("t1", "did:foo", mockAgent),
+      /Failed to delete message/
+    );
+  });
 });

--- a/server/src/tests/notification-controller.test.ts
+++ b/server/src/tests/notification-controller.test.ts
@@ -1,0 +1,80 @@
+import { test, describe, mock, afterEach } from "node:test";
+import assert from "node:assert";
+import { NotificationController } from "../controllers/notification-controller";
+
+describe("NotificationController", () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  function makeService(): any {
+    return {
+      saveSubscription: mock.fn(async () => {}),
+      deleteSubscription: mock.fn(async () => {}),
+    };
+  }
+
+  function makeLogger(): any {
+    return {
+      info: mock.fn(),
+      error: mock.fn(),
+      warn: mock.fn(),
+      debug: mock.fn(),
+    };
+  }
+
+  function makeReq(overrides: any = {}): any {
+    return { body: {}, session: { did: "did:foo" }, params: {}, ...overrides };
+  }
+
+  function makeRes(): any {
+    const res: any = {};
+    res.status = mock.fn(() => res);
+    res.json = mock.fn(() => res);
+    return res;
+  }
+
+  describe("getVapidPublicKey", () => {
+    test("returns 501 (not yet enabled)", async () => {
+      const controller = new NotificationController(makeService(), makeLogger());
+      const res = makeRes();
+      await controller.getVapidPublicKey(makeReq(), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 501);
+      assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], {
+        error: "Web push not yet enabled",
+      });
+    });
+  });
+
+  describe("subscribe", () => {
+    test("returns 403 when no session", async () => {
+      const controller = new NotificationController(makeService(), makeLogger());
+      const res = makeRes();
+      await controller.subscribe(makeReq({ session: null }), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 403);
+    });
+
+    test("returns 501 when authenticated (stub)", async () => {
+      const controller = new NotificationController(makeService(), makeLogger());
+      const res = makeRes();
+      await controller.subscribe(makeReq(), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 501);
+    });
+  });
+
+  describe("unsubscribe", () => {
+    test("returns 403 when no session", async () => {
+      const controller = new NotificationController(makeService(), makeLogger());
+      const res = makeRes();
+      await controller.unsubscribe(makeReq({ session: null }), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 403);
+    });
+
+    test("returns 501 when authenticated (stub)", async () => {
+      const controller = new NotificationController(makeService(), makeLogger());
+      const res = makeRes();
+      await controller.unsubscribe(makeReq(), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 501);
+    });
+  });
+});

--- a/server/src/tests/notification-service.test.ts
+++ b/server/src/tests/notification-service.test.ts
@@ -1,0 +1,48 @@
+import { test, describe, beforeEach, mock } from "node:test";
+import assert from "node:assert";
+import { NotificationService } from "../services/notification-service";
+
+describe("NotificationService", () => {
+  let mockDb: any;
+  let mockLogger: any;
+  let service: NotificationService;
+
+  beforeEach(() => {
+    mockLogger = {
+      info: mock.fn(),
+      error: mock.fn(),
+      warn: mock.fn(),
+      debug: mock.fn(),
+    };
+    mockDb = {};
+    service = new NotificationService(mockDb, mockLogger);
+  });
+
+  test("saveSubscription logs info (stub)", async () => {
+    await service.saveSubscription("did:foo", "https://push.example.com/sub", "p256dh-key", "auth-key");
+    assert.strictEqual(mockLogger.info.mock.calls.length, 1);
+    const logArg = mockLogger.info.mock.calls[0].arguments[0];
+    assert.strictEqual(logArg.did, "did:foo");
+  });
+
+  test("deleteSubscription logs info (stub)", async () => {
+    await service.deleteSubscription("did:foo", "https://push.example.com/sub");
+    assert.strictEqual(mockLogger.info.mock.calls.length, 1);
+    const logArg = mockLogger.info.mock.calls[0].arguments[0];
+    assert.strictEqual(logArg.did, "did:foo");
+  });
+
+  test("deleteAllSubscriptionsForUser logs info (stub)", async () => {
+    await service.deleteAllSubscriptionsForUser("did:foo");
+    assert.strictEqual(mockLogger.info.mock.calls.length, 1);
+    const logArg = mockLogger.info.mock.calls[0].arguments[0];
+    assert.strictEqual(logArg.did, "did:foo");
+  });
+
+  test("sendNewMessageNotification logs info (stub)", async () => {
+    await service.sendNewMessageNotification("did:recipient");
+    assert.strictEqual(mockLogger.info.mock.calls.length, 1);
+    const logArg = mockLogger.info.mock.calls[0].arguments[0];
+    assert.strictEqual(logArg.did, "did:recipient");
+  });
+});

--- a/server/src/tests/profile-service.test.ts
+++ b/server/src/tests/profile-service.test.ts
@@ -469,5 +469,55 @@ describe("ProfileService", () => {
       assert.strictEqual(result.following.length, 0);
       assert.strictEqual(result.oomfs.length, 0);
     });
+
+    it("should stop fetching after 5 pages when cursor never clears (max page limit)", async () => {
+      let followsCallCount = 0;
+      const paginatedAgent = {
+        app: {
+          bsky: {
+            graph: {
+              getFollows: mock.fn(async () => {
+                followsCallCount++;
+                return {
+                  success: true,
+                  data: {
+                    follows: [{ did: `did:user:page${followsCallCount}`, handle: `u${followsCallCount}.bsky.app`, displayName: undefined, avatar: undefined }],
+                    cursor: `page${followsCallCount + 1}`,
+                  },
+                };
+              }),
+            },
+          },
+        },
+      };
+      setPublicAgentFollowers([]);
+      mockSelectBuilder.execute = async () => [];
+
+      await profileService.getFriendsOnApp("did:owner:1", paginatedAgent as any);
+
+      assert.strictEqual(followsCallCount, 5);
+    });
+
+    it("should use empty array fallback when fetchPages response has neither follows nor followers", async () => {
+      const agentWithEmptyData = {
+        app: {
+          bsky: {
+            graph: {
+              getFollows: mock.fn(async () => ({
+                success: true,
+                data: { cursor: undefined },
+              })),
+            },
+          },
+        },
+      };
+      setPublicAgentFollowers([]);
+
+      const result = await profileService.getFriendsOnApp("did:owner:1", agentWithEmptyData as any);
+
+      assert.strictEqual(result.moots.length, 0);
+      assert.strictEqual(result.following.length, 0);
+      assert.strictEqual(result.oomfs.length, 0);
+    });
   });
 });


### PR DESCRIPTION
…overage regressions

- notification-service.test.ts: new test file covering all 4 stub methods (saveSubscription, deleteSubscription, deleteAllSubscriptionsForUser, sendNewMessageNotification) — each verifies logger.info is called with the right DID
- notification-controller.test.ts: new test file covering getVapidPublicKey (501), subscribe and unsubscribe (403 unauthenticated, 501 authenticated stubs)
- message-service.test.ts: re-add "deleteMessage outer catch uses fallback when db.execute throws non-Error" — covers the instanceof Error false branch in the outer deleteMessage catch (was dropped during PR3 conflict resolution, causing a regression)
- profile-service.test.ts: add 5-page limit test (covers fetchPages loop counter exhaustion) and empty-data test (covers res.data.follows ?? res.data.followers ?? [] empty-array fallback)
- auth-service.test.ts: fix onConflict mock to invoke the callback in createOrConfirmUserProfile test, covering the (oc) => oc.column("did").doNothing() arrow function

https://claude.ai/code/session_01RAWPS3eg5N2hmLKgMt5FJF