### PR TITLE
Remove monospace font, use Inter everywhere

### DIFF
--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -192,7 +192,6 @@ export function Navigation({
             />
             <Box style={{ minWidth: 0 }}>
               <Text
-                ff="monospace"
                 fz={9}
                 tt="uppercase"
                 c="dimmed"
@@ -200,7 +199,7 @@ export function Navigation({
               >
                 Viewing profile
               </Text>
-              <Text ff="monospace" fz={12} fw={600} truncate>
+              <Text fz={12} fw={600} truncate>
                 @{viewingHandle}
               </Text>
             </Box>
@@ -324,7 +323,6 @@ function FriendSection({
           fw={700}
           c="dimmed"
           tt="uppercase"
-          ff="monospace"
           style={{ letterSpacing: "0.1em", flex: 1 }}
         >
           {label}
@@ -354,7 +352,7 @@ function FriendSection({
                       <Text fz={13} fw={600} truncate style={{ lineHeight: 1.3 }}>
                         {friend.displayName || friend.handle}
                       </Text>
-                      <Text ff="monospace" fz={10} c="dimmed" truncate style={{ lineHeight: 1.3 }}>
+                      <Text fz={10} c="dimmed" truncate style={{ lineHeight: 1.3 }}>
                         @{friend.handle}
                       </Text>
                     </Box>

--- a/client/src/Theme.tsx
+++ b/client/src/Theme.tsx
@@ -42,7 +42,6 @@ const navyfragenTheme = createTheme({
   black: "#1E1B4B",
 
   fontFamily: "Inter, system-ui, sans-serif",
-  fontFamilyMonospace: "JetBrains Mono, ui-monospace, monospace",
 
   headings: {
     fontFamily: "Inter, system-ui, sans-serif",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -36,7 +36,6 @@ body {
   --nf-grad-mark:  linear-gradient(135deg, #3349E0 0%, #5322c5 55%, #4F1FA6 100%);
   --nf-grad-dark:  linear-gradient(135deg, #1E1B4B 0%, #3B2E78 50%, #6B3FD4 100%);
   --nf-font-sans: 'Inter', system-ui, sans-serif;
-  --nf-font-mono: 'JetBrains Mono', ui-monospace, monospace;
   --nf-ease:     cubic-bezier(.2,.7,.2,1);
   --nf-dur-fast: 120ms;
   --nf-dur-base: 200ms;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -50,7 +50,7 @@ function ShortcutHint({ label, hint }: { label: string; hint: string }) {
       }}
     >
       <Text fz={13}>{label}</Text>
-      <Text ff="monospace" fz={12} c="dimmed">
+      <Text fz={12} c="dimmed">
         {hint.replace("Alt", "Alt/Cmd")}
       </Text>
     </Box>
@@ -266,7 +266,6 @@ export default function Home() {
             fw={700}
             mb="sm"
             tt="uppercase"
-            ff="monospace"
             c="dimmed"
             fz={11}
             style={{ letterSpacing: "0.1em" }}
@@ -298,7 +297,6 @@ export default function Home() {
             fw={700}
             mb="sm"
             tt="uppercase"
-            ff="monospace"
             c="dimmed"
             fz={11}
             style={{ letterSpacing: "0.1em" }}

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -699,7 +699,7 @@ export default function Messages() {
                 Messages
               </Title>
               {!messagesLoading && (
-                <Text ff="monospace" fz={11} c="dimmed" mt={6} style={{ letterSpacing: "0.05em" }}>
+                <Text fz={11} c="dimmed" mt={6} style={{ letterSpacing: "0.05em" }}>
                   {msgCount > 0 ? (
                     <><span style={{ color: "var(--nf-sunshine)" }}>●</span> {msgCount} new</>
                   ) : "no messages"}
@@ -728,7 +728,6 @@ export default function Messages() {
             >
               <Box style={{ flex: 1, minWidth: 200 }}>
                 <Text
-                  ff="monospace"
                   size="xs"
                   c="white"
                   opacity={0.85}
@@ -738,7 +737,6 @@ export default function Messages() {
                   your inbox link · publicly accessible
                 </Text>
                 <Text
-                  ff="monospace"
                   fw={700}
                   c="white"
                   fz={17}
@@ -816,7 +814,7 @@ export default function Messages() {
                     <span
                       style={{ display: "flex", alignItems: "center", gap: 6 }}
                     >
-                      <Text ff="monospace" size="xs" c="dimmed">
+                      <Text size="xs" c="dimmed">
                         {
                           [
                             appendProfileLink,
@@ -936,7 +934,7 @@ export default function Messages() {
                     <span
                       style={{ display: "flex", alignItems: "center", gap: 6 }}
                     >
-                      <Text ff="monospace" size="xs" c="dimmed">
+                      <Text size="xs" c="dimmed">
                         {
                           themes[
                             (settingsLoading
@@ -1005,7 +1003,6 @@ export default function Messages() {
                         }}
                       >
                         <Text
-                          ff="monospace"
                           fw={700}
                           tt="uppercase"
                           c="dimmed"
@@ -1025,7 +1022,7 @@ export default function Messages() {
                               style={{ display: "flex", justifyContent: "space-between", padding: "3px 0" }}
                             >
                               <Text fz={12}>{label}</Text>
-                              <Text ff="monospace" fz={11} c="dimmed">
+                              <Text fz={11} c="dimmed">
                                 {hint.replace("Alt", "Alt/⌘")}
                               </Text>
                             </Box>
@@ -1094,7 +1091,6 @@ export default function Messages() {
                         <Group justify="space-between" align="center">
                           <Group gap={8} align="center">
                             <Text
-                              ff="monospace"
                               fz={10}
                               c="white"
                               opacity={0.8}
@@ -1198,7 +1194,7 @@ export default function Messages() {
                                   count={responseText.length}
                                   limit={characterLimit}
                                 />
-                                <Text ff="monospace" size="xs" c="dimmed">
+                                <Text size="xs" c="dimmed">
                                   {responseText.length}/{characterLimit}
                                 </Text>
                               </Group>

--- a/client/src/pages/PublicProfile.tsx
+++ b/client/src/pages/PublicProfile.tsx
@@ -425,7 +425,7 @@ export default function PublicProfile() {
                   >
                     {profile.displayName}
                   </Text>
-                  <Text ff="monospace" c="dimmed" mt={2} fz={13}>
+                  <Text c="dimmed" mt={2} fz={13}>
                     @{profile.handle}
                   </Text>
                 </Box>

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -375,7 +375,6 @@ function StatItem({ value, label, size, truncate }: StatItemProps) {
         {value}
       </Text>
       <Text
-        ff="monospace"
         size="xs"
         c="dimmed"
         tt="uppercase"


### PR DESCRIPTION
## Summary

- Removed all `ff="monospace"` props from Text components across Navigation, Messages, Home, Settings, and PublicProfile pages
- Deleted the `fontFamilyMonospace` theme definition from `Theme.tsx`
- Removed the `--nf-font-mono` CSS token from `index.css`
- All previously monospaced text now inherits the app's default Inter font

## Test plan

- [x] Check Navigation sidebar — handle/username text renders in Inter
- [x] Check Messages page — inbox URL, timestamps, character count, and keyboard shortcuts use Inter
- [x] Check Home page — keyboard shortcuts section uses Inter
- [x] Check Settings page — label text uses Inter
- [x] Check Public Profile page — `@handle` below display name uses Inter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpXofzZYa7VScd4tMq3cvt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpXofzZYa7VScd4tMq3cvt)_