### PR TITLE
feat: add lexicon publishing script for AT Protocol network resolution

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -14,6 +14,12 @@ POSTGRESQL_URL=""      # PostgreSQL connection string, e.g. "postgres://user:pas
 # AXIOM_TOKEN=""
 # AXIOM_DATASET=""
 
+# Lexicon publishing (optional — run `npm run publish-lexicons` after setting the DNS record)
+# Also add DNS: _lexicon.navyfragen.app TXT "did=<your-DID>"  (the script prints the exact value)
+# LEXICON_AUTHORITY_HANDLE=""
+# LEXICON_AUTHORITY_PASSWORD=""
+# LEXICON_AUTHORITY_PDS="https://bsky.social"
+
 # Web Push / VAPID (optional — set all three to enable push notifications)
 # Generate a key pair with: npx web-push generate-vapid-keys
 # VAPID_PUBLIC_KEY=""

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsc -p tsconfig.check.json --noEmit",
     "test": "node --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts",
     "test:watch": "node --import ./src/tests/test-bootstrap.js --import tsx --watch --test src/**/*.test.ts",
-    "test:coverage": "c8 node --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts"
+    "test:coverage": "c8 node --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts",
+    "publish-lexicons": "tsx --tsconfig tsconfig.json src/scripts/publish-lexicons.ts"
   },
   "lint-staged": {
     "src/**/*.ts": [
@@ -44,7 +45,8 @@
       "src/lib/id-resolver.ts",
       "src/lib/env.ts",
       "src/routes.ts",
-      "src/routes/*.ts"
+      "src/routes/*.ts",
+      "src/scripts/**"
     ]
   },
   "dependencies": {

--- a/server/src/scripts/publish-lexicons.ts
+++ b/server/src/scripts/publish-lexicons.ts
@@ -1,0 +1,58 @@
+/**
+ * Publishes the app.navyfragen.message lexicon to the AT Protocol network.
+ *
+ * Run this once after setting up the DNS TXT record:
+ *   _lexicon.navyfragen.app  TXT  "did=<your-DID>"
+ *
+ * Usage:
+ *   LEXICON_AUTHORITY_HANDLE=you.bsky.social \
+ *   LEXICON_AUTHORITY_PASSWORD=your-app-password \
+ *   npm run publish-lexicons
+ *
+ * The DID printed by this script is what goes into the DNS TXT record.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { AtpAgent } from "@atproto/api";
+
+async function main() {
+  const handle = process.env.LEXICON_AUTHORITY_HANDLE;
+  const password = process.env.LEXICON_AUTHORITY_PASSWORD;
+  const pdsUrl = process.env.LEXICON_AUTHORITY_PDS ?? "https://bsky.social";
+
+  if (!handle || !password) {
+    console.error(
+      "Error: LEXICON_AUTHORITY_HANDLE and LEXICON_AUTHORITY_PASSWORD must be set.\n" +
+        "See the script header for usage."
+    );
+    process.exit(1);
+  }
+
+  const agent = new AtpAgent({ service: pdsUrl });
+  await agent.login({ identifier: handle, password });
+
+  const did = agent.did;
+  console.log(`Logged in as ${handle} (${did})`);
+  console.log(`\nDNS record to add:\n  _lexicon.navyfragen.app  TXT  "did=${did}"\n`);
+
+  const lexiconPath = join(__dirname, "../../lexicons/message.json");
+  const lexicon = JSON.parse(readFileSync(lexiconPath, "utf-8"));
+  const nsid = lexicon.id as string;
+
+  await agent.com.atproto.repo.putRecord({
+    repo: did!,
+    collection: "com.atproto.lexicon.schema",
+    rkey: nsid,
+    record: { $type: "com.atproto.lexicon.schema", ...lexicon },
+    validate: false,
+  });
+
+  console.log(`Published ${nsid} → at://${did}/com.atproto.lexicon.schema/${nsid}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `server/src/scripts/publish-lexicons.ts` — a one-time script that publishes the `app.navyfragen.message` lexicon to a Bluesky PDS under the `com.atproto.lexicon.schema` collection, making it resolvable by AT Protocol tools (e.g. pdsls.dev)
- Documents the required `_lexicon.navyfragen.app` DNS TXT record in `.env.template`
- Adds `npm run publish-lexicons` script to `server/package.json`
- Excludes `src/scripts/**` from test coverage

## Root cause

The NSID `app.navyfragen.message` has authority `navyfragen.app`. AT Protocol lexicon resolution works by:
1. Looking up `_lexicon.navyfragen.app` DNS TXT record → `did=<DID>`
2. Fetching the lexicon from `at://<DID>/com.atproto.lexicon.schema/app.navyfragen.message`

Neither step was set up, so tools like pdsls.dev couldn't resolve the schema.

## How to use

1. Run the script to get your DID and publish the lexicon:
   ```sh
   cd server
   LEXICON_AUTHORITY_HANDLE=you.bsky.social \
   LEXICON_AUTHORITY_PASSWORD=your-app-password \
   npm run publish-lexicons
   ```
2. The script prints the exact DNS record to add:
   ```
   _lexicon.navyfragen.app  TXT  "did=<your-DID>"
   ```
3. Add that DNS TXT record in your DNS provider. Once it propagates, pdsls.dev and other AT Protocol tools will be able to resolve `app.navyfragen.message`.

## Test plan

- [ ] Run `npm run publish-lexicons` with valid credentials and confirm the record appears in the authority account's PDS
- [ ] Add the DNS TXT record and verify pdsls.dev can display `app.navyfragen.message` records without the "lexicon authority not found" error

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtassNhKUYr6CMiazwVgiC)_