### PR TITLE
test: cover client auth/push-notification services and Login/AppHeader UI (batch 1/N)

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -158,7 +158,11 @@ function UserMenu({
   const hasMultiple = accounts.length > 1;
 
   const handleSwitch = (did: string, handle: string) => {
+    // The menu item for the active account is rendered with `disabled`, so a click can
+    // never reach this handler with did === activeDid; kept as a defensive guard.
+    /* v8 ignore start */
     if (did === activeDid || isSwitching) return;
+    /* v8 ignore stop */
     triggerHaptic();
 
     switchAccount(

--- a/client/src/tests/authService.test.ts
+++ b/client/src/tests/authService.test.ts
@@ -9,9 +9,12 @@ import {
   useSession,
   useLogin,
   useLogout,
+  useSwitchAccount,
+  useE2ELogin,
   authKeys,
   SessionResponse,
 } from "../api/authService";
+import { clearFriendsCache } from "../api/profileService";
 import { queryClient } from "../api/queryClient";
 
 function makeWrapper() {
@@ -34,6 +37,10 @@ vi.mock("../api/queryClient", () => ({
   queryClient: {
     invalidateQueries: vi.fn(),
   },
+}));
+
+vi.mock("../api/profileService", () => ({
+  clearFriendsCache: vi.fn(),
 }));
 
 const originalLocation = window.location;
@@ -110,6 +117,38 @@ describe("authService", () => {
       expect(apiClient.post).toHaveBeenCalledWith("/logout");
     });
   });
+
+  describe("switchAccount", () => {
+    it("should call apiClient.post with the correct endpoint and data", async () => {
+      const mockResponse = { success: true, did: "did:example:456" };
+      vi.mocked(apiClient.post).mockResolvedValueOnce(mockResponse);
+
+      const result = await authService.switchAccount({ did: "did:example:456" });
+
+      expect(result).toEqual(mockResponse);
+      expect(apiClient.post).toHaveBeenCalledWith("/accounts/switch", {
+        did: "did:example:456",
+      });
+    });
+  });
+
+  describe("e2eLogin", () => {
+    it("should call apiClient.post with the correct endpoint and data", async () => {
+      const mockResponse = { success: true };
+      vi.mocked(apiClient.post).mockResolvedValueOnce(mockResponse);
+
+      const result = await authService.e2eLogin({
+        identifier: "user.example.com",
+        password: "hunter2",
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(apiClient.post).toHaveBeenCalledWith("/auth/e2e-login", {
+        identifier: "user.example.com",
+        password: "hunter2",
+      });
+    });
+  });
 });
 
 describe("auth hooks", () => {
@@ -163,5 +202,53 @@ describe("auth hooks", () => {
       queryKey: authKeys.session,
     });
     expect(window.location.href).toBe("/");
+  });
+
+  it("useSwitchAccount returns a mutation object", () => {
+    const { result } = renderHook(() => useSwitchAccount(), {
+      wrapper: makeWrapper(),
+    });
+    expect(typeof result.current.mutate).toBe("function");
+  });
+
+  it("useSwitchAccount.onSuccess clears the friends cache for the new did", async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      success: true,
+      did: "did:example:789",
+    });
+    const { result } = renderHook(() => useSwitchAccount(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({ did: "did:example:789" });
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/accounts/switch", {
+      did: "did:example:789",
+    });
+    expect(vi.mocked(clearFriendsCache)).toHaveBeenCalledWith("did:example:789");
+  });
+
+  it("useE2ELogin returns a mutation object", () => {
+    const { result } = renderHook(() => useE2ELogin(), {
+      wrapper: makeWrapper(),
+    });
+    expect(typeof result.current.mutate).toBe("function");
+  });
+
+  it("useE2ELogin executes the mutationFn with the provided data", async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce({ success: true });
+    const { result } = renderHook(() => useE2ELogin(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync({
+        identifier: "user.example.com",
+        password: "hunter2",
+      });
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/auth/e2e-login", {
+      identifier: "user.example.com",
+      password: "hunter2",
+    });
   });
 });

--- a/client/src/tests/components/AppHeader.test.tsx
+++ b/client/src/tests/components/AppHeader.test.tsx
@@ -1,12 +1,19 @@
 import * as mantineCore from "@mantine/core";
-import { screen, fireEvent } from "@testing-library/react";
+import { showNotification } from "@mantine/notifications";
+import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import * as authService from "../../api/authService";
+import * as accountSwitchToast from "../../lib/accountSwitchToast";
 // eslint-disable-next-line import/order
 import { renderWithProviders } from "../testUtils";
+
+vi.mock("../../lib/accountSwitchToast", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/accountSwitchToast")>();
+  return { ...actual, buildAccountSwitchUrl: vi.fn() };
+});
 
 vi.mock("../../api/authService", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../api/authService")>();
@@ -40,6 +47,9 @@ const mockUseSession = vi.mocked(authService.useSession);
 const mockUseLogout = vi.mocked(authService.useLogout);
 const mockUseSwitchAccount = vi.mocked(authService.useSwitchAccount);
 const mockUseComputedColorScheme = vi.mocked(mantineCore.useComputedColorScheme);
+const mockBuildAccountSwitchUrl = vi.mocked(accountSwitchToast.buildAccountSwitchUrl);
+
+const originalLocation = window.location;
 
 describe("AppHeader", () => {
   const defaultProps = {
@@ -250,5 +260,184 @@ describe("AppHeader", () => {
       // The catch block resets body styles
       expect(document.body.style.pointerEvents).toBe("");
     }
+  });
+
+  describe("account switcher", () => {
+    const accounts = [
+      { did: "did:example:active", handle: "active.bsky.social", displayName: "Active User" },
+      { did: "did:example:other", handle: "other.bsky.social", displayName: "Other User" },
+    ];
+
+    beforeEach(() => {
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: { ...originalLocation, href: "" },
+      });
+      mockUseSession.mockReturnValue({
+        data: {
+          isLoggedIn: true,
+          profile: { handle: "active.bsky.social", displayName: "Active User", avatar: null },
+          accounts,
+          did: "did:example:active",
+        },
+        isLoading: false,
+      } as any);
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: originalLocation,
+      });
+    });
+
+    async function openMenu() {
+      const userBtn = screen.getAllByText("Active User")[0].closest("button")!;
+      await userEvent.click(userBtn);
+    }
+
+    it("lists every account with the active one checked and disabled", async () => {
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      expect(screen.getByText("Other User")).toBeInTheDocument();
+      const activeItem = screen.getByText("@active.bsky.social").closest('[role="menuitem"]');
+      expect(activeItem).toHaveAttribute("data-disabled", "true");
+    });
+
+    it("does nothing when clicking the already-active account", async () => {
+      const mockSwitch = vi.fn();
+      mockUseSwitchAccount.mockReturnValue({ mutate: mockSwitch, isPending: false } as any);
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      const activeItem = screen.getByText("@active.bsky.social").closest("button")!;
+      fireEvent.click(activeItem);
+      expect(mockSwitch).not.toHaveBeenCalled();
+    });
+
+    it("switches to another account and redirects on success", async () => {
+      let capturedCallbacks: any;
+      const mockSwitch = vi.fn((_data, callbacks) => {
+        capturedCallbacks = callbacks;
+      });
+      mockUseSwitchAccount.mockReturnValue({ mutate: mockSwitch, isPending: false } as any);
+      mockBuildAccountSwitchUrl.mockReturnValue("/?accountSwitched=other.bsky.social");
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      const otherItem = screen.getByText("@other.bsky.social").closest("button")!;
+      fireEvent.click(otherItem);
+
+      expect(mockSwitch).toHaveBeenCalledWith({ did: "did:example:other" }, expect.any(Object));
+
+      act(() => {
+        capturedCallbacks.onSuccess();
+      });
+
+      expect(mockBuildAccountSwitchUrl).toHaveBeenCalledWith("other.bsky.social");
+      expect(window.location.href).toBe("/?accountSwitched=other.bsky.social");
+    });
+
+    it("shows an error notification when switching accounts fails", async () => {
+      let capturedCallbacks: any;
+      const mockSwitch = vi.fn((_data, callbacks) => {
+        capturedCallbacks = callbacks;
+      });
+      mockUseSwitchAccount.mockReturnValue({ mutate: mockSwitch, isPending: false } as any);
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      const otherItem = screen.getByText("@other.bsky.social").closest("button")!;
+      fireEvent.click(otherItem);
+
+      await waitFor(() => expect(mockSwitch).toHaveBeenCalled());
+
+      act(() => {
+        capturedCallbacks.onError({ error: "Switch failed" });
+      });
+
+      expect(vi.mocked(showNotification)).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Couldn't switch account", message: "Switch failed" })
+      );
+    });
+
+    it("shows a fallback error message when switching accounts fails without a message", async () => {
+      let capturedCallbacks: any;
+      const mockSwitch = vi.fn((_data, callbacks) => {
+        capturedCallbacks = callbacks;
+      });
+      mockUseSwitchAccount.mockReturnValue({ mutate: mockSwitch, isPending: false } as any);
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      const otherItem = screen.getByText("@other.bsky.social").closest("button")!;
+      fireEvent.click(otherItem);
+
+      await waitFor(() => expect(mockSwitch).toHaveBeenCalled());
+
+      act(() => {
+        capturedCallbacks.onError({} as any);
+      });
+
+      expect(vi.mocked(showNotification)).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Couldn't switch account", message: "Please try again." })
+      );
+    });
+
+    it("does not render the account switcher section when there is only one account", async () => {
+      mockUseSession.mockReturnValue({
+        data: {
+          isLoggedIn: true,
+          profile: { handle: "active.bsky.social", displayName: "Active User", avatar: null },
+          accounts: [accounts[0]],
+          did: "did:example:active",
+        },
+        isLoading: false,
+      } as any);
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      expect(screen.queryByText("Accounts")).not.toBeInTheDocument();
+    });
+
+    it("does nothing when a switch is already pending", async () => {
+      const mockSwitch = vi.fn();
+      mockUseSwitchAccount.mockReturnValue({ mutate: mockSwitch, isPending: true } as any);
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      const otherItem = screen.getByText("@other.bsky.social").closest("button")!;
+      fireEvent.click(otherItem);
+      expect(mockSwitch).not.toHaveBeenCalled();
+    });
+
+    it("falls back to did/handle placeholders when displayName and handle are missing", async () => {
+      const mockSwitch = vi.fn();
+      mockUseSwitchAccount.mockReturnValue({ mutate: mockSwitch, isPending: false } as any);
+      mockUseSession.mockReturnValue({
+        data: {
+          isLoggedIn: true,
+          profile: { handle: "active.bsky.social", displayName: "Active User", avatar: null },
+          accounts: [
+            accounts[0],
+            { did: "did:example:bare", handle: undefined, displayName: undefined, avatar: null },
+          ],
+          did: "did:example:active",
+        },
+        isLoading: false,
+      } as any);
+      renderWithProviders(<AppHeader {...defaultProps} />);
+      await openMenu();
+      // Falls back to the did for both the label and the avatar initial.
+      const bareItem = screen.getByText("did:example:bare").closest("button")!;
+      expect(bareItem).toHaveTextContent("?");
+
+      fireEvent.click(bareItem);
+      expect(mockSwitch).toHaveBeenCalledWith({ did: "did:example:bare" }, expect.any(Object));
+    });
+
+    it("triggers haptics and onNavigate when 'Add account' is clicked", async () => {
+      const onNavClose = vi.fn();
+      renderWithProviders(<AppHeader {...defaultProps} onNavClose={onNavClose} />);
+      await openMenu();
+      const addAccountItem = screen.getByText("Add account");
+      fireEvent.click(addAccountItem);
+      expect(onNavClose).toHaveBeenCalled();
+      expect(addAccountItem.closest("a")).toHaveAttribute("href", "/login?add=1");
+    });
   });
 });

--- a/client/src/tests/components/PushNotificationsButton.test.tsx
+++ b/client/src/tests/components/PushNotificationsButton.test.tsx
@@ -1,0 +1,120 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import * as notificationService from "../../api/notificationService";
+import { PushNotificationsButton } from "../../components/PushNotificationsButton";
+import { renderWithProviders } from "../testUtils";
+
+vi.mock("../../api/notificationService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/notificationService")>();
+  return {
+    ...actual,
+    getPushPermission: vi.fn(),
+    usePushAvailable: vi.fn(),
+    useEnablePushNotifications: vi.fn(),
+    useDisablePushNotifications: vi.fn(),
+  };
+});
+
+const mockGetPushPermission = vi.mocked(notificationService.getPushPermission);
+const mockUsePushAvailable = vi.mocked(notificationService.usePushAvailable);
+const mockUseEnablePushNotifications = vi.mocked(notificationService.useEnablePushNotifications);
+const mockUseDisablePushNotifications = vi.mocked(notificationService.useDisablePushNotifications);
+
+const SUBSCRIBED_FLAG = "nf-push-subscribed";
+
+describe("PushNotificationsButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockUsePushAvailable.mockReturnValue({ data: true, isLoading: false } as any);
+    mockUseEnablePushNotifications.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue("endpoint"),
+      isPending: false,
+    } as any);
+    mockUseDisablePushNotifications.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue(undefined),
+      isPending: false,
+    } as any);
+  });
+
+  it("shows a loader while availability is being checked", () => {
+    mockUsePushAvailable.mockReturnValue({ data: undefined, isLoading: true } as any);
+    mockGetPushPermission.mockReturnValue("default");
+    renderWithProviders(<PushNotificationsButton />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows an unavailable button when the server does not support push", () => {
+    mockUsePushAvailable.mockReturnValue({ data: false, isLoading: false } as any);
+    mockGetPushPermission.mockReturnValue("default");
+    renderWithProviders(<PushNotificationsButton />);
+    expect(screen.getByRole("button", { name: /push notifications unavailable/i })).toBeDisabled();
+  });
+
+  it("shows an unavailable button when the browser is unsupported", () => {
+    mockGetPushPermission.mockReturnValue("unsupported");
+    renderWithProviders(<PushNotificationsButton />);
+    expect(screen.getByRole("button", { name: /push notifications unavailable/i })).toBeDisabled();
+  });
+
+  it("shows an unavailable button when permission was denied", () => {
+    mockGetPushPermission.mockReturnValue("denied");
+    renderWithProviders(<PushNotificationsButton />);
+    expect(screen.getByRole("button", { name: /push notifications unavailable/i })).toBeDisabled();
+  });
+
+  it("shows an 'Enable' button when not subscribed", () => {
+    mockGetPushPermission.mockReturnValue("default");
+    renderWithProviders(<PushNotificationsButton />);
+    expect(screen.getByRole("button", { name: /enable push notifications/i })).toBeInTheDocument();
+  });
+
+  it("shows an 'Enabled' button when locally subscribed and permission is granted", () => {
+    localStorage.setItem(SUBSCRIBED_FLAG, "1");
+    mockGetPushPermission.mockReturnValue("granted");
+    renderWithProviders(<PushNotificationsButton />);
+    expect(screen.getByRole("button", { name: /push notifications enabled/i })).toBeInTheDocument();
+  });
+
+  it("enables push notifications on click and persists the subscribed flag", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue("endpoint");
+    mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
+    mockGetPushPermission.mockReturnValue("default");
+    renderWithProviders(<PushNotificationsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /enable push notifications/i }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    await waitFor(() => expect(localStorage.getItem(SUBSCRIBED_FLAG)).toBe("1"));
+  });
+
+  it("disables push notifications on click and clears the subscribed flag", async () => {
+    localStorage.setItem(SUBSCRIBED_FLAG, "1");
+    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    mockUseDisablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
+    mockGetPushPermission.mockReturnValue("granted");
+    renderWithProviders(<PushNotificationsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /push notifications enabled/i }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    await waitFor(() => expect(localStorage.getItem(SUBSCRIBED_FLAG)).toBeNull());
+  });
+
+  it("shows an error notification when enabling push fails", async () => {
+    const mutateAsync = vi.fn().mockRejectedValue({ error: "Boom" });
+    mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
+    mockGetPushPermission.mockReturnValue("default");
+    renderWithProviders(<PushNotificationsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /enable push notifications/i }));
+    await waitFor(() => expect(screen.getByText("Boom")).toBeInTheDocument());
+  });
+
+  it("shows a fallback error message when the rejection has no error string", async () => {
+    const mutateAsync = vi.fn().mockRejectedValue({});
+    mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
+    mockGetPushPermission.mockReturnValue("default");
+    renderWithProviders(<PushNotificationsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /enable push notifications/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/something went wrong. please try again/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/client/src/tests/notificationService.test.ts
+++ b/client/src/tests/notificationService.test.ts
@@ -1,0 +1,277 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { apiClient } from "../api/apiClient";
+import {
+  getPushPermission,
+  usePushAvailable,
+  useEnablePushNotifications,
+  useDisablePushNotifications,
+} from "../api/notificationService";
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return Wrapper;
+}
+
+vi.mock("../api/apiClient", () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const VAPID_KEY = "BEXAMPLE_VAPID-KEY_123";
+
+describe("getPushPermission", () => {
+  const originalNotification = (window as any).Notification;
+
+  afterEach(() => {
+    (window as any).Notification = originalNotification;
+  });
+
+  it("returns 'unsupported' when Notification is not in window", () => {
+    delete (window as any).Notification;
+    expect(getPushPermission()).toBe("unsupported");
+  });
+
+  it("returns the current Notification.permission", () => {
+    (window as any).Notification = { permission: "granted" };
+    expect(getPushPermission()).toBe("granted");
+  });
+});
+
+describe("usePushAvailable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when the vapid key is available", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ vapidPublicKey: VAPID_KEY });
+    const { result } = renderHook(() => usePushAvailable(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(true);
+  });
+
+  it("returns false when apiClient throws a 501 (push not configured server-side)", async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce({ status: 501 });
+    const { result } = renderHook(() => usePushAvailable(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(false);
+  });
+
+  it("rejects when apiClient throws a non-501 error", async () => {
+    vi.mocked(apiClient.get).mockRejectedValueOnce({ status: 500 });
+    const { result } = renderHook(() => usePushAvailable(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useEnablePushNotifications", () => {
+  const originalNotification = (window as any).Notification;
+  const originalServiceWorker = (navigator as any).serviceWorker;
+  const originalPushManager = (window as any).PushManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (window as any).PushManager = class {};
+  });
+
+  afterEach(() => {
+    (window as any).Notification = originalNotification;
+    (window as any).PushManager = originalPushManager;
+    delete (navigator as any).serviceWorker;
+    if (originalServiceWorker !== undefined) {
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: originalServiceWorker,
+        configurable: true,
+      });
+    }
+  });
+
+  it("throws when the server does not support push (no vapid key)", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ vapidPublicKey: null });
+    const { result } = renderHook(() => useEnablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync()).rejects.toMatchObject({
+        error: "Push notifications are not available on this server",
+        status: 501,
+      });
+    });
+  });
+
+  it("throws when the browser does not support service workers/push manager", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ vapidPublicKey: VAPID_KEY });
+    delete (navigator as any).serviceWorker;
+    const { result } = renderHook(() => useEnablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync()).rejects.toMatchObject({
+        error: "Push notifications are not supported by this browser",
+        status: 501,
+      });
+    });
+  });
+
+  it("throws when notification permission is not granted", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ vapidPublicKey: VAPID_KEY });
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { ready: Promise.resolve({}) },
+      configurable: true,
+    });
+    (window as any).Notification = { requestPermission: vi.fn().mockResolvedValue("denied") };
+    const { result } = renderHook(() => useEnablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync()).rejects.toMatchObject({
+        error: "Notification permission was not granted",
+        status: 403,
+      });
+    });
+  });
+
+  it("throws when the subscription has no endpoint", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ vapidPublicKey: VAPID_KEY });
+    (window as any).Notification = { requestPermission: vi.fn().mockResolvedValue("granted") };
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve({
+          pushManager: {
+            subscribe: vi.fn().mockResolvedValue({
+              toJSON: () => ({ endpoint: undefined, keys: undefined }),
+            }),
+          },
+        }),
+      },
+      configurable: true,
+    });
+    const { result } = renderHook(() => useEnablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync()).rejects.toMatchObject({
+        error: "Push subscription returned no endpoint",
+        status: 502,
+      });
+    });
+  });
+
+  it("subscribes successfully and posts subscription details to the server", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ vapidPublicKey: VAPID_KEY });
+    vi.mocked(apiClient.post).mockResolvedValueOnce(undefined);
+    (window as any).Notification = { requestPermission: vi.fn().mockResolvedValue("granted") };
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve({
+          pushManager: {
+            subscribe: vi.fn().mockResolvedValue({
+              toJSON: () => ({
+                endpoint: "https://push.example.com/abc",
+                keys: { p256dh: "p256dh-key", auth: "auth-key" },
+              }),
+            }),
+          },
+        }),
+      },
+      configurable: true,
+    });
+    const { result } = renderHook(() => useEnablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    let endpoint: string | undefined;
+    await act(async () => {
+      endpoint = await result.current.mutateAsync();
+    });
+    expect(endpoint).toBe("https://push.example.com/abc");
+    expect(apiClient.post).toHaveBeenCalledWith("/notifications/subscribe", {
+      endpoint: "https://push.example.com/abc",
+      keys: { p256dh: "p256dh-key", auth: "auth-key" },
+    });
+  });
+});
+
+describe("useDisablePushNotifications", () => {
+  const originalServiceWorker = (navigator as any).serviceWorker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete (navigator as any).serviceWorker;
+    if (originalServiceWorker !== undefined) {
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: originalServiceWorker,
+        configurable: true,
+      });
+    }
+  });
+
+  it("does nothing when the browser has no service worker support", async () => {
+    delete (navigator as any).serviceWorker;
+    const { result } = renderHook(() => useDisablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    expect(apiClient.delete).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no existing subscription", async () => {
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve({
+          pushManager: { getSubscription: vi.fn().mockResolvedValue(null) },
+        }),
+      },
+      configurable: true,
+    });
+    const { result } = renderHook(() => useDisablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    expect(apiClient.delete).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes and notifies the server when a subscription exists", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        ready: Promise.resolve({
+          pushManager: {
+            getSubscription: vi.fn().mockResolvedValue({
+              endpoint: "https://push.example.com/xyz",
+              unsubscribe,
+            }),
+          },
+        }),
+      },
+      configurable: true,
+    });
+    vi.mocked(apiClient.delete).mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useDisablePushNotifications(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(apiClient.delete).toHaveBeenCalledWith("/notifications/subscribe", {
+      endpoint: "https://push.example.com/xyz",
+    });
+  });
+});

--- a/client/src/tests/pages/Login.test.tsx
+++ b/client/src/tests/pages/Login.test.tsx
@@ -320,6 +320,230 @@ describe("Login page", () => {
     });
   });
 
+  describe("handle suggestion selection", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("sorts and renders multiple suggestions, allowing selection of the top match", async () => {
+      const mockActors = [
+        { did: "did:plc:def", handle: "alicia.bsky.social", displayName: "Alicia" },
+        { did: "did:plc:abc", handle: "ali.bsky.social", displayName: "Ali" },
+      ];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      fireEvent.change(getHandleInput(), { target: { value: "ali" } });
+
+      // Exact handle match ("ali.bsky.social") should be ranked first.
+      const suggestionRow = await screen.findByRole("option", {}, { timeout: 2000 });
+      expect(suggestionRow).toHaveTextContent("Ali");
+
+      fireEvent.click(suggestionRow);
+      expect((getHandleInput() as HTMLInputElement).value).toBe("ali.bsky.social");
+    });
+
+    it("offers the typed handle directly when there are no search results", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: [] }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      fireEvent.change(getHandleInput(), { target: { value: "unknown.example.com" } });
+
+      const suggestionRow = await screen.findByText("@unknown.example.com", {}, { timeout: 2000 });
+      fireEvent.click(suggestionRow);
+      expect((getHandleInput() as HTMLInputElement).value).toBe("unknown.example.com");
+    });
+
+    it("auto-selects a single suggestion that exactly matches the typed handle", async () => {
+      const mockActors = [
+        { did: "did:plc:abc", handle: "karan.bsky.social", displayName: "Karan" },
+      ];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      fireEvent.change(getHandleInput(), { target: { value: "karan.bsky.social" } });
+
+      await waitFor(() => expect(screen.getByText("Karan")).toBeInTheDocument(), { timeout: 2000 });
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("ranks a suggestion with no matching prefix last and clears a manual selection on Escape", async () => {
+      const mockActors = [
+        { did: "did:plc:karina", handle: "karina.bsky.social", displayName: "Karina" },
+        { did: "did:plc:karan", handle: "karan.bsky.social", displayName: "Karan" },
+        { did: "did:plc:zzz", handle: "zzz.bsky.social", displayName: "Zzz" },
+        // Handle doesn't match the prefix, but the display name does (rank 3).
+        { did: "did:plc:disp", handle: "unrelated.bsky.social", displayName: "Karenina" },
+        // Neither handle nor (missing) display name match — falls to the `?? ""` fallback.
+        { did: "did:plc:nodisp", handle: "other.bsky.social", displayName: undefined },
+      ];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      const input = getHandleInput();
+      fireEvent.change(input, { target: { value: "kar" } });
+
+      const suggestionRow = await screen.findByRole("option", {}, { timeout: 2000 });
+      fireEvent.click(suggestionRow);
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+
+      fireEvent.keyDown(input, { key: "Escape" });
+      expect(await screen.findByRole("option", {}, { timeout: 2000 })).toBeInTheDocument();
+    });
+
+    it("clears a manual selection when the user resumes typing", async () => {
+      const mockActors = [
+        { did: "did:plc:abc", handle: "karan.bsky.social", displayName: "Karan" },
+      ];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      const input = getHandleInput();
+      fireEvent.change(input, { target: { value: "kar" } });
+      const suggestionRow = await screen.findByRole("option", {}, { timeout: 2000 });
+      fireEvent.click(suggestionRow);
+      expect(screen.getByText("Karan")).toBeInTheDocument();
+
+      fireEvent.change(input, { target: { value: "karan.bsky.socia" } });
+      // Typing again clears the manual selection; the static "selected" row disappears.
+      await waitFor(() => expect(screen.queryByText("Karan")).not.toBeInTheDocument());
+    });
+
+    it("shows 'No handles found' and tolerates a response with no actors field", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      // Two characters, no dot: search runs but the handle is not "ready" yet, so the
+      // typed-handle offer is skipped and the plain "No handles found" branch renders.
+      fireEvent.change(getHandleInput(), { target: { value: "ab" } });
+
+      expect(
+        await screen.findByText(/no handles found/i, {}, { timeout: 2000 })
+      ).toBeInTheDocument();
+    });
+
+    it("navigates with ArrowDown into the suggestion and back to the input with Escape", async () => {
+      const mockActors = [{ did: "did:plc:abc", handle: "someone.bsky.social" }];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      const input = getHandleInput();
+      fireEvent.change(input, { target: { value: "some" } });
+
+      const suggestionRow = await screen.findByRole("option", {}, { timeout: 2000 });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      expect(document.activeElement).toBe(suggestionRow);
+
+      fireEvent.keyDown(suggestionRow, { key: "Escape" });
+      expect(document.activeElement).toBe(input);
+    });
+
+    it("moves focus back to the input when ArrowUp is pressed on a suggestion", async () => {
+      const mockActors = [{ did: "did:plc:abc", handle: "someone.bsky.social" }];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      const input = getHandleInput();
+      fireEvent.change(input, { target: { value: "some" } });
+
+      const suggestionRow = await screen.findByRole("option", {}, { timeout: 2000 });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(suggestionRow, { key: "ArrowUp" });
+      expect(document.activeElement).toBe(input);
+    });
+
+    it("ignores unrelated keys on a suggestion row and on the main input", async () => {
+      const mockActors = [{ did: "did:plc:abc", handle: "someone.bsky.social" }];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ actors: mockActors }),
+        })
+      );
+      mockUseLogin.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+      renderWithProviders(<Login />);
+
+      const input = getHandleInput();
+      fireEvent.change(input, { target: { value: "some" } });
+
+      const suggestionRow = await screen.findByRole("option", {}, { timeout: 2000 });
+      fireEvent.keyDown(suggestionRow, { key: "a" });
+      expect(suggestionRow).toBeInTheDocument();
+
+      fireEvent.keyDown(input, { key: "a" });
+      expect(document.activeElement).not.toBe(suggestionRow);
+    });
+  });
+
+  it("shows a validation error when the typed handle exceeds the max length", async () => {
+    const mockMutate = vi.fn();
+    mockUseLogin.mockReturnValue({ mutate: mockMutate, isPending: false } as any);
+    renderWithProviders(<Login />);
+
+    const longHandle = `${"a".repeat(70)}.bsky.social`;
+    fireEvent.change(getHandleInput(), { target: { value: longHandle } });
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/handle too long/i)).toBeInTheDocument();
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
   describe("E2ELoginPanel", () => {
     beforeEach(() => {
       vi.stubEnv("VITE_E2E_TESTING", "true");

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -28,6 +28,14 @@ This document explains coverage exclusions and hard-to-test code.
 
 **What it would take to test:** Not possible through React rendering — the branch requires `friendsLoading` to be simultaneously falsy (to skip the loading skeleton) and truthy (to skip the empty-state text).
 
+### `client/src/components/AppHeader.tsx` — unreachable `did === activeDid` guard in `handleSwitch`
+
+**Line:** `if (did === activeDid || isSwitching) return;` inside `handleSwitch` (the account-switcher's `UserMenu`).
+
+**Why ignored:** The `Menu.Item` for the currently-active account is rendered with `disabled={isActive || isSwitching}`, and Mantine/JSDOM do not dispatch click events to disabled buttons. `handleSwitch` can therefore only ever be invoked with `did !== activeDid` through the UI, making the `did === activeDid` arm of the guard permanently unreachable in tests. It's kept in the source as defense-in-depth in case the disabled state and the handler ever fall out of sync.
+
+**What it would take to test:** Call `handleSwitch` directly (bypassing the disabled menu item) by exporting it or via a component ref, with `did` equal to `activeDid`.
+
 ### `client/src/pages/Settings.tsx` — unreachable `!installPrompt` early-return guard
 
 **Line:** `if (!installPrompt) return;` inside `handleInstallClick`.


### PR DESCRIPTION
## Summary

Part of an ongoing effort to reach 100% unit test coverage across the repo, working in batches of ~5 files per PR. This batch targets the five client-side files with the largest coverage gaps (client `npm run test -- --coverage`):

| File | Before (stmts/branch) | After |
|---|---|---|
| `client/src/api/notificationService.ts` | 28.26% / 20% | 100% / 100% |
| `client/src/api/authService.ts` | 65% / 100% | 100% / 100% |
| `client/src/components/PushNotificationsButton.tsx` | 51.85% / 52.63% | 100% / 100% |
| `client/src/pages/Login.tsx` | 66.66% / 50.9% | 100% / 100% |
| `client/src/components/AppHeader.tsx` | 73.33% / 43.58% | 100% / ~100%* |

\* one branch excluded — see below.

Client-wide coverage moved from 88.35%/81.67% (stmts/branch) to 98.5%/94.06% as a side effect of these five files (other files' gaps are unrelated and left for a follow-up PR).

## Tests added

- `authService.test.ts`: `switchAccount`, `e2eLogin`, `useSwitchAccount` (incl. `onSuccess` cache-clear), `useE2ELogin`.
- `notificationService.test.ts` (new file): `getPushPermission`, `usePushAvailable`, `useEnablePushNotifications` (all guard branches + happy path), `useDisablePushNotifications`.
- `components/PushNotificationsButton.test.tsx` (new file): all availability/permission states, enable/disable flows, error + fallback-error notifications.
- `pages/Login.test.tsx`: multi-suggestion ranking/sorting (`rankActor`), typed-handle fallback offer, single-exact-match auto-select, keyboard navigation (`ArrowDown`/`ArrowUp`/`Escape`) between the input and suggestion row, manual-selection clearing, handle-too-long validation, and the `data.actors ?? []` / "No handles found" fallback paths.
- `components/AppHeader.test.tsx`: multi-account switcher — listing, active-account disabled state, switching accounts (success/error/fallback-error), no-op on an already-pending switch, and did/handle placeholder fallbacks.

## Intentionally excluded

- `client/src/components/AppHeader.tsx`: the `did === activeDid` arm of the guard in `handleSwitch` is wrapped in `/* v8 ignore start/stop */`. The menu item for the active account is rendered `disabled`, so a click can never reach the handler with `did === activeDid` — the guard is unreachable via the UI and kept only as defense-in-depth. Documented in `docs/testing-notes.md` alongside the existing analogous `Settings.tsx` exclusion.

## Test plan

- [x] `cd client && npm run test -- --coverage` — 394 tests passing, target files at 100%
- [x] `cd client && npm run lint` — no new errors (pre-existing warnings only)
- [x] `cd client && npm run build` — `tsc && vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Y1uDs9ctwHYNif8EkRcBd


---
_Generated by [Claude Code](https://claude.ai/code/session_012Y1uDs9ctwHYNif8EkRcBd)_