### PR TITLE
test: achieve 100% coverage for server auth/profile/notification services (batch 2/N)

### DIFF
--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -172,6 +172,18 @@ These branches are V8 JIT internals; no user-written test can reach them. The sa
 
 These files all previously caused a visible coverage drop because the class body is small enough that 2 uncovered artifact branches crossed the rounding threshold.
 
+### `server/src/services/notification-service.ts` — module-scope and class-closing-brace artifacts (single-line variant)
+
+**Lines:** line 1 (module-scope artifact) and the line before the class's final `}`.
+
+**Why suppressed with two `/* v8 ignore next 1 */` markers instead of `start/stop`:** Same two V8 JIT artifacts as the class-based modules above, but this file has several standalone exported functions (`readVapidConfig`, `isWebPushConfigured`, `createConcurrencyLimiter`) between the module-scope line and the class declaration. Wrapping `/* v8 ignore start */`...`/* v8 ignore stop */` across that whole span (as done for the pure class-based modules) would also exclude those real, tested functions from coverage. Using a single-line `/* v8 ignore next 1 */` at line 1 and another immediately before the class's closing `}` suppresses only the two artifact branches while leaving every function body (including the class methods) measured normally.
+
+### `server/src/auth/session-agent.ts` — function-declaration artifact on `initializeAgentFromSession`
+
+**Line:** the line immediately before `export async function initializeAgentFromSession(`.
+
+**Why ignored:** Same V8 "function not JIT-compiled" artifact documented for `pds-region.ts` above, but affecting only the second function in this file (`initializeAgentForDid`'s declaration line does not exhibit it — the artifact does not attach to every function declaration consistently). `initializeAgentFromSession` is exercised extensively by `session-agent.test.ts`; a single `/* v8 ignore next 1 */` suppresses just the artifact branch on its declaration line.
+
 ## TypeScript Transpilation Artifacts (tsx source-map gaps)
 
 The following "uncovered" lines are not executable TypeScript — they are blank lines, type annotations, or closing punctuation of multi-line expressions that tsx maps back to the wrong source position. The underlying code **is** executed and tested; only V8's source-map alignment is imprecise.
@@ -184,14 +196,6 @@ The following "uncovered" lines are not executable TypeScript — they are blank
 | `server/src/lib/image-generator.ts` | 144, 454–459 | TypeScript return-type annotation on `generateThemeSpecificHtml` (line 144); static CSS string content inside a multi-hundred-line template literal in `generateTwitterHtml` (lines 454–459) — V8 does not track every line within a template literal |
 
 No `/* v8 ignore */` annotations are added for these because the underlying logic IS reached by tests; the gaps are purely a source-map rendering artefact.
-
-### `server/src/services/auth-service.ts` — e2e branch in `revokeSession`
-
-**Lines:** the `if (hasE2EAgent(did)) { deleteE2EAgent(did); ... return; }` block.
-
-**Why ignored:** This branch only fires when the DID belongs to an E2E test session created by `e2eAuthRoutes`. In the unit test suite `E2E_TESTING` is never set to `true`, so `hasE2EAgent` always returns `false` and the branch is permanently unreachable.
-
-**What it would take to test:** Import and call `setE2EAgent` in a test to plant a fake agent, then call `revokeSession` — but this requires `e2e-agent-store.ts` to be importable in the test context, which it is. Left as a future improvement.
 
 ### `client/src/pages/Login.tsx` — `renderActorOption` dropdown render function
 

--- a/server/src/auth/session-agent.ts
+++ b/server/src/auth/session-agent.ts
@@ -38,6 +38,7 @@ export async function initializeAgentForDid(ctx: AppContext, did: string): Promi
  * Restores the AT Protocol Agent for the session's currently active account.
  * Thin wrapper over {@link initializeAgentForDid} using `req.session.did`.
  */
+/* v8 ignore next 1 */
 export async function initializeAgentFromSession(
   req: Express.Request,
   ctx: AppContext

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -35,7 +35,6 @@ export class AuthService {
   }
 
   async revokeSession(did: string) {
-    /* v8 ignore next 6 */
     if (hasE2EAgent(did)) {
       deleteE2EAgent(did);
       await this.ctx.db.deleteFrom("auth_session").where("key", "=", did).execute();
@@ -52,7 +51,6 @@ export class AuthService {
       .executeTakeFirst();
     if (!dbSession) return null;
 
-    /* v8 ignore next 8 */
     if (hasE2EAgent(did)) {
       const handle = getE2EHandle(did) || did;
       return {

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -1,3 +1,4 @@
+/* v8 ignore next 1 */
 import { Logger } from "pino";
 import { sendNotification, setVapidDetails } from "web-push";
 
@@ -263,4 +264,5 @@ export class NotificationService {
       })
     );
   }
+  /* v8 ignore next 1 */
 }

--- a/server/src/tests/auth-service.test.ts
+++ b/server/src/tests/auth-service.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert";
-import { test, describe, beforeEach, mock } from "node:test";
+import { test, describe, beforeEach, afterEach, mock } from "node:test";
 
 import { OAuthResolverError } from "@atproto/oauth-client-node";
 
+import { deleteE2EAgent, setE2EAgent } from "../auth/e2e-agent-store";
 import { AuthService } from "../services/auth-service";
 
 describe("AuthService", () => {
@@ -32,6 +33,12 @@ describe("AuthService", () => {
             return this as any;
           }),
           onConflict: mock.fn(function (this: any) {
+            return this as any;
+          }),
+          execute: mock.fn(async () => ({})),
+        })),
+        deleteFrom: mock.fn(() => ({
+          where: mock.fn(function (this: any) {
             return this as any;
           }),
           execute: mock.fn(async () => ({})),
@@ -93,6 +100,20 @@ describe("AuthService", () => {
   test("revokeSession calls oauthClient.revoke", async () => {
     await service.revokeSession("did:foo");
     assert.strictEqual(ctx.oauthClient.revoke.mock.calls.length, 1);
+  });
+
+  describe("revokeSession with an E2E agent", () => {
+    afterEach(() => {
+      deleteE2EAgent("did:e2e");
+    });
+
+    test("deletes the E2E agent and auth session instead of calling oauthClient.revoke", async () => {
+      setE2EAgent("did:e2e", {} as any, "e2e-user.bsky.social");
+      await service.revokeSession("did:e2e");
+      assert.strictEqual(ctx.oauthClient.revoke.mock.calls.length, 0);
+      assert.strictEqual(ctx.db.deleteFrom.mock.calls.length, 1);
+      assert.strictEqual(ctx.db.deleteFrom.mock.calls[0].arguments[0], "auth_session");
+    });
   });
 
   test("encryptDid and decryptDid roundtrip", () => {
@@ -159,6 +180,54 @@ describe("AuthService", () => {
       ctx.oauthClient.restore = mock.fn(async () => ({ sub: "did:foo" }));
       // The real Agent has no valid network session so getProfile will throw
       await assert.rejects(() => service.checkSession("did:foo"), /.+/);
+    });
+
+    describe("with an E2E agent", () => {
+      afterEach(() => {
+        deleteE2EAgent("did:e2e");
+      });
+
+      test("returns a synthetic profile built from the stored E2E handle", async () => {
+        ctx.db.selectFrom = mock.fn(() => ({
+          selectAll: mock.fn(function (this: any) {
+            return this as any;
+          }),
+          where: mock.fn(function (this: any) {
+            return this as any;
+          }),
+          executeTakeFirst: mock.fn(async () => ({ key: "did:e2e" })),
+        }));
+        setE2EAgent("did:e2e", {} as any, "e2e-user.bsky.social");
+
+        const result = await service.checkSession("did:e2e");
+
+        assert.deepStrictEqual(result, {
+          did: "did:e2e",
+          handle: "e2e-user.bsky.social",
+          displayName: "e2e-user.bsky.social",
+          description: "",
+          avatar: undefined,
+          banner: undefined,
+          createdAt: undefined,
+        });
+      });
+
+      test("falls back to the did as the handle when no E2E handle was stored", async () => {
+        ctx.db.selectFrom = mock.fn(() => ({
+          selectAll: mock.fn(function (this: any) {
+            return this as any;
+          }),
+          where: mock.fn(function (this: any) {
+            return this as any;
+          }),
+          executeTakeFirst: mock.fn(async () => ({ key: "did:e2e" })),
+        }));
+        setE2EAgent("did:e2e", {} as any, "");
+
+        const result = await service.checkSession("did:e2e");
+
+        assert.strictEqual(result?.handle, "did:e2e");
+      });
     });
   });
 

--- a/server/src/tests/notification-service.test.ts
+++ b/server/src/tests/notification-service.test.ts
@@ -1,5 +1,11 @@
 import assert from "node:assert";
-import { test, describe, beforeEach, mock } from "node:test";
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
+import { test, describe, before, after, beforeEach, afterEach, mock } from "node:test";
 
 import { generateVAPIDKeys } from "web-push";
 
@@ -46,6 +52,18 @@ function makeUpdateBuilder() {
       return this;
     }),
     execute: mock.fn(async () => ({})),
+  };
+}
+
+// A valid-shaped (but throwaway) push subscription keypair, so web-push's
+// client-side payload encryption succeeds and the test actually reaches the
+// network call instead of failing validation before it.
+function makeSubscriptionKeys() {
+  const ecdh = crypto.createECDH("prime256v1");
+  ecdh.generateKeys();
+  return {
+    p256dh: ecdh.getPublicKey("base64url"),
+    auth: crypto.randomBytes(16).toString("base64url"),
   };
 }
 
@@ -228,6 +246,190 @@ describe("NotificationService", () => {
         process.env.VAPID_SUBJECT = prev.subj;
       }
     });
+
+    test("returns early (no-op) when setVapidDetails throws for a malformed subject", async () => {
+      const keys = generateVAPIDKeys();
+      const prev = {
+        pub: process.env.VAPID_PUBLIC_KEY,
+        priv: process.env.VAPID_PRIVATE_KEY,
+        subj: process.env.VAPID_SUBJECT,
+      };
+      process.env.VAPID_PUBLIC_KEY = keys.publicKey;
+      process.env.VAPID_PRIVATE_KEY = keys.privateKey;
+      process.env.VAPID_SUBJECT = "not-a-valid-subject";
+
+      try {
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockLogger.error.mock.calls.length, 1);
+        // Bails out before ever querying for subscriptions.
+        assert.strictEqual(mockDb.selectFrom.mock.calls.length, 0);
+      } finally {
+        process.env.VAPID_PUBLIC_KEY = prev.pub;
+        process.env.VAPID_PRIVATE_KEY = prev.priv;
+        process.env.VAPID_SUBJECT = prev.subj;
+      }
+    });
+
+    // These tests exercise the real `web-push` `sendNotification` call against a
+    // local HTTPS server (self-signed cert) instead of mocking the module, since
+    // `node:test`'s `mock.module()` requires the `--experimental-test-module-mocks`
+    // flag, which this repo's test script does not enable.
+    describe("against a local HTTPS push endpoint", () => {
+      let server: https.Server;
+      let port: number;
+      let nextStatus: number;
+      let prevEnv: { pub?: string; priv?: string; subj?: string; tls?: string };
+
+      before(() => {
+        const certDir = fs.mkdtempSync(path.join(os.tmpdir(), "wp-test-certs-"));
+        const keyPath = path.join(certDir, "key.pem");
+        const certPath = path.join(certDir, "cert.pem");
+        execFileSync("openssl", [
+          "req",
+          "-x509",
+          "-newkey",
+          "rsa:2048",
+          "-keyout",
+          keyPath,
+          "-out",
+          certPath,
+          "-days",
+          "1",
+          "-nodes",
+          "-subj",
+          "/CN=127.0.0.1",
+        ]);
+
+        nextStatus = 201;
+        server = https.createServer(
+          { key: fs.readFileSync(keyPath), cert: fs.readFileSync(certPath) },
+          (req, res) => {
+            req.resume();
+            req.on("end", () => {
+              res.writeHead(nextStatus);
+              res.end();
+            });
+          }
+        );
+
+        return new Promise<void>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            port = (server.address() as { port: number }).port;
+            fs.rmSync(certDir, { recursive: true, force: true });
+            resolve();
+          });
+        });
+      });
+
+      after(() => {
+        return new Promise<void>((resolve) => server.close(() => resolve()));
+      });
+
+      beforeEach(() => {
+        nextStatus = 201;
+        const keys = generateVAPIDKeys();
+        prevEnv = {
+          pub: process.env.VAPID_PUBLIC_KEY,
+          priv: process.env.VAPID_PRIVATE_KEY,
+          subj: process.env.VAPID_SUBJECT,
+          tls: process.env.NODE_TLS_REJECT_UNAUTHORIZED,
+        };
+        process.env.VAPID_PUBLIC_KEY = keys.publicKey;
+        process.env.VAPID_PRIVATE_KEY = keys.privateKey;
+        process.env.VAPID_SUBJECT = "mailto:test@example.com";
+        // The server above uses a throwaway self-signed cert.
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+        const subKeys = makeSubscriptionKeys();
+        mockDb.selectFrom = mock.fn(() =>
+          makeSelectBuilder(undefined, [
+            {
+              did: "did:recipient",
+              endpoint: `https://127.0.0.1:${port}/sub`,
+              p256dh: subKeys.p256dh,
+              auth: subKeys.auth,
+            },
+          ])
+        );
+      });
+
+      afterEach(() => {
+        process.env.VAPID_PUBLIC_KEY = prevEnv.pub;
+        process.env.VAPID_PRIVATE_KEY = prevEnv.priv;
+        process.env.VAPID_SUBJECT = prevEnv.subj;
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevEnv.tls;
+      });
+
+      test("resolves the recipient's handle and sends successfully", async () => {
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockResolver.resolveDidToHandle.mock.calls.length, 1);
+        assert.strictEqual(mockLogger.error.mock.calls.length, 0);
+      });
+
+      test("falls back to a generic no-op when handle resolution fails, but still sends", async () => {
+        mockResolver.resolveDidToHandle = mock.fn(async () => {
+          throw new Error("resolution failed");
+        });
+
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockLogger.error.mock.calls.length, 0);
+      });
+
+      test("deletes the subscription when the push service reports 410 Gone", async () => {
+        nextStatus = 410;
+        const deleteBuilder = makeDeleteBuilder();
+        mockDb.deleteFrom = mock.fn(() => deleteBuilder);
+
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockDb.deleteFrom.mock.calls.length, 1);
+        // One info log from deleteSubscription itself, one from the "removed expired" note.
+        assert.strictEqual(mockLogger.info.mock.calls.length, 2);
+      });
+
+      test("deletes the subscription when the push service reports 404 Not Found", async () => {
+        nextStatus = 404;
+        const deleteBuilder = makeDeleteBuilder();
+        mockDb.deleteFrom = mock.fn(() => deleteBuilder);
+
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockDb.deleteFrom.mock.calls.length, 1);
+      });
+
+      test("logs an error and keeps the subscription for other failure statuses", async () => {
+        nextStatus = 500;
+
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockDb.deleteFrom.mock.calls.length, 0);
+        assert.strictEqual(mockLogger.error.mock.calls.length, 1);
+      });
+
+      test("logs an error (statusCode undefined) when the failure has no HTTP response at all", async () => {
+        // A malformed subscription key fails web-push's own client-side validation
+        // synchronously, before any network call — the resulting error has no
+        // `statusCode` field, exercising the `undefined` fallback.
+        mockDb.selectFrom = mock.fn(() =>
+          makeSelectBuilder(undefined, [
+            {
+              did: "did:recipient",
+              endpoint: `https://127.0.0.1:${port}/sub`,
+              p256dh: "too-short",
+              auth: "also-too-short",
+            },
+          ])
+        );
+
+        await service.sendNewMessageNotification("did:recipient");
+
+        assert.strictEqual(mockDb.deleteFrom.mock.calls.length, 0);
+        assert.strictEqual(mockLogger.error.mock.calls.length, 1);
+      });
+    });
   });
 });
 
@@ -257,6 +459,25 @@ describe("createConcurrencyLimiter", () => {
       limiter.run(() => Promise.reject(new Error("boom"))),
       /boom/
     );
+  });
+
+  test("exposes active/pending counts while tasks are in flight and queued", async () => {
+    const limiter = createConcurrencyLimiter(1);
+    let releaseFirst: () => void = () => {};
+    const blocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const firstRun = limiter.run(() => blocked);
+    const secondRun = limiter.run(() => Promise.resolve());
+    // First task is active immediately; second is queued behind the limit of 1.
+    assert.strictEqual(limiter.active, 1);
+    assert.strictEqual(limiter.pending, 1);
+
+    releaseFirst();
+    await Promise.all([firstRun, secondRun]);
+    assert.strictEqual(limiter.active, 0);
+    assert.strictEqual(limiter.pending, 0);
   });
 
   test("resumes queue slots as tasks complete", async () => {

--- a/server/src/tests/notification-service.test.ts
+++ b/server/src/tests/notification-service.test.ts
@@ -279,7 +279,8 @@ describe("NotificationService", () => {
       let server: https.Server;
       let port: number;
       let nextStatus: number;
-      let prevEnv: { pub?: string; priv?: string; subj?: string; tls?: string };
+      let prevEnv: { pub?: string; priv?: string; subj?: string };
+      let prevGlobalAgent: typeof https.globalAgent;
 
       before(() => {
         const certDir = fs.mkdtempSync(path.join(os.tmpdir(), "wp-test-certs-"));
@@ -299,11 +300,16 @@ describe("NotificationService", () => {
           "-nodes",
           "-subj",
           "/CN=127.0.0.1",
+          // A SAN entry is required — modern Node/OpenSSL clients reject
+          // certs that only match via the legacy CN fallback.
+          "-addext",
+          "subjectAltName=IP:127.0.0.1",
         ]);
 
+        const certPem = fs.readFileSync(certPath);
         nextStatus = 201;
         server = https.createServer(
-          { key: fs.readFileSync(keyPath), cert: fs.readFileSync(certPath) },
+          { key: fs.readFileSync(keyPath), cert: certPem },
           (req, res) => {
             req.resume();
             req.on("end", () => {
@@ -312,6 +318,12 @@ describe("NotificationService", () => {
             });
           }
         );
+
+        // Trust this run's throwaway CA specifically (scoped to the global
+        // agent web-push falls back to), rather than disabling certificate
+        // validation process-wide.
+        prevGlobalAgent = https.globalAgent;
+        https.globalAgent = new https.Agent({ ca: certPem });
 
         return new Promise<void>((resolve) => {
           server.listen(0, "127.0.0.1", () => {
@@ -323,6 +335,7 @@ describe("NotificationService", () => {
       });
 
       after(() => {
+        https.globalAgent = prevGlobalAgent;
         return new Promise<void>((resolve) => server.close(() => resolve()));
       });
 
@@ -333,13 +346,10 @@ describe("NotificationService", () => {
           pub: process.env.VAPID_PUBLIC_KEY,
           priv: process.env.VAPID_PRIVATE_KEY,
           subj: process.env.VAPID_SUBJECT,
-          tls: process.env.NODE_TLS_REJECT_UNAUTHORIZED,
         };
         process.env.VAPID_PUBLIC_KEY = keys.publicKey;
         process.env.VAPID_PRIVATE_KEY = keys.privateKey;
         process.env.VAPID_SUBJECT = "mailto:test@example.com";
-        // The server above uses a throwaway self-signed cert.
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
         const subKeys = makeSubscriptionKeys();
         mockDb.selectFrom = mock.fn(() =>
@@ -358,7 +368,6 @@ describe("NotificationService", () => {
         process.env.VAPID_PUBLIC_KEY = prevEnv.pub;
         process.env.VAPID_PRIVATE_KEY = prevEnv.priv;
         process.env.VAPID_SUBJECT = prevEnv.subj;
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = prevEnv.tls;
       });
 
       test("resolves the recipient's handle and sends successfully", async () => {

--- a/server/src/tests/profile-controller.test.ts
+++ b/server/src/tests/profile-controller.test.ts
@@ -13,6 +13,14 @@ describe("ProfileController", () => {
       oauthClient: {
         restore: mock.fn(async () => ({ sub: "did:foo" })),
       },
+      resolver: {
+        resolveHandleToDid: mock.fn(async () => "did:foo"),
+      },
+      idResolver: {
+        did: {
+          resolveAtprotoData: mock.fn(async () => ({ pds: "https://pds.example.com" })),
+        },
+      },
       logger: {
         info: mock.fn(),
         error: mock.fn(),
@@ -29,6 +37,7 @@ describe("ProfileController", () => {
       getFriendsOnApp: mock.fn(async () => []),
       checkFollowsBot: mock.fn(async () => false),
       resolveHandleToDid: mock.fn(async () => "did:foo"),
+      searchActorsTypeahead: mock.fn(async () => []),
       ...overrides,
     };
   }
@@ -192,6 +201,67 @@ describe("ProfileController", () => {
       const res = makeRes();
       await controller.checkBotFollow(makeReq(), res);
       assert.strictEqual(res.status.mock.calls[0].arguments[0], 500);
+    });
+  });
+
+  describe("getHandlePDS", () => {
+    test("returns the PDS hostname on success", async () => {
+      const ctx = makeCtx();
+      const controller = new ProfileController(makeService(), ctx.logger, ctx);
+      const res = makeRes();
+      await controller.getHandlePDS(makeReq({ params: { handle: "foo.bsky.social" } }), res);
+      assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], { pds: "pds.example.com" });
+    });
+
+    test("returns 404 when the handle does not resolve to a DID", async () => {
+      const ctx = makeCtx();
+      ctx.resolver.resolveHandleToDid = mock.fn(async () => undefined);
+      const controller = new ProfileController(makeService(), ctx.logger, ctx);
+      const res = makeRes();
+      await controller.getHandlePDS(makeReq({ params: { handle: "nobody.bsky.social" } }), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 404);
+      assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], { error: "Handle not found" });
+    });
+
+    test("returns 500 when PDS resolution throws", async () => {
+      const ctx = makeCtx();
+      ctx.idResolver.did.resolveAtprotoData = mock.fn(async () => {
+        throw new Error("network error");
+      });
+      const controller = new ProfileController(makeService(), ctx.logger, ctx);
+      const res = makeRes();
+      await controller.getHandlePDS(makeReq({ params: { handle: "foo.bsky.social" } }), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 500);
+      assert.strictEqual(ctx.logger.error.mock.calls.length, 1);
+    });
+  });
+
+  describe("searchHandles", () => {
+    test("returns matching actors on success", async () => {
+      const svc = makeService({
+        searchActorsTypeahead: mock.fn(async () => [{ did: "did:foo", handle: "foo.bsky.social" }]),
+      });
+      const ctx = makeCtx();
+      const controller = new ProfileController(svc, ctx.logger, ctx);
+      const res = makeRes();
+      await controller.searchHandles(makeReq({ query: { q: "foo" } }), res);
+      assert.deepStrictEqual(res.json.mock.calls[0].arguments[0], {
+        actors: [{ did: "did:foo", handle: "foo.bsky.social" }],
+      });
+    });
+
+    test("returns 500 when the search fails", async () => {
+      const svc = makeService({
+        searchActorsTypeahead: mock.fn(async () => {
+          throw new Error("search failed");
+        }),
+      });
+      const ctx = makeCtx();
+      const controller = new ProfileController(svc, ctx.logger, ctx);
+      const res = makeRes();
+      await controller.searchHandles(makeReq({ query: { q: "foo" } }), res);
+      assert.strictEqual(res.status.mock.calls[0].arguments[0], 500);
+      assert.strictEqual(ctx.logger.error.mock.calls.length, 1);
     });
   });
 

--- a/server/src/tests/profile-service.test.ts
+++ b/server/src/tests/profile-service.test.ts
@@ -289,6 +289,53 @@ describe("ProfileService", () => {
     });
   });
 
+  describe("searchActorsTypeahead", () => {
+    it("should map the agent's search results to the trimmed actor shape", async () => {
+      const searchMock = mock.fn(async () => ({
+        data: {
+          actors: [
+            {
+              did: "did:user:1",
+              handle: "user1.bsky.app",
+              displayName: "User One",
+              avatar: "https://cdn.test/1.jpg",
+            },
+            {
+              did: "did:user:2",
+              handle: "user2.bsky.app",
+              displayName: undefined,
+              avatar: undefined,
+            },
+          ],
+        },
+      }));
+      (profileService as any).agent.searchActorsTypeahead = searchMock;
+
+      const result = await profileService.searchActorsTypeahead("user");
+
+      assert.deepStrictEqual(result, [
+        {
+          did: "did:user:1",
+          handle: "user1.bsky.app",
+          displayName: "User One",
+          avatar: "https://cdn.test/1.jpg",
+        },
+        { did: "did:user:2", handle: "user2.bsky.app", displayName: undefined, avatar: undefined },
+      ]);
+      assert.deepStrictEqual(searchMock.mock.calls[0].arguments, [{ q: "user", limit: 8 }]);
+    });
+
+    it("should return an empty array when there are no matching actors", async () => {
+      (profileService as any).agent.searchActorsTypeahead = mock.fn(async () => ({
+        data: { actors: [] },
+      }));
+
+      const result = await profileService.searchActorsTypeahead("nobody");
+
+      assert.deepStrictEqual(result, []);
+    });
+  });
+
   describe("getFriendsOnApp", () => {
     const sampleFollows = [
       {

--- a/server/src/tests/session-agent.test.ts
+++ b/server/src/tests/session-agent.test.ts
@@ -1,11 +1,31 @@
 import assert from "node:assert";
-import { test, describe, mock } from "node:test";
+import { test, describe, mock, afterEach } from "node:test";
 
 import { Agent } from "@atproto/api";
 
+import { deleteE2EAgent, setE2EAgent } from "../auth/e2e-agent-store";
 import { initializeAgentFromSession } from "../auth/session-agent";
 
 describe("initializeAgentFromSession", () => {
+  describe("with an E2E agent", () => {
+    afterEach(() => {
+      deleteE2EAgent("did:e2e");
+    });
+
+    test("returns the stored E2E agent without calling oauthClient.restore", async () => {
+      const e2eAgent = {} as Agent;
+      setE2EAgent("did:e2e", e2eAgent, "e2e-user.bsky.social");
+      const restoreMock = mock.fn(async () => ({}));
+      const ctx: any = {
+        oauthClient: { restore: restoreMock },
+        logger: { warn: mock.fn() },
+      };
+      const result = await initializeAgentFromSession({ session: { did: "did:e2e" } } as any, ctx);
+      assert.strictEqual(result, e2eAgent);
+      assert.strictEqual(restoreMock.mock.calls.length, 0);
+    });
+  });
+
   test("returns null when req.session is null", async () => {
     const result = await initializeAgentFromSession({ session: null } as any, {} as any);
     assert.strictEqual(result, null);


### PR DESCRIPTION
## Summary

Second batch in an ongoing effort to reach 100% unit test coverage across the repo (batch 1: #196, client-side). This batch targets the five largest server-side coverage gaps (server `npm run test:coverage`):

| File | Before (stmts/branch) | After |
|---|---|---|
| `server/src/services/notification-service.ts` | 87.59% / 92.3% | 100% / 100% |
| `server/src/controllers/profile-controller.ts` | 86.66% / 100% | 100% / 100% |
| `server/src/services/profile-service.ts` | 94.7% / 100% | 100% / 100% |
| `server/src/services/auth-service.ts` | 96.61% / 100% | 100% / 100% |
| `server/src/auth/session-agent.ts` | 96% / 91.3% | 100% / 100% |

Server-wide coverage moved from 98.74%/97.3% (stmts/branch) to 99.74%/97.83% as a result.

## Tests added

- `profile-controller.test.ts`: `getHandlePDS` (success, handle-not-found 404, resolution failure 500) and `searchHandles` (success, failure 500) — these two controller methods had no tests at all.
- `profile-service.test.ts`: `searchActorsTypeahead` (maps agent results to the trimmed actor shape; empty results).
- `session-agent.test.ts`: `initializeAgentFromSession` returning a stored E2E agent without touching `oauthClient.restore`.
- `auth-service.test.ts`: the E2E branches of `checkSession` (synthetic profile from the stored E2E handle, did-fallback when no handle stored) and `revokeSession` (deletes the E2E agent/session instead of calling `oauthClient.revoke`).
- `notification-service.test.ts`: the full `sendNewMessageNotification` send path — handle-resolution success/failure, VAPID-subject validation failure, and the 410/404 subscription-cleanup vs. generic-error branches. Exercised against a real local HTTPS server with a throwaway self-signed cert (spun up in `before()`/`after()`), rather than mocking `web-push`, since `node:test`'s `mock.module()` requires the `--experimental-test-module-mocks` flag, which this repo's `test`/`test:coverage` scripts don't pass. Also covers the previously-unread `active`/`pending` getters on `createConcurrencyLimiter`.

## Bug found while raising coverage

Two `/* v8 ignore next N */` comments in `auth-service.ts` (on the E2E branches of `checkSession` and `revokeSession`) undercounted their line span, silently masking genuinely-testable code from coverage reporting. Both branches are reachable via the existing `setE2EAgent`/`e2e-agent-store.ts` helpers, so the ignores were removed in favor of real tests instead of re-padding the line count.

## Intentionally excluded (documented in `docs/testing-notes.md`)

- `server/src/services/notification-service.ts`: module-scope and class-closing-brace V8 JIT artifacts, using single-line ignores (rather than the existing `start/stop` span pattern) because the file has real, tested standalone functions between the module scope and the class.
- `server/src/auth/session-agent.ts`: a function-declaration JIT artifact on `initializeAgentFromSession`, same category as the existing `pds-region.ts` exclusion.
- Removed the now-stale `auth-service.ts` "e2e branch in revokeSession" doc entry, since that branch is fixed and tested rather than ignored.

## Test plan

- [x] `cd server && npm run test:coverage` — 297 tests passing, all five target files at 100%
- [x] `cd server && npm run lint` — no new errors (pre-existing warnings only)
- [x] `cd server && npm run typecheck` && `npm run build` — both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Y1uDs9ctwHYNif8EkRcBd


---
_Generated by [Claude Code](https://claude.ai/code/session_012Y1uDs9ctwHYNif8EkRcBd)_