### PR TITLE
test: achieve 100% unit test coverage (part 1)

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -189,11 +189,12 @@ function UserMenu({
     try {
       document.body.style.pointerEvents = "none";
       document.body.style.opacity = "0.5";
-      /* v8 ignore next 4 */
+      /* v8 ignore start */
     } catch {
       document.body.style.pointerEvents = "";
       document.body.style.opacity = "";
     }
+    /* v8 ignore stop */
 
     switchAccount(
       { did },

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -36,6 +36,14 @@ This document explains coverage exclusions and hard-to-test code.
 
 **What it would take to test:** Call `handleSwitch` directly (bypassing the disabled menu item) by exporting it or via a component ref, with `did` equal to `activeDid`.
 
+### `client/src/components/AppHeader.tsx` — `handleSwitch` catch block that resets `body.style`
+
+**Lines:** the `catch { document.body.style.pointerEvents = ""; document.body.style.opacity = ""; }` block inside `handleSwitch` (the account-switcher's `UserMenu`).
+
+**Why ignored:** Same pattern as the `onLogout` catch block already documented in `CLAUDE.md`'s `/* v8 ignore next */` convention — the `try` only assigns string literals to `document.body.style`, which never throws in practice. Note: a `/* v8 ignore next 4 */` placed on the line before `} catch {` did **not** suppress this block (the two assignment lines still showed as uncovered) even though the identical pattern worked for the `onLogout` handler a few lines above. Switching to `/* v8 ignore start */` immediately before `} catch {` and `/* v8 ignore stop */` immediately after the closing `}` reliably suppresses the whole block.
+
+**What it would take to test:** Not worth pursuing — would require mocking `document.body.style` property assignment to throw, which doesn't reflect any real browser behavior.
+
 ### `client/src/pages/Settings.tsx` — unreachable `!installPrompt` early-return guard
 
 **Line:** `if (!installPrompt) return;` inside `handleInstallClick`.
@@ -211,6 +219,24 @@ These files all previously caused a visible coverage drop because the class body
 **Line:** the line immediately before `export async function initializeAgentFromSession(`.
 
 **Why ignored:** Same V8 "function not JIT-compiled" artifact documented for `pds-region.ts` above, but affecting only the second function in this file (`initializeAgentForDid`'s declaration line does not exhibit it — the artifact does not attach to every function declaration consistently). `initializeAgentFromSession` is exercised extensively by `session-agent.test.ts`; a single `/* v8 ignore next 1 */` suppresses just the artifact branch on its declaration line.
+
+### `server/src/tests/*.test.ts` — module-scope artifact on the import block (per-file rollout)
+
+**Lines:** line 1 of each affected test file (the first `import` statement).
+
+**Why ignored:** Unlike client-side test files (excluded wholesale from coverage via `src/tests/**` in `vite.config.ts`), the server's `c8.exclude` list in `server/package.json` does **not** exclude `src/tests/**`, so `.test.ts` files are measured by c8 like any other source file. Every module — test files included — exhibits the same V8 module-scope "not-initialized" branch artifact documented above for `pds-region.ts` and the class-based service/controller modules, mapped to line 1. `pds-region.test.ts` has been fixed (`/* v8 ignore start */` before the imports, `/* v8 ignore stop */` after) as the first of these; the same fix needs to be rolled out to the remaining server test files that still show a line-1 gap (`auth-controller.test.ts`, `auth-service.test.ts`, `image-generator.test.ts`, `image-generator-generate.test.ts`, `message-controller.test.ts`, `message-service.test.ts`, `notification-controller.test.ts`, `notification-service.test.ts`, `profile-controller.test.ts`, `profile-service.test.ts`, `session-agent.test.ts`, `settings-controller.test.ts`, `settings-service.test.ts`) in a follow-up pass.
+
+### `server/src/tests/auth-service.test.ts` — unused `selectFrom`/`insertInto` chains in the default mock context
+
+**Why removed (not ignored):** `makeMockCtx`'s default `db` mock included full `selectFrom(...)` and `insertInto(...)` chain stubs, but `AuthService` only ever calls `db.deleteFrom(...)` (in `deleteSession`) — `selectFrom`/`insertInto` are unused by the class entirely. Every test that exercises a code path needing `selectFrom`/`insertInto` (e.g. `checkSession`, profile creation) overrides `ctx.db.selectFrom`/`ctx.db.insertInto` with a test-specific mock, so the defaults in `makeMockCtx` were dead code — genuinely unreachable, not just under-tested. Removed rather than annotated, since they were unused scaffolding rather than a real code path.
+
+### `server/src/tests/image-generator-generate.test.ts` — dead `try/catch` around `mock.timers.reset()`
+
+**Why removed (not ignored):** The `afterEach` hook wrapped `mock.timers.reset()` in a `try { ... } catch { /* not enabled */ }`, defending against a hypothetical throw when mock timers were never enabled. Verified empirically (`node --eval` calling `mock.timers.reset()` with no prior `mock.timers.enable()`) that Node's `node:test` `MockTimers.reset()` does not throw in this case — it's a no-op. No test in this file ever calls `mock.timers.enable()`, so the `catch` arm was unreachable in every run. Removed the `try/catch`, calling `mock.timers.reset()` directly.
+
+### `server/src/tests/message-service.test.ts` — dead table-name branch in a one-off `selectFrom` mock
+
+**Why removed (not ignored):** The test `"respondToMessage with image uses default theme when user_settings is null"` built an inline `mockDb.selectFrom = mock.fn((table) => { if (table === "user_settings") {...} return mockSelectBuilder; })`. `MessageService.respondToMessage` only calls `db.selectFrom("user_settings")` once (to look up the image theme when `includeQuestionAsImage` is true) — it never queries any other table within that method — so the `return mockSelectBuilder` fallback for a non-matching table name was unreachable in this test. Simplified to a mock that always returns the `user_settings` shape.
 
 ## TypeScript Transpilation Artifacts (tsx source-map gaps)
 

--- a/server/src/tests/auth-service.test.ts
+++ b/server/src/tests/auth-service.test.ts
@@ -19,24 +19,6 @@ describe("AuthService", () => {
         clientMetadata: { foo: "bar" },
       },
       db: {
-        selectFrom: mock.fn(() => ({
-          selectAll: mock.fn(function (this: any) {
-            return this as any;
-          }),
-          where: mock.fn(function (this: any) {
-            return this as any;
-          }),
-          executeTakeFirst: mock.fn(async () => ({ key: "did:foo" })),
-        })),
-        insertInto: mock.fn(() => ({
-          values: mock.fn(function (this: any) {
-            return this as any;
-          }),
-          onConflict: mock.fn(function (this: any) {
-            return this as any;
-          }),
-          execute: mock.fn(async () => ({})),
-        })),
         deleteFrom: mock.fn(() => ({
           where: mock.fn(function (this: any) {
             return this as any;

--- a/server/src/tests/image-generator-generate.test.ts
+++ b/server/src/tests/image-generator-generate.test.ts
@@ -19,11 +19,7 @@ describe("generateQuestionImage", () => {
 
   afterEach(() => {
     mock.restoreAll();
-    try {
-      mock.timers.reset();
-    } catch {
-      /* not enabled */
-    }
+    mock.timers.reset();
   });
 
   function makeLogger() {

--- a/server/src/tests/message-service.test.ts
+++ b/server/src/tests/message-service.test.ts
@@ -692,18 +692,13 @@ describe("MessageService", () => {
   });
 
   test("respondToMessage with image uses default theme when user_settings is null", async () => {
-    mockDb.selectFrom = mock.fn((table: string) => {
-      if (table === "user_settings") {
-        return {
-          selectAll: mock.fn(() => ({
-            where: mock.fn(() => ({
-              executeTakeFirst: mock.fn(async () => undefined),
-            })),
-          })),
-        };
-      }
-      return mockSelectBuilder;
-    });
+    mockDb.selectFrom = mock.fn(() => ({
+      selectAll: mock.fn(() => ({
+        where: mock.fn(() => ({
+          executeTakeFirst: mock.fn(async () => undefined),
+        })),
+      })),
+    }));
     const result = await messageService.respondToMessage(
       "tid",
       "did:example:user",

--- a/server/src/tests/pds-region.test.ts
+++ b/server/src/tests/pds-region.test.ts
@@ -1,7 +1,9 @@
+/* v8 ignore start */
 import assert from "node:assert";
 import { test, describe } from "node:test";
 
 import { pdsRegion } from "../lib/pds-region";
+/* v8 ignore stop */
 
 describe("pdsRegion", () => {
   test("returns us for bsky.social", () => {


### PR DESCRIPTION
## Summary

First PR in a series aiming for 100% unit test coverage across the repo. The client and server `src/**` business logic were already essentially at 100% coverage before this PR — the remaining gaps were all in test-file scaffolding itself (the server's `c8` config measures `src/tests/**`, unlike the client which excludes it).

- **`client/src/components/AppHeader.tsx`**: the `handleSwitch` catch block that resets `document.body.style` used `/* v8 ignore next 4 */`, which did not actually suppress the two assignment lines (confirmed by coverage report). Switched to `/* v8 ignore start */` / `/* v8 ignore stop */`, matching the pattern that already works for the sibling `onLogout` catch block. **Client coverage is now 100% across all four v8 metrics.**
- **`server/src/tests/auth-service.test.ts`**: removed unused `selectFrom`/`insertInto` mock chains from the default `makeMockCtx` — `AuthService` only ever calls `db.deleteFrom`, and every test that needs `selectFrom`/`insertInto` already overrides them with test-specific mocks, so the defaults were dead code.
- **`server/src/tests/image-generator-generate.test.ts`**: removed a `try/catch` around `mock.timers.reset()` in `afterEach`. Verified empirically that `reset()` never throws even when timers were never enabled, so the `catch` was unreachable in every run.
- **`server/src/tests/message-service.test.ts`**: simplified an inline `selectFrom` mock that branched on table name — `respondToMessage` only ever queries `user_settings` in that code path, so the non-matching fallback branch was unreachable.
- **`server/src/tests/pds-region.test.ts`**: wrapped the import block in `/* v8 ignore start */` / `/* v8 ignore stop */` to suppress the V8 module-scope "not-initialized" artifact on line 1 — the same documented pattern already used for several `src/**` files.
- **`docs/testing-notes.md`**: documented all of the above, including a note that the same import-block artifact still needs the same fix rolled out to the other 13 server test files (tracked for a follow-up PR).

## Coverage

| | Before | After |
|---|---|---|
| Server (stmt/branch/func/line) | 99.79% / 98.15% / 94.68% / 99.79% | 100% / 98.39% / 95.01% / 100% |
| Client (stmt/branch/func/line) | 99.81% / 100% / 100% / 99.8% | **100% / 100% / 100% / 100%** |

No tests were added — this PR only fixes/removes dead test scaffolding and coverage-ignore annotations. All 295 server tests and 467 client tests still pass.

**Remaining gap:** the server's branch/func percentages are still below 100% because 13 more `src/tests/*.test.ts` files exhibit the same V8 module-scope import-block artifact fixed here for `pds-region.test.ts` (`auth-controller.test.ts`, `image-generator.test.ts`, `message-controller.test.ts`, `notification-controller.test.ts`, `notification-service.test.ts`, `profile-controller.test.ts`, `profile-service.test.ts`, `session-agent.test.ts`, `settings-controller.test.ts`, `settings-service.test.ts`, etc.). No lines were excluded without documentation — everything removed was verified to be genuinely dead code, and every `/* v8 ignore */` addition is explained in `docs/testing-notes.md`.

## Test plan

- [x] `cd server && npm run test:coverage` — 295/295 tests pass, 100% statements/lines
- [x] `cd client && npm run test:coverage` — 467/467 tests pass, 100% across all four metrics
- [x] `npm run lint` (client & server) — no new warnings/errors introduced
- [x] `npm run typecheck` (client & server) — passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01MZVjoKCrJtPwon1czPzqcZ)_