### PR TITLE
Migrate server from CommonJS to native ESM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ Do **not** use it to skip real business logic. Document any usage in `docs/testi
 
 ### Module Mocking in Server Tests
 
-Controller and session-agent tests use `mock.module()` (Node.js v22.3+ API) to mock dependencies before a dynamic `import()` of the module under test. The pattern:
+The server runs as native ESM (see issue #216), which keeps `node:test`'s `mock.module()` API (Node.js v22.3+) available — it is no longer blocked by a CJS transform layer. The current test suite relies on dependency-injection mocks (chainable DB builders passed into constructors) rather than `mock.module()`, but the module-mocking path is open for cases that need to intercept a constructor the SUT imports at module scope (e.g. `@atproto/api`'s `Agent`). The pattern, when needed:
 
 ```typescript
 before(async () => {

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -16,9 +16,9 @@ This document explains coverage exclusions and hard-to-test code.
 
 **Lines:** the `agent.getProfile()` call and the following data extraction inside `checkSession`.
 
-**Why ignored:** This block calls AT Protocol methods on a live `Agent` instance. `mock.module` is unavailable under `tsx` (CJS transform), so the `Agent` constructor cannot be intercepted at the module level. The `agent.getProfile()` method requires a live Bluesky network session.
+**Why ignored:** This block calls AT Protocol methods on a live `Agent` instance. The `agent.getProfile()` method requires a live Bluesky network session.
 
-**What it would take to test:** Switch the test runner to use native ES modules (enabling `mock.module`), or refactor `checkSession` to accept an injected `Agent`-like interface that can be replaced in tests.
+**What it would take to test:** The server now runs as native ESM (see issue #216), so `node:test`'s `mock.module()` is no longer blocked by a CJS transform layer and could intercept the `Agent` constructor at the module level. Adopting that pattern (call `mock.module("@atproto/api", ...)` in a `before()` hook, then dynamically `import()` the module under test) would let this branch run without a network session. Alternatively, refactor `checkSession` to accept an injected `Agent`-like interface that can be replaced in tests.
 
 ### `client/src/Navigation.tsx` — unreachable `null` tail of friends ternary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4807,9 +4807,9 @@
             }
         },
         "node_modules/await-lock": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-1.2.1.tgz",
-            "integrity": "sha512-l4920ZIFwIFGpNDeGDnKi/b2t03BuSRV8gMuP94KMvb4kuF+1RLBafQOrOXFYLCc46k/zUgStj78tJTY+gqnaA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-3.0.0.tgz",
+            "integrity": "sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==",
             "license": "MIT"
         },
         "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
         "ws": "^8.21.0"
     },
     "overrides": {
-        "esbuild": ">=0.28.1",
-        "multiformats": "^14.0.4",
-        "await-lock": "1.2.1"
+        "esbuild": ">=0.28.1"
     }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "For answering anonymous questions and posting them to Bluesky",
   "author": "Karan Shukla",
   "license": "MIT",
-  "main": "index.ts",
+  "type": "module",
+  "main": "dist/index.js",
   "private": true,
   "scripts": {
     "dev": "tsx watch --clear-screen=false src/index.ts | pino-pretty",
@@ -105,6 +106,7 @@
       "!src/**/__tests__/**",
       "!src/**/*.test.*"
     ],
+    "format": "esm",
     "splitting": false,
     "sourcemap": true,
     "clean": true

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -275,7 +275,7 @@ migrations["008"] = {
   },
 };
 
-export const createDb = (location: string): Database => {
+export const createDb = async (location: string): Promise<Database> => {
   if (env.POSTGRESQL_URL) {
     return new Kysely<DatabaseSchema>({
       dialect: new PostgresDialect({
@@ -285,9 +285,8 @@ export const createDb = (location: string): Database => {
       }),
     });
   }
-  // Lazy require so the native binary is never loaded when PostgreSQL is in use
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const SqliteDb = require("better-sqlite3");
+  // Lazy import so the native binary is never loaded when PostgreSQL is in use
+  const { default: SqliteDb } = await import("better-sqlite3");
   return new Kysely<DatabaseSchema>({
     dialect: new SqliteDialect({
       database: new SqliteDb(location),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -71,7 +71,7 @@ export class Server {
     const logger = createLogger();
 
     // Set up the SQLite database
-    const db = createDb(DB_PATH);
+    const db = await createDb(DB_PATH);
     await migrateToLatest(db);
 
     // Create the atproto utilities

--- a/server/src/scripts/publish-lexicons.ts
+++ b/server/src/scripts/publish-lexicons.ts
@@ -17,6 +17,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { AtpAgent } from "@atproto/api";
 
@@ -40,7 +41,7 @@ async function main() {
   console.log(`Logged in as ${handle} (${did})`);
   console.log(`\nDNS record to add:\n  _lexicon.navyfragen.app  TXT  "did=${did}"\n`);
 
-  const lexiconPath = join(__dirname, "../../lexicons/message.json");
+  const lexiconPath = join(fileURLToPath(import.meta.url), "../../lexicons/message.json");
   const lexicon = JSON.parse(readFileSync(lexiconPath, "utf-8"));
   const nsid = lexicon.id as string;
 

--- a/server/src/services/notification-service.ts
+++ b/server/src/services/notification-service.ts
@@ -1,6 +1,9 @@
 /* v8 ignore next 1 */
 import { Logger } from "pino";
-import { sendNotification, setVapidDetails } from "web-push";
+// web-push is CJS whose named exports aren't statically detectable by Node's
+// ESM loader (cjs-module-lexer), so we import the default and destructure.
+import webPush from "web-push";
+const { sendNotification, setVapidDetails } = webPush;
 
 import type { Database } from "../database/db";
 

--- a/server/src/tests/notification-service.test.ts
+++ b/server/src/tests/notification-service.test.ts
@@ -7,7 +7,10 @@ import os from "node:os";
 import path from "node:path";
 import { test, describe, before, after, beforeEach, afterEach, mock } from "node:test";
 
-import { generateVAPIDKeys } from "web-push";
+// web-push is CJS whose named exports aren't statically detectable by Node's
+// ESM loader (cjs-module-lexer), so import the default and destructure.
+import webPush from "web-push";
+const { generateVAPIDKeys } = webPush;
 
 import { NotificationService, createConcurrencyLimiter } from "../services/notification-service";
 
@@ -272,9 +275,11 @@ describe("NotificationService", () => {
     });
 
     // These tests exercise the real `web-push` `sendNotification` call against a
-    // local HTTPS server (self-signed cert) instead of mocking the module, since
-    // `node:test`'s `mock.module()` requires the `--experimental-test-module-mocks`
-    // flag, which this repo's test script does not enable.
+    // local HTTPS server (self-signed cert) rather than mocking the module, so
+    // they cover web-push's actual HTTP/encryption behavior end-to-end. (The
+    // server is now native ESM, so `mock.module()` no longer needs a special
+    // flag — these could be converted to mocks later if the local-server setup
+    // becomes a maintenance burden.)
     describe("against a local HTTPS push endpoint", () => {
       let server: https.Server;
       let port: number;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "ignoreDeprecations": "5.0",
     "paths": {
       "#/*": ["./src/*"]
     },


### PR DESCRIPTION
Closes #216.

## Summary

The server was CommonJS end-to-end (tsup emitted CJS, booted via `node dist/index.js`, no `"type": "module"`), which blocked ESM-only dependency bumps in the `@atproto/*` family and forced fragile root `overrides` pinning `await-lock`/`multiformats` to old CJS versions.

This migrates `server/` to native ESM and drops those overrides.

## Why this is low-risk

tsup's config uses `entry: ["src"]` and **fully bundles each entry inline** — all relative and `#/` alias imports are resolved by esbuild at build time, so Node never sees them at runtime. This means no `.js` extensions need to be added across the codebase (85 relative + 13 alias imports), and no runtime `imports` map is needed for the `#/` alias.

## Changes

| Area | Change |
| --- | --- |
| `server/package.json` | Add `"type": "module"`, set tsup `"format": "esm"`, point `"main"` at `dist/index.js` |
| `server/tsconfig.json` | Drop stale `ignoreDeprecations: "5.0"` (module/moduleResolution stay `ESNext`/`Bundler` — `NodeNext` would require `.js` extensions on every relative import including generated lexicon code, and tsup handles emit anyway) |
| `src/database/db.ts` | Replace the only `require()` with a dynamic `import()`; make `createDb` async and `await` it at the call site. Lazy-load intent (skip the `better-sqlite3` native binary under Postgres) is preserved |
| `src/scripts/publish-lexicons.ts` | Replace `__dirname` with `fileURLToPath(import.meta.url)` |
| `src/services/notification-service.ts` + test | `web-push` is CJS whose named exports aren't statically detectable by Node's ESM loader (`cjs-module-lexer`), so switch to a default import + destructure. **This was a real production-breaking bug under ESM**, not just a test quirk |
| root `package.json` | Drop the `multiformats` and `await-lock` overrides. `await-lock` now resolves transitively to `3.0.0` via `@atproto/api@0.20.28`; `multiformats` dedupes to `14.0.4` via the server's direct dep |
| Docs | Update `CLAUDE.md`, `docs/testing-notes.md`, and a test comment that framed `mock.module()` as blocked by CJS — it's now available, though the suite still uses DI mocks by choice |

No Dockerfile change needed: it already copies `server/package.json` (now with `"type": "module"`) to the runtime image root.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run build` — emits ESM (zero `require()` calls in `dist/index.js`)
- ✅ `npm run lint` — 0 errors
- ✅ `npm test` — **all 295 tests pass** (up from 237; the two `web-push`-dependent test files now fully execute)
- ✅ `node dist/index.js` boots cleanly under Node 24
- ✅ `npm ls` exit 0 — dependency tree consistent, no `ELSPROBLEMS`

## Out of scope (follow-ups)

- Bumping `@atproto/*` packages to newer ESM-only releases
- Adopting `mock.module()` in auth/session tests to cover the previously-untestable `Agent` paths (the path is now open)