### PR TITLE
Adopt mock.module() to test AuthService.checkSession's getProfile path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,16 +195,26 @@ Do **not** use it to skip real business logic. Document any usage in `docs/testi
 
 ### Module Mocking in Server Tests
 
-The server runs as native ESM (see issue #216), which keeps `node:test`'s `mock.module()` API (Node.js v22.3+) available — it is no longer blocked by a CJS transform layer. The current test suite relies on dependency-injection mocks (chainable DB builders passed into constructors) rather than `mock.module()`, but the module-mocking path is open for cases that need to intercept a constructor the SUT imports at module scope (e.g. `@atproto/api`'s `Agent`). The pattern, when needed:
+`node:test`'s `mock.module()` (still flagged `--experimental-test-module-mocks` on Node 24) lets a test replace a module's exports before the system-under-test imports it. The test scripts (`test`, `test:watch`, `test:coverage`) already pass the flag. The default mocking strategy is dependency injection (chainable DB builders passed into constructors); `mock.module` is reserved for code that constructs a dependency at module scope with no injection seam — e.g. `auth-service.ts` → `session-agent.ts`'s `new Agent(...)`. The pattern, from `auth-service.test.ts`:
 
 ```typescript
+let AuthService: typeof import("../services/auth-service").AuthService;
+let mockAgent: { getProfile: (...args: any[]) => Promise<any> };
+
 before(async () => {
-  mock.module("@atproto/api", {
-    namedExports: { Agent: function(session) { return mockAgent; } },
+  mockAgent = { getProfile: mock.fn(async () => ({ data: undefined })) };
+  // Register the mock BEFORE importing the module under test so its
+  // transitive import of session-agent picks up the fakes.
+  await mock.module("../auth/session-agent", {
+    exports: { initializeAgentForDid: async (ctx, did) => { /* ... */ mockAgent } },
   });
-  const mod = await import("../controllers/some-controller.ts");
-  SomeController = mod.SomeController;
+  const mod = await import("../services/auth-service");
+  AuthService = mod.AuthService;
 });
 ```
 
-`mock.module` must be called **before** the target module is imported. Always use `before()` + dynamic `import()` in test files that need module-level mocking — never top-level static imports of the module under test.
+Notes:
+- `mock.module` is called on the **test context** (`t.mock.module`) inside a test, or on the top-level `mock` import inside `before()`. It must run **before** the SUT is imported — so the SUT is loaded via a dynamic `import()` in `before()`, never a top-level static import.
+- Mock the **nearest seam** to the SUT, not the deepest leaf. `auth-service.ts` imports `initializeAgentForDid` from `../auth/session-agent`; mocking that module (not `@atproto/api` directly) avoids having to re-export every other `@atproto/api` symbol (`RichText`, `AtpAgent`, …) that other transitively-imported modules use.
+- The mock should faithfully reproduce the real module's branching (e.g. return the e2e agent when present, `null` on restore-miss) so existing tests that rely on the real behavior keep passing.
+- Use the `exports` option key, not the deprecated `namedExports`.

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -14,11 +14,7 @@ This document explains coverage exclusions and hard-to-test code.
 
 ### `server/src/services/auth-service.ts` — `agent.getProfile()` block in `checkSession`
 
-**Lines:** the `agent.getProfile()` call and the following data extraction inside `checkSession`.
-
-**Why ignored:** This block calls AT Protocol methods on a live `Agent` instance. The `agent.getProfile()` method requires a live Bluesky network session.
-
-**What it would take to test:** The server now runs as native ESM (see issue #216), so `node:test`'s `mock.module()` is no longer blocked by a CJS transform layer and could intercept the `Agent` constructor at the module level. Adopting that pattern (call `mock.module("@atproto/api", ...)` in a `before()` hook, then dynamically `import()` the module under test) would let this branch run without a network session. Alternatively, refactor `checkSession` to accept an injected `Agent`-like interface that can be replaced in tests.
+**Status: now tested.** This block was previously ignored because `node:test`'s `mock.module()` was unavailable under the CJS `tsx` transform. After the ESM migration (#216) it became reachable: `auth-service.test.ts` mocks `../auth/session-agent` via `mock.module()` (registered in a `before()` hook before dynamically importing `auth-service`) so `initializeAgentForDid` returns a fake agent whose `getProfile` is controlled per-test. The block now has full coverage (success path, `!data` branch, optional-field fallbacks, getProfile rejection). See the `checkSession` tests for the pattern.
 
 ### `client/src/Navigation.tsx` — unreachable `null` tail of friends ternary
 

--- a/server/package.json
+++ b/server/package.json
@@ -17,9 +17,9 @@
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "typecheck": "tsc -p tsconfig.check.json --noEmit",
-    "test": "node --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts",
-    "test:watch": "node --import ./src/tests/test-bootstrap.js --import tsx --watch --test src/**/*.test.ts",
-    "test:coverage": "c8 node --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts",
+    "test": "node --experimental-test-module-mocks --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts",
+    "test:watch": "node --experimental-test-module-mocks --import ./src/tests/test-bootstrap.js --import tsx --watch --test src/**/*.test.ts",
+    "test:coverage": "c8 node --experimental-test-module-mocks --import ./src/tests/test-bootstrap.js --import tsx --test src/**/*.test.ts",
     "publish-lexicons": "tsx --tsconfig tsconfig.json src/scripts/publish-lexicons.ts"
   },
   "lint-staged": {

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -66,7 +66,6 @@ export class AuthService {
 
     const agent = await initializeAgentForDid(this.ctx, did);
     if (!agent) return null;
-    /* v8 ignore next 12 */
     const response = await agent.getProfile({ actor: did });
     const data = response?.data as AppBskyActorDefs.ProfileViewDetailed;
     if (!data) return null;

--- a/server/src/tests/auth-service.test.ts
+++ b/server/src/tests/auth-service.test.ts
@@ -1,14 +1,49 @@
 import assert from "node:assert";
-import { test, describe, beforeEach, afterEach, mock } from "node:test";
+import { test, describe, before, beforeEach, afterEach, mock } from "node:test";
 
 import { OAuthResolverError } from "@atproto/oauth-client-node";
 
-import { deleteE2EAgent, setE2EAgent } from "../auth/e2e-agent-store";
-import { AuthService } from "../services/auth-service";
+import { deleteE2EAgent, getE2EAgent, setE2EAgent } from "../auth/e2e-agent-store";
+
+// `mock.module` must be registered before the module under test is imported so
+// that auth-service's transitive import of session-agent picks up the mock.
+// AuthService is therefore loaded lazily in `before()` and held in this `let`.
+//
+// The mock faithfully reproduces the real `initializeAgentForDid` branching
+// (e2e agent > null-on-restore-miss > fake agent) so the existing E2E/no-agent
+// tests keep working; only the `new Agent(session)` leaf is replaced with
+// `mockAgent`, whose `getProfile` tests reassign to exercise the previously
+// untestable getProfile block in checkSession.
+let AuthService: typeof import("../services/auth-service").AuthService;
+let mockAgent: { getProfile: (...args: any[]) => Promise<any> };
+
+before(async () => {
+  mockAgent = { getProfile: mock.fn(async () => ({ data: undefined })) };
+  await mock.module("../auth/session-agent", {
+    exports: {
+      // Mirror the real contract: e2e bypass first, then null on restore-miss,
+      // otherwise hand back the controllable fake agent.
+      initializeAgentForDid: async (ctx: any, did: string) => {
+        const e2e = getE2EAgent(did);
+        if (e2e) return e2e;
+        const restored = await ctx.oauthClient.restore(did);
+        if (!restored) return null;
+        return mockAgent;
+      },
+      initializeAgentFromSession: async (req: any, ctx: any) => {
+        if (!req.session?.did) return null;
+        const { initializeAgentForDid } = await import("../auth/session-agent");
+        return initializeAgentForDid(ctx, req.session.did);
+      },
+    },
+  });
+  const mod = await import("../services/auth-service");
+  AuthService = mod.AuthService;
+});
 
 describe("AuthService", () => {
   let ctx: any;
-  let service: AuthService;
+  let service: InstanceType<typeof AuthService>;
 
   function makeMockCtx(overrides: any = {}) {
     return {
@@ -148,7 +183,7 @@ describe("AuthService", () => {
       assert.strictEqual(result, null);
     });
 
-    test("throws when agent exists but getProfile call fails (covers !agent=false branch)", async () => {
+    test("returns the mapped profile when getProfile resolves with data", async () => {
       ctx.db.selectFrom = mock.fn(() => ({
         selectAll: mock.fn(function (this: any) {
           return this as any;
@@ -158,10 +193,98 @@ describe("AuthService", () => {
         }),
         executeTakeFirst: mock.fn(async () => ({ key: "did:foo" })),
       }));
-      // Restore returns a non-null object so initializeAgentForDid creates a real Agent
       ctx.oauthClient.restore = mock.fn(async () => ({ sub: "did:foo" }));
-      // The real Agent has no valid network session so getProfile will throw
-      await assert.rejects(() => service.checkSession("did:foo"), /.+/);
+      mockAgent.getProfile = mock.fn(async () => ({
+        data: {
+          did: "did:foo",
+          handle: "foo.bsky.social",
+          displayName: "Foo",
+          description: "a bio",
+          avatar: "https://example.com/a.png",
+          banner: "https://example.com/b.png",
+          createdAt: "2024-01-01T00:00:00.000Z",
+        },
+      }));
+      const result = await service.checkSession("did:foo");
+      assert.deepStrictEqual(result, {
+        did: "did:foo",
+        handle: "foo.bsky.social",
+        displayName: "Foo",
+        description: "a bio",
+        avatar: "https://example.com/a.png",
+        banner: "https://example.com/b.png",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      });
+      assert.deepStrictEqual(mockAgent.getProfile.mock.calls[0].arguments[0], {
+        actor: "did:foo",
+      });
+    });
+
+    test("coerces absent optional profile fields to empty string / undefined", async () => {
+      ctx.db.selectFrom = mock.fn(() => ({
+        selectAll: mock.fn(function (this: any) {
+          return this as any;
+        }),
+        where: mock.fn(function (this: any) {
+          return this as any;
+        }),
+        executeTakeFirst: mock.fn(async () => ({ key: "did:foo" })),
+      }));
+      ctx.oauthClient.restore = mock.fn(async () => ({ sub: "did:foo" }));
+      mockAgent.getProfile = mock.fn(async () => ({
+        data: {
+          did: "did:foo",
+          handle: "foo.bsky.social",
+          displayName: undefined,
+          description: undefined,
+          avatar: undefined,
+          banner: undefined,
+          createdAt: undefined,
+        },
+      }));
+      const result = await service.checkSession("did:foo");
+      assert.deepStrictEqual(result, {
+        did: "did:foo",
+        handle: "foo.bsky.social",
+        displayName: "",
+        description: "",
+        avatar: undefined,
+        banner: undefined,
+        createdAt: undefined,
+      });
+    });
+
+    test("returns null when getProfile resolves but data is falsy", async () => {
+      ctx.db.selectFrom = mock.fn(() => ({
+        selectAll: mock.fn(function (this: any) {
+          return this as any;
+        }),
+        where: mock.fn(function (this: any) {
+          return this as any;
+        }),
+        executeTakeFirst: mock.fn(async () => ({ key: "did:foo" })),
+      }));
+      ctx.oauthClient.restore = mock.fn(async () => ({ sub: "did:foo" }));
+      mockAgent.getProfile = mock.fn(async () => ({ data: null }));
+      const result = await service.checkSession("did:foo");
+      assert.strictEqual(result, null);
+    });
+
+    test("rethrows when getProfile rejects", async () => {
+      ctx.db.selectFrom = mock.fn(() => ({
+        selectAll: mock.fn(function (this: any) {
+          return this as any;
+        }),
+        where: mock.fn(function (this: any) {
+          return this as any;
+        }),
+        executeTakeFirst: mock.fn(async () => ({ key: "did:foo" })),
+      }));
+      ctx.oauthClient.restore = mock.fn(async () => ({ sub: "did:foo" }));
+      mockAgent.getProfile = mock.fn(async () => {
+        throw new Error("network down");
+      });
+      await assert.rejects(() => service.checkSession("did:foo"), /network down/);
     });
 
     describe("with an E2E agent", () => {

--- a/server/src/tests/notification-service.test.ts
+++ b/server/src/tests/notification-service.test.ts
@@ -277,9 +277,9 @@ describe("NotificationService", () => {
     // These tests exercise the real `web-push` `sendNotification` call against a
     // local HTTPS server (self-signed cert) rather than mocking the module, so
     // they cover web-push's actual HTTP/encryption behavior end-to-end. (The
-    // server is now native ESM, so `mock.module()` no longer needs a special
-    // flag — these could be converted to mocks later if the local-server setup
-    // becomes a maintenance burden.)
+    // test scripts now pass --experimental-test-module-mocks, so `mock.module()`
+    // is available — these could be converted to mocks later if the local-server
+    // setup becomes a maintenance burden.)
     describe("against a local HTTPS push endpoint", () => {
       let server: https.Server;
       let port: number;


### PR DESCRIPTION
Follow-up to #216 (PR #240). The ESM migration unblocked `node:test`'s `mock.module()`, which was previously unavailable under the CJS tsx transform. This PR closes the last AT Protocol coverage gap.

## Context

Two follow-ups were noted as out-of-scope in PR #240:

1. **Bump `@atproto/*` to ESM-only versions** — turns out this is **already complete**. PR #240's lockfile regeneration pulled every `@atproto/*` package to its latest published version (`@atproto/api@0.20.28`, etc.), all of which are ESM-only (`"type": "module"`). `npm outdated` is empty. Nothing to bump.

2. **Adopt `mock.module()` in auth/session tests** — this PR. The only code path previously untestable was the `agent.getProfile()` block in `AuthService.checkSession` (`auth-service.ts:69-81`), marked `/* v8 ignore next 12 */`.

## What changed

**`mock.module()` API reality check:** During implementation I found the prior docs were inaccurate on two points:
- `mock.module` still requires the `--experimental-test-module-mocks` flag on Node 24.15.0 (it is *not* unflagged). Added the flag to all three test scripts.
- The option key is `exports`, not the deprecated `namedExports`.

**Mocking strategy — nearest seam:** Rather than mocking `@atproto/api` directly (which would require re-exporting every other symbol — `RichText`, `AtpAgent`, etc. — that transitively-imported modules use), I mock `../auth/session-agent`, the module `auth-service.ts` actually imports. The mock faithfully reproduces the real `initializeAgentForDid` contract:
- Returns the e2e agent when present (so existing E2E tests pass)
- Returns `null` on restore-miss (so existing no-agent tests pass)
- Otherwise returns a controllable `mockAgent` whose `getProfile` tests reassign per-case

**New tests** for the previously-ignored `getProfile` block:
- Success-path mapping (full `ProfileViewDetailed` → return shape)
- Optional-field fallback coercion (`displayName`/`description` → `""`, `avatar`/`banner` → `undefined`)
- `!data` null branch
- `getProfile` rejection rethrow

**`auth-service.ts`:** dropped the `/* v8 ignore next 12 */` — the block is now covered.

**Docs:** rewrote the `CLAUDE.md` "Module Mocking in Server Tests" section to match the actual working pattern, and marked the `testing-notes.md` entry as tested.

## Verification

- ✅ `auth-service.ts` is now at **100% coverage** (lines/branches/functions/statements)
- ✅ All **298 server tests pass** (up from 295)
- ✅ `typecheck` clean
- ✅ `lint` 0 errors
- ✅ Existing E2E and no-agent tests pass unchanged (the mock preserves their contract)