### PR TITLE
fix: PWA full-screen launch + always show profile row in account switcher

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -17,6 +17,14 @@
   <meta property="og:image" content="https://navyfragen.app/navyfragen-og.png" />
   <meta name="viewport"
     content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-visual" />
+  <!-- iOS standalone launch: "Add to Home Screen" opens without Safari's chrome.
+       viewport-fit=cover above enables env(safe-area-inset-*) in index.css. -->
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <!-- "default" adapts to the active color scheme (dark text on the light-mode
+       header, light on the dark-mode header); black-translucent would force
+       always-white status-bar text, unreadable against the light header. -->
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <!-- Chrome address bar matches light/dark scheme -->
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#FDF8FF" />
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0B0A24" />

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -178,7 +178,7 @@ function UserMenu({
 }: UserMenuProps) {
   const { triggerHaptic } = useHaptic(1);
   const { mutate: switchAccount, isPending: isSwitching } = useSwitchAccount();
-  const hasMultiple = accounts.length > 1;
+  const hasMultiple = accounts.length > 1; // gates the "Accounts" label only
 
   const handleSwitch = (did: string, handle: string) => {
     /* v8 ignore start */
@@ -255,10 +255,13 @@ function UserMenu({
       </Menu.Target>
 
       <Menu.Dropdown>
-        {/* Account switcher — only shown when more than one account is signed in. */}
-        {hasMultiple && (
+        {/* Account switcher — the active profile row always renders above
+            "Add account", even when only one account is signed in. The
+            "Accounts" label is shown only when there are other switchable
+            accounts to list beneath the current one. */}
+        {accounts.length > 0 && (
           <>
-            <Menu.Label>Accounts</Menu.Label>
+            {hasMultiple && <Menu.Label>Accounts</Menu.Label>}
             {accounts.map((acct) => {
               const isActive = acct.did === activeDid;
               const label = acct.displayName || acct.handle || acct.did;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -14,6 +14,28 @@ body {
   min-height: 100dvh;
 }
 
+/* PWA safe-area insets: keep the fixed header (and its content) clear of the
+   notch / status bar, and reserve space at the bottom for the home-indicator
+   gesture area. These env() values are non-zero only because viewport-fit=cover
+   is set in index.html; on desktop / non-notched devices they resolve to 0.
+
+   Growing --app-shell-header-height makes the header's solid background extend
+   behind the status bar AND auto-re-offsets the mobile Navbar's `top` (Mantine
+   derives --app-shell-header-offset from it). padding-top on the header then
+   pushes the logo / buttons below the notch. Main's inline pt={70} would
+   otherwise hide content under the now-taller header, so it's bumped by the
+   same inset; padding-bottom keeps the last scrollable item above the indicator. */
+:root {
+  --app-shell-header-height: calc(60px + env(safe-area-inset-top));
+}
+.mantine-AppShell-header {
+  padding-top: env(safe-area-inset-top);
+}
+.mantine-AppShell-main {
+  padding-top: calc(70px + env(safe-area-inset-top)) !important;
+  padding-bottom: env(safe-area-inset-bottom) !important;
+}
+
 /* Constrain the mobile navbar to 60% of the viewport width */
 .mantine-AppShell-navbar {
   max-width: 60vw !important;

--- a/client/src/tests/components/AppHeader.test.tsx
+++ b/client/src/tests/components/AppHeader.test.tsx
@@ -381,7 +381,7 @@ describe("AppHeader", () => {
       );
     });
 
-    it("does not render the account switcher section when there is only one account", async () => {
+    it("always shows the active profile row when there is only one account, with no others listed", async () => {
       mockUseSession.mockReturnValue({
         data: {
           isLoggedIn: true,
@@ -393,7 +393,16 @@ describe("AppHeader", () => {
       } as any);
       renderWithProviders(<AppHeader {...defaultProps} />);
       await openMenu();
+      // The active profile row renders unconditionally above "Add account"...
+      expect(screen.getByText("@active.bsky.social")).toBeInTheDocument();
+      // ...marked active (disabled + checked)...
+      const activeItem = screen.getByText("@active.bsky.social").closest('[role="menuitem"]');
+      expect(activeItem).toHaveAttribute("data-disabled", "true");
+      // ...with no "Accounts" label (only shown when there are others)...
       expect(screen.queryByText("Accounts")).not.toBeInTheDocument();
+      // ...and no other switchable accounts listed beneath it.
+      expect(screen.queryByText("Other User")).not.toBeInTheDocument();
+      expect(screen.queryByText("@other.bsky.social")).not.toBeInTheDocument();
     });
 
     it("does nothing when a switch is already pending", async () => {


### PR DESCRIPTION
Fixes two small, independent UI issues in one PR.

## #225 — Make PWA stretch correctly and take up entire phone screen
**Closes #225**

The installed PWA didn't fill the screen because `index.html` lacked the Apple PWA meta tags (so iOS "Add to Home Screen" relaunched inside Safari's chrome) and there was no safe-area padding.

- **`client/index.html`** — add `apple-mobile-web-app-capable` (+ `mobile-web-app-capable` for Android/Chrome) and `apple-mobile-web-app-status-bar-style` meta tags. `status-bar-style="default"` adapts to the active light/dark color scheme (the app supports both via `defaultColorScheme=\"auto\"`); `black-translucent` was rejected because it forces always-white status-bar text that's unreadable against the `#FDF8FF` light-mode header.
- **`client/src/index.css`** — add `env(safe-area-inset-*)` handling in the existing PWA block, no-ops on desktop where the env values resolve to `0`:
  - Grow Mantine's `--app-shell-header-height` by `env(safe-area-inset-top)` → header's solid bg extends behind the notch/status bar, **and** the mobile Navbar's fixed `top` auto-re-offsets (Mantine derives `--app-shell-header-offset` from height).
  - `padding-top` on the header pushes the logo/buttons below the notch.
  - `padding-top`/`padding-bottom` on main (beats the inline `pt={70}`) so content clears the taller header and the home-indicator gesture area.

`viewport-fit=cover` (already present) is what makes these `env()` values non-zero.

## #235 — Always show current profile row in account switcher
**Closes #235**

The entire accounts block in `UserMenu` was gated on `hasMultiple` (`accounts.length > 1`), so the active profile row vanished when only one account was signed in. The server always includes the active account in `accounts` (`auth-controller.ts` upserts it on every `/session`), so the row can safely render unconditionally.

- **`client/src/components/AppHeader.tsx`** — gate the accounts block on `accounts.length > 0` instead of `hasMultiple`; the active profile row now always renders above "Add account". The `hasMultiple` flag now gates only the "Accounts" `Menu.Label` (shown when there are other switchable accounts). Multi-account behavior is unchanged.
- **`client/src/tests/components/AppHeader.test.tsx`** — rewrote the single-account test to assert the new behavior: the profile row is present (checked/disabled), no "Accounts" label, no other switchable accounts listed.

## Verification
- `npm run lint` — 0 errors (418 pre-existing `any` warnings, unchanged)
- `npm run test` — all 471 client tests pass, including the updated account-switcher test
- `npm run build` — succeeds; confirmed the new meta tags and safe-area CSS are in the built `dist/` output