### PR TITLE
fix: app header scrolls away instead of staying fixed

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -43,17 +43,41 @@ body {
 
 /* Boxed layout: cap the whole app (header + navbar + main) to a centered
    column on wide/4K screens instead of letting it stretch edge-to-edge.
-   AppShell's header/navbar use `position: fixed`, which normally resolves
-   against the viewport — giving this wrapper a `transform` creates a new
-   containing block, so those fixed elements clip to its width instead. */
+   NOTE: the header/navbar use `position: fixed` and must clip to this column
+   width — but an ancestor `transform` would also make them scroll with the
+   page (a transformed element becomes the containing block for fixed
+   descendants, turning fixed into absolute). So the wrapper does NOT use a
+   transform; instead the fixed elements are centered/clipped directly below. */
 .app-shell-boundary {
   max-width: 1400px;
   margin: 0 auto;
   min-height: 100dvh;
   position: relative;
-  transform: translateZ(0);
   border-left: 1px solid var(--nf-app-boundary-border);
   border-right: 1px solid var(--nf-app-boundary-border);
+}
+
+/* Center + clip the fixed header to the 1400px column without an ancestor
+   transform (which would make it scroll away — see note above). max-width
+   makes this a no-op below 1400px, so mobile/desktop-wide headers are
+   unaffected. translateX(-50%) re-centers after the left: 50% shift. */
+.mantine-AppShell-header {
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 1400px;
+}
+/* The navbar is also position: fixed. On wide screens it's a visible sidebar
+   that must align to the column's left edge (= 50% − half the column). This
+   only matters once the 1400px column is actually centered with room to spare,
+   so the gate matches .app-shell-boundary's max-width — below it the column is
+   full-width and the navbar's default left: 0 is correct. The mobile off-canvas
+   drawer (uses left: 0 + a slide transform) is untouched. */
+@media (min-width: 87.5em) {
+  .mantine-AppShell-navbar {
+    left: calc(50% - 700px);
+  }
 }
 
 /* Brand CSS tokens */


### PR DESCRIPTION
## Problem
The top app bar disappears when you scroll down the page — it should stay fixed to the viewport. Reported as a possible regression from #225, but investigation showed it's **pre-existing** (the cause predates and is independent of that PR).

## Root cause
`.app-shell-boundary` (the wrapper around the whole `AppShell`) had `transform: translateZ(0)`. Per the CSS spec, **a transformed ancestor becomes the containing block for `position: fixed` descendants** — which effectively turns `fixed` into `absolute` relative to that ancestor. So Mantine's `position: fixed; top: 0` header behaved as if absolutely positioned and scrolled away with the page.

Confirmed live with Playwright: at `scrollY: 300`, the header's `getBoundingClientRect()` was `top: -300` (scrolled off-screen) even though `getComputedStyle` reported `position: fixed; top: 0px`.

The transform existed for a reason — it was the mechanism that clipped the fixed header/navbar to the 1400px boxed column on wide screens (its containing-block side-effect pinned the fixed elements to the wrapper's width). Removing it would reintroduce edge-to-edge stretching on 4K displays.

## Fix
Replace the transform-based width-clipping with **direct positioning** that preserves true viewport-fixed behavior (`client/src/index.css`, the only file changed):

1. **Remove** `transform: translateZ(0)` from `.app-shell-boundary`.
2. **Header** — center + clip directly: `left: 50%; transform: translateX(-50%); width: 100%; max-width: 1400px`. This is a no-op below 1400px (mobile/desktop-wide headers are unaffected).
3. **Navbar** — re-align the fixed sidebar to the column's left edge: `left: calc(50% - 700px)`, gated to `@media (min-width: 87.5em)` (1400px). The gate is critical:
   - On mobile (< 768px) the navbar is an off-canvas drawer using `left: 0` + a slide transform — untouched.
   - At mid-widths (e.g. 1280px) the column is full-width and `calc(50% - 700px)` would be negative, pushing the navbar off-screen — so the gate only applies once the 1400px column is actually centered with room to spare.

The `1400px` / `700px` / `87.5em` values mirror `.app-shell-boundary`'s existing `max-width: 1400px`.

## Verification
Verified live at three viewports with Playwright against the running dev server (all measuring real `getBoundingClientRect`, not mocked):

| Viewport | Header on scroll | Header width | Navbar |
|---|---|---|---|
| **390px mobile** | ✅ sticks (`top: 0` at scrollY 500) | full-width 374px | ✅ drawer off-screen (slide transform intact) |
| **1280px desktop** | ✅ sticks | full-width 0→1280 | ✅ left:0, visible, in-bounds |
| **2560px wide** | ✅ sticks | 580→1980 (1400px, matches column) | ✅ left:580, aligned to column edge |

- `npm run lint` — 0 errors
- `npm run build` — succeeds
- `npm run test` — 470/471 pass. The 1 failure (`Messages.test.tsx > "does not scroll into view when the newest message target is already visible"`) is **pre-existing flakiness**: it fails identically on `main` without this change and passes in isolation. This PR is CSS-only and doesn't touch any code that test exercises.

## Notes
- This is independent of / builds on top of #242 (merged), which added the safe-area PWA CSS. No conflict — both touch `index.css` in different sections.
- Considered switching `AppShell` to `mode=\"static\"` (grid + sticky header) as an alternative, but rejected it: static mode makes the root the scroll container, which would change scroll behavior and risk breaking `window.scrollTo`, scroll-to-top, and the existing `overscroll-behavior-y` handling — a much larger behavioral change for a one-line root cause.