### PR TITLE
fix: source follows and followers from one agent in friends list

### DIFF
--- a/server/src/controllers/profile-controller.ts
+++ b/server/src/controllers/profile-controller.ts
@@ -77,13 +77,8 @@ export class ProfileController {
       return res.status(403).json({ error: "Not authenticated" });
     }
 
-    const agent = await initializeAgentFromSession(req, this.ctx);
-    if (!agent) {
-      return res.status(401).json({ error: "Session expired" });
-    }
-
     try {
-      const result = await this.profileService.getFriendsOnApp(userDid, agent);
+      const result = await this.profileService.getFriendsOnApp(userDid);
       return res.json(result);
     } catch (err) {
       this.logger.error({ err, did: userDid }, "Failed to fetch friends on app");

--- a/server/src/services/profile-service.ts
+++ b/server/src/services/profile-service.ts
@@ -73,10 +73,7 @@ export class ProfileService {
    * @param handle The user's handle
    * @returns The resolved DID
    */
-  async getFriendsOnApp(
-    userDid: string,
-    agent: Agent
-  ): Promise<{
+  async getFriendsOnApp(userDid: string): Promise<{
     moots: { did: string; handle: string; displayName?: string; avatar?: string }[];
     following: { did: string; handle: string; displayName?: string; avatar?: string }[];
     oomfs: { did: string; handle: string; displayName?: string; avatar?: string }[];
@@ -109,12 +106,20 @@ export class ProfileService {
       return map;
     }
 
+    // Both calls go through the same public appview agent so the follows and
+    // followers datasets are read from one consistent indexing state. Splitting
+    // them across the authenticated caller agent and this public agent could
+    // observe the same relationship differently (one appview session lagging
+    // the other), which mislabels moots as oomfs. Note we can't move follows to
+    // the authenticated agent instead: its OAuth scope grants getFollows but not
+    // getFollowers, so doing so would break getFollowers for existing sessions.
+    const agent = this.agent;
     const [followingMap, followersMap] = await Promise.all([
       fetchPages((cursor) =>
         agent.app.bsky.graph.getFollows({ actor: userDid, limit: 100, cursor })
       ),
       fetchPages((cursor) =>
-        this.agent.app.bsky.graph.getFollowers({ actor: userDid, limit: 100, cursor })
+        agent.app.bsky.graph.getFollowers({ actor: userDid, limit: 100, cursor })
       ),
     ]);
 

--- a/server/src/tests/profile-controller.test.ts
+++ b/server/src/tests/profile-controller.test.ts
@@ -121,15 +121,6 @@ describe("ProfileController", () => {
       assert.strictEqual(res.status.mock.calls[0].arguments[0], 403);
     });
 
-    test("returns 401 when agent is null", async () => {
-      const ctx = makeCtx();
-      ctx.oauthClient.restore = mock.fn(async () => null);
-      const controller = new ProfileController(makeService(), ctx.logger, ctx);
-      const res = makeRes();
-      await controller.getFriends(makeReq(), res);
-      assert.strictEqual(res.status.mock.calls[0].arguments[0], 401);
-    });
-
     test("returns moots, following, and oomfs on success", async () => {
       const svc = makeService({
         getFriendsOnApp: mock.fn(async () => ({

--- a/server/src/tests/profile-service.test.ts
+++ b/server/src/tests/profile-service.test.ts
@@ -348,27 +348,24 @@ describe("ProfileService", () => {
       { did: "did:user:3", handle: "user3.bsky.app", displayName: undefined, avatar: undefined },
     ];
 
-    // authenticated agent — only needs getFollows (getFollowers uses the public agent)
-    const makeAuthAgent = (follows: typeof sampleFollows) => ({
-      app: {
-        bsky: {
-          graph: {
-            getFollows: mock.fn(async () => ({
-              success: true,
-              data: { follows, cursor: undefined },
-            })),
-          },
-        },
-      },
-    });
-
-    // sets the service's internal public AtpAgent mock to return the given followers
-    const setPublicAgentFollowers = (followers: typeof sampleFollows) => {
+    // Configures the service's single internal agent with the given follows and
+    // followers. Both getFollows and getFollowers are served by the same mock so
+    // we can assert they originate from one agent instance.
+    const setServiceAgent = (
+      follows: typeof sampleFollows,
+      followers: typeof sampleFollows,
+      getFollowsImpl?: (params: any) => Promise<any>
+    ) => {
       (profileService as any).agent = {
-        ...(profileService as any).agent,
         app: {
           bsky: {
             graph: {
+              getFollows: getFollowsImpl
+                ? mock.fn(getFollowsImpl)
+                : mock.fn(async () => ({
+                    success: true,
+                    data: { follows, cursor: undefined },
+                  })),
               getFollowers: mock.fn(async () => ({
                 success: true,
                 data: { followers, cursor: undefined },
@@ -381,15 +378,14 @@ describe("ProfileService", () => {
 
     it("should separate moots, following-only, and followers-only", async () => {
       // user:1 = mutual, user:3 = I follow them (not back), user:2 = they follow me (not back)
-      const mockAgent = makeAuthAgent([sampleFollows[0], sampleFollows[2]]);
-      setPublicAgentFollowers([sampleFollows[0], sampleFollows[1]]);
+      setServiceAgent([sampleFollows[0], sampleFollows[2]], [sampleFollows[0], sampleFollows[1]]);
       mockSelectBuilder.execute = async () => [
         { did: "did:user:1" },
         { did: "did:user:2" },
         { did: "did:user:3" },
       ];
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", mockAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 1);
       assert.strictEqual(result.moots[0].did, "did:user:1");
@@ -403,11 +399,10 @@ describe("ProfileService", () => {
 
     it("should put followers-only users in oomfs", async () => {
       // user:2 follows me but I don't follow them
-      const mockAgent = makeAuthAgent([]);
-      setPublicAgentFollowers([sampleFollows[1]]);
+      setServiceAgent([], [sampleFollows[1]]);
       mockSelectBuilder.execute = async () => [{ did: "did:user:2" }];
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", mockAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 0);
       assert.strictEqual(result.following.length, 0);
@@ -417,11 +412,10 @@ describe("ProfileService", () => {
 
     it("should put following-only users in following", async () => {
       // user:3 I follow but they don't follow back
-      const mockAgent = makeAuthAgent([sampleFollows[2]]);
-      setPublicAgentFollowers([]);
+      setServiceAgent([sampleFollows[2]], []);
       mockSelectBuilder.execute = async () => [{ did: "did:user:3" }];
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", mockAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 0);
       assert.strictEqual(result.following.length, 1);
@@ -430,11 +424,10 @@ describe("ProfileService", () => {
     });
 
     it("should return empty when nobody is on the app", async () => {
-      const mockAgent = makeAuthAgent(sampleFollows);
-      setPublicAgentFollowers([]);
+      setServiceAgent(sampleFollows, []);
       mockSelectBuilder.execute = async () => [];
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", mockAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 0);
       assert.strictEqual(result.following.length, 0);
@@ -442,10 +435,9 @@ describe("ProfileService", () => {
     });
 
     it("should return empty when user has no follows or followers", async () => {
-      const mockAgent = makeAuthAgent([]);
-      setPublicAgentFollowers([]);
+      setServiceAgent([], []);
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", mockAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 0);
       assert.strictEqual(result.following.length, 0);
@@ -456,73 +448,67 @@ describe("ProfileService", () => {
 
     it("should follow cursor pagination for follows across multiple pages", async () => {
       let followsCallCount = 0;
-      const paginatedAgent = {
-        app: {
-          bsky: {
-            graph: {
-              getFollows: mock.fn(async (params: any) => {
-                followsCallCount++;
-                if (followsCallCount === 1) {
-                  return {
-                    success: true,
-                    data: {
-                      follows: [
-                        {
-                          did: "did:user:1",
-                          handle: "user1.bsky.app",
-                          displayName: "Page1",
-                          avatar: undefined,
-                        },
-                      ],
-                      cursor: "page2-cursor",
-                    },
-                  };
-                }
-                return {
-                  success: true,
-                  data: {
-                    follows: [
-                      {
-                        did: "did:user:2",
-                        handle: "user2.bsky.app",
-                        displayName: "Page2",
-                        avatar: undefined,
-                      },
-                    ],
-                    cursor: undefined,
-                  },
-                };
-              }),
+      setServiceAgent([], [], async (params: any) => {
+        followsCallCount++;
+        if (followsCallCount === 1) {
+          return {
+            success: true,
+            data: {
+              follows: [
+                {
+                  did: "did:user:1",
+                  handle: "user1.bsky.app",
+                  displayName: "Page1",
+                  avatar: undefined,
+                },
+              ],
+              cursor: "page2-cursor",
             },
+          };
+        }
+        return {
+          success: true,
+          data: {
+            follows: [
+              {
+                did: "did:user:2",
+                handle: "user2.bsky.app",
+                displayName: "Page2",
+                avatar: undefined,
+              },
+            ],
+            cursor: undefined,
           },
-        },
-      };
-      setPublicAgentFollowers([]);
+        };
+      });
       mockSelectBuilder.execute = async () => [{ did: "did:user:1" }, { did: "did:user:2" }];
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", paginatedAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(followsCallCount, 2);
       assert.strictEqual(result.following.length, 2);
       // Verify cursor was forwarded on the second call
-      const secondCallArgs = (paginatedAgent.app.bsky.graph.getFollows as any).mock.calls[1]
-        .arguments[0];
+      const secondCallArgs = ((profileService as any).agent.app.bsky.graph.getFollows as any).mock
+        .calls[1].arguments[0];
       assert.strictEqual(secondCallArgs.cursor, "page2-cursor");
     });
 
     it("should stop fetching when getFollows returns success: false", async () => {
-      const failingAgent = {
+      (profileService as any).agent = {
         app: {
           bsky: {
             graph: {
               getFollows: mock.fn(async () => ({ success: false, data: {} })),
+              getFollowers: mock.fn(async () => ({
+                success: true,
+                data: { followers: [], cursor: undefined },
+              })),
             },
           },
         },
       };
-      setPublicAgentFollowers([]);
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", failingAgent as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 0);
       assert.strictEqual(result.following.length, 0);
@@ -531,41 +517,32 @@ describe("ProfileService", () => {
 
     it("should stop fetching after 5 pages when cursor never clears (max page limit)", async () => {
       let followsCallCount = 0;
-      const paginatedAgent = {
-        app: {
-          bsky: {
-            graph: {
-              getFollows: mock.fn(async () => {
-                followsCallCount++;
-                return {
-                  success: true,
-                  data: {
-                    follows: [
-                      {
-                        did: `did:user:page${followsCallCount}`,
-                        handle: `u${followsCallCount}.bsky.app`,
-                        displayName: undefined,
-                        avatar: undefined,
-                      },
-                    ],
-                    cursor: `page${followsCallCount + 1}`,
-                  },
-                };
-              }),
-            },
+      setServiceAgent([], [], async () => {
+        followsCallCount++;
+        return {
+          success: true,
+          data: {
+            follows: [
+              {
+                did: `did:user:page${followsCallCount}`,
+                handle: `u${followsCallCount}.bsky.app`,
+                displayName: undefined,
+                avatar: undefined,
+              },
+            ],
+            cursor: `page${followsCallCount + 1}`,
           },
-        },
-      };
-      setPublicAgentFollowers([]);
+        };
+      });
       mockSelectBuilder.execute = async () => [];
 
-      await profileService.getFriendsOnApp("did:owner:1", paginatedAgent as any);
+      await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(followsCallCount, 5);
     });
 
     it("should use empty array fallback when fetchPages response has neither follows nor followers", async () => {
-      const agentWithEmptyData = {
+      (profileService as any).agent = {
         app: {
           bsky: {
             graph: {
@@ -573,17 +550,37 @@ describe("ProfileService", () => {
                 success: true,
                 data: { cursor: undefined },
               })),
+              getFollowers: mock.fn(async () => ({
+                success: true,
+                data: { followers: [], cursor: undefined },
+              })),
             },
           },
         },
       };
-      setPublicAgentFollowers([]);
 
-      const result = await profileService.getFriendsOnApp("did:owner:1", agentWithEmptyData as any);
+      const result = await profileService.getFriendsOnApp("did:owner:1");
 
       assert.strictEqual(result.moots.length, 0);
       assert.strictEqual(result.following.length, 0);
       assert.strictEqual(result.oomfs.length, 0);
+    });
+
+    it("should source both getFollows and getFollowers from the same agent instance", async () => {
+      // Regression guard for the moots/oomfs categorization bug: previously
+      // getFollows used the caller's authenticated agent while getFollowers used
+      // the service's public agent, so the two datasets could disagree on
+      // indexing state and mislabel mutuals. Both calls must now originate from
+      // the service's single internal agent.
+      setServiceAgent(sampleFollows, sampleFollows);
+
+      await profileService.getFriendsOnApp("did:owner:1");
+
+      const agent = (profileService as any).agent;
+      const getFollowsMock = agent.app.bsky.graph.getFollows;
+      const getFollowersMock = agent.app.bsky.graph.getFollowers;
+      assert.strictEqual(getFollowsMock.mock.calls.length, 1);
+      assert.strictEqual(getFollowersMock.mock.calls.length, 1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #198 — mutual follows (\"moots\") were sometimes mislabeled as one-way followers (\"oomfs\") in the friends list.

`getFriendsOnApp()` fetched `getFollows` through the caller's authenticated agent and `getFollowers` through the service's separate public `api.bsky.app` agent. Because those two calls hit different appview sessions, the same underlying relationship could appear present in one dataset but not yet reflected in the other, causing the moots/oomfs classification to receive inconsistent inputs.

## Changes

- **`server/src/services/profile-service.ts`** — `getFriendsOnApp()` now routes both `getFollows` and `getFollowers` through the service's single internal public agent, so both datasets reflect one consistent indexing state. Drops the now-unused `agent` parameter.
- **`server/src/controllers/profile-controller.ts`** — `getFriends` no longer restores an agent or passes it through; the dead 401 \"agent is null\" branch is removed.

## Why the public agent (not the authenticated one)

The OAuth client scope (`server/src/auth/client.ts:27,31`) grants `rpc:app.bsky.graph.getFollows?aud=*` but **not** `getFollowers`. Moving follows onto the authenticated agent instead would break `getFollowers` for existing sessions until they re-auth. Using the public agent for both requires no scope change and no session migration.

The moots/following/oomfs classification logic itself is unchanged — only its inputs are now consistent.

## Acceptance criteria

- [x] `getFriendsOnApp()` uses one agent/session for both the `getFollows` and `getFollowers` calls for a given `userDid`
- [x] A test exercises the case where the two calls would previously have used different agents, confirming both calls now originate from the same agent instance (`profile-service.test.ts` → \"should source both getFollows and getFollowers from the same agent instance\")
- [x] Existing `profile-service.test.ts` and `profile-controller.test.ts` coverage still passes (298/298)

## Test plan

- [x] `npm test` in `server/` — 298 pass, 0 fail
- [x] `npm run typecheck` in `server/` — clean
- [x] pre-push hook (prettier + oxlint + typecheck on client + server) — passed

Fixes #198