### PR TITLE
fix: render push notifications toggle as a Switch

### DIFF
--- a/client/src/components/PushNotificationsButton.tsx
+++ b/client/src/components/PushNotificationsButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Loader } from "@mantine/core";
+import { Loader, Switch } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useState } from "react";
 
@@ -31,12 +31,12 @@ export function PushNotificationsButton() {
     isServerPushAvailable === false || !isBrowserSupported || permission === "denied";
 
   if (isCheckingAvailability) return <Loader size="sm" />;
+
   if (isUnavailable) {
-    return (
-      <Button fullWidth disabled>
-        Push Notifications Unavailable
-      </Button>
-    );
+    // A disabled switch reads as "off, and you can't turn it on here" more
+    // clearly than the old inert button, and matches the PDS Sync control's
+    // affordance on the neighbouring card.
+    return <Switch size="lg" label="Push Notifications Unavailable" checked={false} disabled />;
   }
 
   const togglePush = async () => {
@@ -59,17 +59,13 @@ export function PushNotificationsButton() {
     }
   };
 
-  if (isSubscribed) {
-    return (
-      <Button fullWidth loading={isBusy} onClick={togglePush}>
-        Push Notifications Enabled
-      </Button>
-    );
-  }
-
   return (
-    <Button fullWidth variant="outline" loading={isBusy} onClick={togglePush}>
-      Enable Push Notifications
-    </Button>
+    <Switch
+      size="lg"
+      label={isSubscribed ? "Push Notifications Enabled" : "Enable Push Notifications"}
+      checked={isSubscribed}
+      disabled={isBusy}
+      onChange={togglePush}
+    />
   );
 }

--- a/client/src/tests/components/PushNotificationsButton.test.tsx
+++ b/client/src/tests/components/PushNotificationsButton.test.tsx
@@ -23,6 +23,10 @@ const mockUseDisablePushNotifications = vi.mocked(notificationService.useDisable
 
 const SUBSCRIBED_FLAG = "nf-push-subscribed";
 
+// Mantine Switch renders an <input type="checkbox" role="switch">. A helper
+// keeps the assertions readable across the on/off/unavailable states.
+const switchInput = () => screen.getByRole("switch");
+
 describe("PushNotificationsButton", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,58 +46,67 @@ describe("PushNotificationsButton", () => {
     mockUsePushAvailable.mockReturnValue({ data: undefined, isLoading: true } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
   });
 
-  it("shows an unavailable button when the server does not support push", () => {
+  it("renders a disabled, unchecked switch when the server does not support push", () => {
     mockUsePushAvailable.mockReturnValue({ data: false, isLoading: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.getByRole("button", { name: /push notifications unavailable/i })).toBeDisabled();
+    expect(switchInput()).toBeDisabled();
+    expect(switchInput()).not.toBeChecked();
+    expect(screen.getByText(/push notifications unavailable/i)).toBeInTheDocument();
   });
 
-  it("shows an unavailable button when the browser is unsupported", () => {
+  it("renders a disabled, unchecked switch when the browser is unsupported", () => {
     mockGetPushPermission.mockReturnValue("unsupported");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.getByRole("button", { name: /push notifications unavailable/i })).toBeDisabled();
+    expect(switchInput()).toBeDisabled();
+    expect(switchInput()).not.toBeChecked();
+    expect(screen.getByText(/push notifications unavailable/i)).toBeInTheDocument();
   });
 
-  it("shows an unavailable button when permission was denied", () => {
+  it("renders a disabled, unchecked switch when permission was denied", () => {
     mockGetPushPermission.mockReturnValue("denied");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.getByRole("button", { name: /push notifications unavailable/i })).toBeDisabled();
+    expect(switchInput()).toBeDisabled();
+    expect(switchInput()).not.toBeChecked();
+    expect(screen.getByText(/push notifications unavailable/i)).toBeInTheDocument();
   });
 
-  it("shows an 'Enable' button when not subscribed", () => {
+  it("renders an unchecked switch with an Enable label when not subscribed", () => {
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.getByRole("button", { name: /enable push notifications/i })).toBeInTheDocument();
+    expect(switchInput()).not.toBeDisabled();
+    expect(switchInput()).not.toBeChecked();
+    expect(screen.getByText(/enable push notifications/i)).toBeInTheDocument();
   });
 
-  it("shows an 'Enabled' button when locally subscribed and permission is granted", () => {
+  it("renders a checked switch with an Enabled label when subscribed and permission is granted", () => {
     localStorage.setItem(SUBSCRIBED_FLAG, "1");
     mockGetPushPermission.mockReturnValue("granted");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.getByRole("button", { name: /push notifications enabled/i })).toBeInTheDocument();
+    expect(switchInput()).toBeChecked();
+    expect(screen.getByText(/push notifications enabled/i)).toBeInTheDocument();
   });
 
-  it("enables push notifications on click and persists the subscribed flag", async () => {
+  it("enables push notifications on toggle and persists the subscribed flag", async () => {
     const mutateAsync = vi.fn().mockResolvedValue("endpoint");
     mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(screen.getByRole("button", { name: /enable push notifications/i }));
+    fireEvent.click(switchInput());
     await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
     await waitFor(() => expect(localStorage.getItem(SUBSCRIBED_FLAG)).toBe("1"));
   });
 
-  it("disables push notifications on click and clears the subscribed flag", async () => {
+  it("disables push notifications on toggle and clears the subscribed flag", async () => {
     localStorage.setItem(SUBSCRIBED_FLAG, "1");
     const mutateAsync = vi.fn().mockResolvedValue(undefined);
     mockUseDisablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("granted");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(screen.getByRole("button", { name: /push notifications enabled/i }));
+    fireEvent.click(switchInput());
     await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
     await waitFor(() => expect(localStorage.getItem(SUBSCRIBED_FLAG)).toBeNull());
   });
@@ -103,7 +116,7 @@ describe("PushNotificationsButton", () => {
     mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(screen.getByRole("button", { name: /enable push notifications/i }));
+    fireEvent.click(switchInput());
     await waitFor(() => expect(screen.getByText("Boom")).toBeInTheDocument());
   });
 
@@ -112,7 +125,7 @@ describe("PushNotificationsButton", () => {
     mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(screen.getByRole("button", { name: /enable push notifications/i }));
+    fireEvent.click(switchInput());
     await waitFor(() =>
       expect(screen.getByText(/something went wrong. please try again/i)).toBeInTheDocument()
     );


### PR DESCRIPTION
## Summary

Addresses #192 — improves the discoverability of the push notifications on/off control (option (a): more discoverable single toggle).

The control was a `Button` that flipped between an outline \"Enable Push Notifications\" and a filled \"Push Notifications Enabled\" label, plus a third disabled \"Unavailable\" button. The on/off state wasn't legible at a glance — the filled/outline distinction is a visual emphasis cue, not a state cue, so users had to read the label to know whether push was on.

## Changes

- **`client/src/components/PushNotificationsButton.tsx`** — render the control as a Mantine `Switch` instead of a `Button`:
  - checked/unchecked position reads as on/off immediately
  - matches the PDS Sync `Switch` on the neighbouring card for a consistent affordance across the settings page
  - the unavailable state is a disabled, unchecked switch — clearly \"off, and you can't turn it on here\"
  - the busy state disables the switch (Mantine 9 `Switch` has no `loading` prop)
- **`client/src/tests/components/PushNotificationsButton.test.tsx`** — updated assertions from button role/name to switch role + checked state; same 10 cases covered.

The underlying enable/disable flow (`createPushSubscription` / `cancelPushSubscription`, the `nf-push-subscribed` localStorage flag, the server subscribe/unsubscribe endpoints) is unchanged. No schema or server changes.

## Out of scope (per #192)

- The existing single Enable/Disable control stays on `Settings.tsx` — not moved.
- No per-notification-type toggles (option b) or in-notification opt-out (option c).

## Test plan

- [x] `npx vitest run` in `client/` — 471 pass across 31 files (incl. the 10 updated `PushNotificationsButton` tests and the `Settings` page tests that render it)
- [x] `npm run typecheck` in `client/` — clean
- [x] pre-push hook (prettier + oxlint + typecheck on client + server) — passed

Addresses #192