### PR TITLE
fix: restore missing left app boundary border on wide screens

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -47,14 +47,36 @@ body {
    width — but an ancestor `transform` would also make them scroll with the
    page (a transformed element becomes the containing block for fixed
    descendants, turning fixed into absolute). So the wrapper does NOT use a
-   transform; instead the fixed elements are centered/clipped directly below. */
+   transform; instead the fixed elements are centered/clipped directly below.
+
+   The column's left/right divider lines are drawn via the ::before overlay
+   below, NOT via border-left/right on .app-shell-boundary itself. A parent's
+   border paints *below* its fixed descendants, so the opaque fixed navbar
+   (repositioned to the column's left edge on wide screens — see
+   .mantine-AppShell-navbar below) would paint over a real border-left and
+   make the left divider vanish (the right one survived because nothing
+   covers it). The overlay sits at z-index 200, above the navbar (101), so
+   both dividers render. */
 .app-shell-boundary {
   max-width: 1400px;
   margin: 0 auto;
   min-height: 100dvh;
   position: relative;
+}
+
+.app-shell-boundary::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1400px;
+  max-width: 100vw;
+  pointer-events: none;
   border-left: 1px solid var(--nf-app-boundary-border);
   border-right: 1px solid var(--nf-app-boundary-border);
+  z-index: 200;
 }
 
 /* Center + clip the fixed header to the 1400px column without an ancestor


### PR DESCRIPTION
## Summary

On wide screens (≥1400px), the app renders as a centered column with thin left/right divider lines framing it. The **left divider was missing** — only the right one showed.

## Root cause

The dividers were drawn via `border-left`/`border-right` on `.app-shell-boundary`. But on wide screens, the fixed navbar is repositioned to the column's left edge (`left: calc(50% - 700px)`, `z-index: 101`) with an opaque background. A parent's border paints **below** its `position: fixed` descendants, so the navbar painted over the left border. The right border survived because nothing covers it.

This was a side effect of `6bc7cba` (already on `main`), which removed the wrapper's `transform` to keep the header truly viewport-fixed and repositioned the navbar flush to the column edge. It's unrelated to #192/#198.

## Fix

Replace the parent border with a `.app-shell-boundary::before` overlay that draws both vertical lines at `position: fixed; z-index: 200` — above the navbar (101) and header (100) — so both dividers render. `pointer-events: none` keeps it non-interactive. Below 1400px the column is full-width, so the overlay's borders sit at the viewport edges and produce no spurious centered line (behavior unchanged for mobile/desktop-wide).

## Verification

Pixel-sampled the rendered edges at 1600px viewport with Playwright:

| Edge | Before | After |
|------|--------|-------|
| Left (x=100, through navbar) | `(253,248,255)` — navbar bg, no divider | `(229,225,236)` — light-mode boundary color ✓ |
| Right (x=1499) | divider present | divider present ✓ |

Dark mode confirmed too: left edge now `(37,36,59)` (boundary color over `#0b0a24`), symmetric with the right.

Also confirmed:
- Narrow viewport (1280px): column is full-width, overlay borders sit at viewport edges — no regression.
- No ancestor creates a competing stacking context (no `transform`/`filter`/`opacity`/`will-change`), so the overlay's `z-index: 200` reliably paints above the navbar.

## Test plan

- [x] `npm run typecheck` in `client/` — clean
- [x] `npx vitest run src/tests/pages/Settings.test.tsx` — 21/21 pass
- [x] pre-push hook (prettier + oxlint + typecheck on client + server) — passed