### PR TITLE
Replace bulky toggle switches with buttons on the Settings page

### DIFF
--- a/client/src/components/PushNotificationsButton.tsx
+++ b/client/src/components/PushNotificationsButton.tsx
@@ -1,4 +1,4 @@
-import { Loader, Switch } from "@mantine/core";
+import { Button, Loader } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useState } from "react";
 
@@ -33,10 +33,11 @@ export function PushNotificationsButton() {
   if (isCheckingAvailability) return <Loader size="sm" />;
 
   if (isUnavailable) {
-    // A disabled switch reads as "off, and you can't turn it on here" more
-    // clearly than the old inert button, and matches the PDS Sync control's
-    // affordance on the neighbouring card.
-    return <Switch size="lg" label="Push Notifications Unavailable" checked={false} disabled />;
+    return (
+      <Button fullWidth variant="outline" disabled>
+        Push Notifications Unavailable
+      </Button>
+    );
   }
 
   const togglePush = async () => {
@@ -60,12 +61,13 @@ export function PushNotificationsButton() {
   };
 
   return (
-    <Switch
-      size="lg"
-      label={isSubscribed ? "Push Notifications Enabled" : "Enable Push Notifications"}
-      checked={isSubscribed}
-      disabled={isBusy}
-      onChange={togglePush}
-    />
+    <Button
+      fullWidth
+      variant={isSubscribed ? "filled" : "outline"}
+      loading={isBusy}
+      onClick={togglePush}
+    >
+      {isSubscribed ? "Push Notifications Enabled" : "Enable Push Notifications"}
+    </Button>
   );
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -5,7 +5,6 @@ import {
   Paper,
   Text,
   Button,
-  Switch,
   Alert,
   Skeleton,
   Loader,
@@ -189,23 +188,19 @@ export default function Settings() {
                 ) : settingsError ? (
                   settingsLoadError
                 ) : (
-                  <Switch
-                    size="lg"
-                    label="Enable PDS Sync"
-                    checked={Boolean(userSettings?.pdsSyncEnabled)}
-                    onChange={(event) => {
+                  <Button
+                    fullWidth
+                    variant={userSettings?.pdsSyncEnabled ? "filled" : "outline"}
+                    loading={updateSettings.isPending}
+                    onClick={() => {
                       updateSettings.mutate({
-                        pdsSyncEnabled: event.currentTarget.checked,
+                        pdsSyncEnabled: !userSettings?.pdsSyncEnabled,
                         imageTheme: userSettings?.imageTheme || "default",
                       });
                     }}
-                    disabled={updateSettings.isPending}
-                    styles={{
-                      label: { opacity: 1, color: "inherit" },
-                      track: { opacity: updateSettings.isPending ? 0.7 : 1 },
-                      thumb: { opacity: updateSettings.isPending ? 0.7 : 1 },
-                    }}
-                  />
+                  >
+                    {userSettings?.pdsSyncEnabled ? "PDS Sync Enabled" : "Enable PDS Sync"}
+                  </Button>
                 )}
               </SettingsCard>
             </Grid.Col>

--- a/client/src/tests/components/PushNotificationsButton.test.tsx
+++ b/client/src/tests/components/PushNotificationsButton.test.tsx
@@ -23,9 +23,8 @@ const mockUseDisablePushNotifications = vi.mocked(notificationService.useDisable
 
 const SUBSCRIBED_FLAG = "nf-push-subscribed";
 
-// Mantine Switch renders an <input type="checkbox" role="switch">. A helper
-// keeps the assertions readable across the on/off/unavailable states.
-const switchInput = () => screen.getByRole("switch");
+// Renders as a plain <button>, mirroring the rest of the settings actions.
+const toggleButton = (name: RegExp) => screen.getByRole("button", { name });
 
 describe("PushNotificationsButton", () => {
   beforeEach(() => {
@@ -46,48 +45,39 @@ describe("PushNotificationsButton", () => {
     mockUsePushAvailable.mockReturnValue({ data: undefined, isLoading: true } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("renders a disabled, unchecked switch when the server does not support push", () => {
+  it("renders a disabled button when the server does not support push", () => {
     mockUsePushAvailable.mockReturnValue({ data: false, isLoading: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    expect(switchInput()).toBeDisabled();
-    expect(switchInput()).not.toBeChecked();
-    expect(screen.getByText(/push notifications unavailable/i)).toBeInTheDocument();
+    expect(toggleButton(/push notifications unavailable/i)).toBeDisabled();
   });
 
-  it("renders a disabled, unchecked switch when the browser is unsupported", () => {
+  it("renders a disabled button when the browser is unsupported", () => {
     mockGetPushPermission.mockReturnValue("unsupported");
     renderWithProviders(<PushNotificationsButton />);
-    expect(switchInput()).toBeDisabled();
-    expect(switchInput()).not.toBeChecked();
-    expect(screen.getByText(/push notifications unavailable/i)).toBeInTheDocument();
+    expect(toggleButton(/push notifications unavailable/i)).toBeDisabled();
   });
 
-  it("renders a disabled, unchecked switch when permission was denied", () => {
+  it("renders a disabled button when permission was denied", () => {
     mockGetPushPermission.mockReturnValue("denied");
     renderWithProviders(<PushNotificationsButton />);
-    expect(switchInput()).toBeDisabled();
-    expect(switchInput()).not.toBeChecked();
-    expect(screen.getByText(/push notifications unavailable/i)).toBeInTheDocument();
+    expect(toggleButton(/push notifications unavailable/i)).toBeDisabled();
   });
 
-  it("renders an unchecked switch with an Enable label when not subscribed", () => {
+  it("renders an Enable button when not subscribed", () => {
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    expect(switchInput()).not.toBeDisabled();
-    expect(switchInput()).not.toBeChecked();
-    expect(screen.getByText(/enable push notifications/i)).toBeInTheDocument();
+    expect(toggleButton(/enable push notifications/i)).not.toBeDisabled();
   });
 
-  it("renders a checked switch with an Enabled label when subscribed and permission is granted", () => {
+  it("renders an Enabled button when subscribed and permission is granted", () => {
     localStorage.setItem(SUBSCRIBED_FLAG, "1");
     mockGetPushPermission.mockReturnValue("granted");
     renderWithProviders(<PushNotificationsButton />);
-    expect(switchInput()).toBeChecked();
-    expect(screen.getByText(/push notifications enabled/i)).toBeInTheDocument();
+    expect(toggleButton(/push notifications enabled/i)).toBeInTheDocument();
   });
 
   it("enables push notifications on toggle and persists the subscribed flag", async () => {
@@ -95,7 +85,7 @@ describe("PushNotificationsButton", () => {
     mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(switchInput());
+    fireEvent.click(toggleButton(/enable push notifications/i));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
     await waitFor(() => expect(localStorage.getItem(SUBSCRIBED_FLAG)).toBe("1"));
   });
@@ -106,7 +96,7 @@ describe("PushNotificationsButton", () => {
     mockUseDisablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("granted");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(switchInput());
+    fireEvent.click(toggleButton(/push notifications enabled/i));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
     await waitFor(() => expect(localStorage.getItem(SUBSCRIBED_FLAG)).toBeNull());
   });
@@ -116,7 +106,7 @@ describe("PushNotificationsButton", () => {
     mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(switchInput());
+    fireEvent.click(toggleButton(/enable push notifications/i));
     await waitFor(() => expect(screen.getByText("Boom")).toBeInTheDocument());
   });
 
@@ -125,7 +115,7 @@ describe("PushNotificationsButton", () => {
     mockUseEnablePushNotifications.mockReturnValue({ mutateAsync, isPending: false } as any);
     mockGetPushPermission.mockReturnValue("default");
     renderWithProviders(<PushNotificationsButton />);
-    fireEvent.click(switchInput());
+    fireEvent.click(toggleButton(/enable push notifications/i));
     await waitFor(() =>
       expect(screen.getByText(/something went wrong. please try again/i)).toBeInTheDocument()
     );

--- a/client/src/tests/pages/Settings.test.tsx
+++ b/client/src/tests/pages/Settings.test.tsx
@@ -197,8 +197,8 @@ describe("Settings page", () => {
     } as any);
     renderWithProviders(<Settings />);
 
-    // Mantine Switch renders as a labelled checkbox input
-    fireEvent.click(screen.getByLabelText(/enable pds sync/i));
+    // pdsSyncEnabled is truthy, so the toggle button reads "PDS Sync Enabled"
+    fireEvent.click(screen.getByRole("button", { name: /pds sync enabled/i }));
 
     await waitFor(() => {
       expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({ pdsSyncEnabled: false }));
@@ -624,14 +624,14 @@ describe("Settings page", () => {
     } as any);
     renderWithProviders(<Settings />);
 
-    fireEvent.click(screen.getByLabelText(/enable pds sync/i));
+    fireEvent.click(screen.getByRole("button", { name: /pds sync enabled/i }));
 
     await waitFor(() => {
       expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining({ imageTheme: "default" }));
     });
   });
 
-  it("renders PDS sync switch with reduced opacity when updateSettings is pending", () => {
+  it("renders PDS sync button in a loading state when updateSettings is pending", () => {
     mockUseUpdateUserSettings.mockReturnValue({
       mutate: vi.fn(),
       isPending: true,
@@ -652,8 +652,8 @@ describe("Settings page", () => {
       isLoading: false,
     } as any);
     renderWithProviders(<Settings />);
-    // isPending=true covers the 0.7 opacity ternary branches in the Switch styles
-    expect(screen.getByLabelText(/enable pds sync/i)).toBeInTheDocument();
+    // isPending=true covers the Button `loading` branch
+    expect(screen.getByRole("button", { name: /pds sync enabled/i })).toBeInTheDocument();
   });
 
   it("shows skeleton for daily notifications card while bot-follow status is loading", () => {

--- a/e2e/web/settings.spec.ts
+++ b/e2e/web/settings.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from "@playwright/test";
 
 test.use({ storageState: "e2e/.auth/user.json" });
 
-// Settings happy paths. The PDS-sync switch writes through to the server
-// (POST /settings); we read its initial checked state from the DOM, toggle it,
+// Settings happy paths. The PDS-sync toggle writes through to the server
+// (POST /settings); we read its initial label from the DOM, toggle it,
 // assert it flipped, then toggle it back to leave the account untouched.
 
 test.beforeEach(async ({ page }) => {
@@ -22,26 +22,28 @@ test("settings page renders key cards", async ({ page }) => {
   await expect(page.getByText("Push Notifications", { exact: true })).toBeVisible();
 });
 
-test("PDS sync switch toggles and is restored afterwards", async ({ page }) => {
-  const sync = page.getByRole("switch", { name: "Enable PDS Sync" });
+test("PDS sync toggle flips label and is restored afterwards", async ({ page }) => {
+  const sync = page.getByRole("button", { name: /pds sync/i });
   await expect(sync).toBeVisible({ timeout: 10_000 });
-  // Wait for settings to load so the switch reflects the server value.
+  // Wait for settings to load so the button reflects the server value.
   await expect(sync).toBeEnabled({ timeout: 10_000 });
-  const initial = await sync.isChecked();
+  const enabledLabel = page.getByRole("button", { name: "PDS Sync Enabled" });
+  const disabledLabel = page.getByRole("button", { name: "Enable PDS Sync" });
+  const initiallyEnabled = await enabledLabel.isVisible();
 
   await sync.click();
-  // UI state flips to the opposite of the initial value.
-  if (initial) {
-    await expect(sync).not.toBeChecked({ timeout: 10_000 });
+  // Label flips to the opposite of the initial value.
+  if (initiallyEnabled) {
+    await expect(disabledLabel).toBeVisible({ timeout: 10_000 });
   } else {
-    await expect(sync).toBeChecked({ timeout: 10_000 });
+    await expect(enabledLabel).toBeVisible({ timeout: 10_000 });
   }
 
   // Restore the original state so the shared account is untouched.
   await sync.click();
-  if (initial) {
-    await expect(sync).toBeChecked({ timeout: 10_000 });
+  if (initiallyEnabled) {
+    await expect(enabledLabel).toBeVisible({ timeout: 10_000 });
   } else {
-    await expect(sync).not.toBeChecked({ timeout: 10_000 });
+    await expect(disabledLabel).toBeVisible({ timeout: 10_000 });
   }
 });


### PR DESCRIPTION
## Summary

- The PDS Sync and Push Notifications settings cards used large Mantine `Switch` controls (`size="lg"`), which looked oversized and out of place next to the plain `Button`-based cards everywhere else on the Settings page.
- Both are now toggling `Button`s — filled when the setting is on, outline when off — matching the visual style already used by the Install/Feed/Delete-data cards and the existing on/off pattern on the Daily Notifications card.
- `Button`'s built-in `loading` prop now drives the pending/busy state instead of manually tweaking track/thumb opacity styles.

## Test plan

- [x] `npm run test` (client) for `Settings.test.tsx` and `PushNotificationsButton.test.tsx` — updated assertions to query the new buttons by accessible name, all passing
- [x] Full client test suite — passes except one pre-existing, unrelated failure in `Messages.test.tsx` (scroll-into-view viewport test), confirmed to fail identically on `main` before this change
- [x] `npm run lint` — no new warnings introduced by this change
- [x] `tsc --noEmit` (via pre-commit hook) — passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01PLNv9JwRoCZKJEzwTSJr9s)_