### PR TITLE
fix: stop PWA update from silently reloading in-progress sessions

### DIFF
--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -1,6 +1,5 @@
 /// <reference lib="webworker" />
 
-import { clientsClaim } from "workbox-core";
 import { precacheAndRoute } from "workbox-precaching";
 import { registerRoute, NavigationRoute } from "workbox-routing";
 import { NetworkFirst, CacheFirst } from "workbox-strategies";
@@ -13,10 +12,15 @@ declare const self: ServiceWorkerGlobalScope;
 // by vite-plugin-pwa's `injectManifest` strategy).
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Take over from older workers immediately so updates apply on the next reload
-// rather than waiting for every tab to close (matches the prior sw.js behavior).
+// Activate a newly installed worker without waiting for every tab to close,
+// but deliberately skip clientsClaim(): claiming already-open tabs fires a
+// `controllerchange` event that vite-plugin-pwa's autoUpdate registration
+// (main.tsx) responds to with an immediate, unprompted `location.reload()` —
+// so any tab open when a new deploy ships gets silently reloaded seconds into
+// the session. Without clientsClaim(), the new worker only takes control of
+// tabs opened/reloaded after activation, so the update applies on the next
+// natural navigation instead of interrupting an in-progress session.
 self.skipWaiting();
-clientsClaim();
 
 // --- Production-only runtime caching ---------------------------------------
 // In dev, vite-plugin-pwa serves the SW with devOptions that intentionally keep


### PR DESCRIPTION
## Summary

Reported symptom: opening the app fetches `/session`, then a second later it fetches `/session` again.

Root cause: `client/src/sw.ts` called `clientsClaim()` unconditionally alongside `self.skipWaiting()`. That made a newly-installed service worker take control of already-open tabs immediately, which fires a `controllerchange` event. `registerType: "autoUpdate"` in `client/vite.config.ts` (introduced by #193, the recent hand-rolled-SW → vite-plugin-pwa migration) responds to that event with an unprompted `location.reload()` — so any tab open when a new deploy ships gets silently reloaded a few seconds into the session, remounting the app and refetching `/session` a second time. Not a Railway caching issue.

## Change

- `client/src/sw.ts`: drop `clientsClaim()` (keep `self.skipWaiting()`). The new SW still activates promptly, but only takes control of tabs opened/reloaded after activation — so a deploy no longer force-reloads a session already in progress; the update applies on the next natural navigation instead.

## Test plan

- [x] `npm run build` (client) — builds cleanly, confirmed `clientsClaim` no longer appears in the emitted `dist/sw.js`
- [x] `npm run lint` (client) — no new warnings/errors
- [x] `npm run test` (client) — 470/471 passing; the one failure (`Messages.test.tsx` scroll-into-view test) reproduces on `main` too when run as part of the full suite and passes in isolation — pre-existing flake, unrelated to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvuDsRQCWC23C9tLMwgt1h)_