### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+Closes #
+
+## Scope
+
+- [ ] client
+- [ ] server
+- [ ] opengraph-service
+- [ ] docker / infra (caddy, anubis)
+- [ ] docs
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] Unit/integration tests pass locally
+- [ ] E2E (Playwright) passes for affected flows
+- [ ] Docker smoke test passes if server/infra changed
+- [ ] Manually verified against a real Bluesky/AT Protocol account
+
+## Checklist
+
+- [ ] No secrets, DIDs, tokens, or `.env` values committed
+- [ ] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens
+- [ ] Docs updated if user-facing behavior or setup changed


### PR DESCRIPTION
Adds `.github/pull_request_template.md` covering client/server/infra scope, E2E, Docker smoke test, and a security-sensitive-change flag so PRs start with a consistent structure.