### PR TITLE
chore: declare repo-level Claude Code plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "typescript-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
     "github@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ dist-ssr
 *.sqlite
 
 #claude
-.claude
-settings.local.json
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 
 # Playwright
 playwright-report/


### PR DESCRIPTION
## Summary
- Adds `typescript-lsp`, `playwright`, `github`, `security-guidance`, `context7`, `claude-md-management`, and `frontend-design` to `.claude/settings.json` `enabledPlugins`
- Un-ignores `.claude/settings.json` in `.gitignore` (keeps `.claude/settings.local.json` ignored)
- So anyone cloning the repo with Claude Code picks up the relevant skills/LSPs automatically, without a manual install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)