### PR TITLE
Abstract data layer onto bun:sqlite; eliminate any from non-test source

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -241,14 +241,16 @@ jobs:
         working-directory: server
         continue-on-error: true
         run: |
-          # The suite is written for node:test + tsx + mock.module; Bun's
-          # runner differs. Capture whatever happens as findings.
-          bun --experimental-test-module-mocks \
-              --import ./src/tests/test-bootstrap.js \
-              --import tsx \
-              --test 'src/**/*.test.ts' > /tmp/bun-runtime-test-output.txt 2>&1 || true
+          # Bun's native `bun test` (not `bun --test`) recognizes node:test's
+          # describe/test/before/after, but does NOT implement the `mock` API
+          # (mock.fn / mock.module), which 13/14 test files use for DB/agent
+          # faking. So the suite is expected to mostly fail here today; this
+          # step captures the real pass/fail split as findings rather than a
+          # silent error. Tracked by #263 as out of scope (mock migration).
+          bun test --preload ./src/tests/test-bootstrap.js src/tests/ \
+              > /tmp/bun-runtime-test-output.txt 2>&1 || true
           {
-            echo "<details><summary>Test runner attempt</summary>"
+            echo "<details><summary>Test runner attempt (expected to mostly fail — see note)</summary>"
             echo ""
             echo '```'
             tail -n 40 /tmp/bun-runtime-test-output.txt

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -154,15 +154,16 @@ jobs:
         if: steps.server-tests.outcome == 'failure'
         run: exit 1
 
-  # Non-blocking canary for issue #251: validate the server's native/SDK deps
-  # under the Bun runtime. Known incompatible as of the findings in the pilot
-  # PR (better-sqlite3 is unsupported by Bun; node:test mock.module patterns
-  # don't translate). This job exists to surface regressions — if Bun ships
-  # support, the probe below will start passing and the canary can be promoted.
+  # Canary for issues #251/#263: validate the server's deps under the Bun
+  # runtime. The SQLite blocker from #251 (better-sqlite3 is unsupported by
+  # Bun) is resolved by abstracting the data layer onto bun:sqlite (#263), so
+  # the SQLite probe is now a real gate — a regression there fails this job.
+  # The node:test runner remains incompatible under Bun (mock.module patterns,
+  # out of scope for #263), so that step keeps its own continue-on-error and
+  # stays informational.
   server-tests-bun-runtime:
     name: Server Tests (Bun runtime canary)
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4
@@ -175,32 +176,59 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Probe native/SDK deps under Bun runtime
+      - name: Probe native/SDK deps + SQLite data layer under Bun runtime
         id: probe
         working-directory: server
+        env:
+          # createDb's SQLite branch pulls #/lib/env, which requires these at
+          # load time. Mirror src/tests/test-bootstrap.js's dummy values.
+          NODE_ENV: test
+          OAUTH_TOKEN_SECRET: 0123456789abcdef0123456789abcdef
         run: |
-          set +e
           {
             echo "## Bun runtime canary — dependency probe"
             echo
             echo "Each line shows whether the module loads + exercises under Bun."
             echo
           } > "$GITHUB_STEP_SUMMARY"
-          for spec in better-sqlite3 sharp web-push; do
+
+          # SQLite data layer — the unblocked path from #263. This MUST print
+          # OK; if it regresses the whole canary should fail (acceptance #2).
+          sqlite_out=$(bun -e "import('./src/database/db.ts').then(async ({createDb,migrateToLatest})=>{const db=await createDb(':memory:');await migrateToLatest(db);await db.insertInto('message').values({tid:'t1',message:'hi',createdAt:'2024-01-01',recipient:'did:web:x'}).execute();const row=await db.selectFrom('message').selectAll().executeTakeFirstOrThrow();await db.destroy();if(row.tid!=='t1')throw new Error('row mismatch '+JSON.stringify(row));console.log('OK',JSON.stringify(row))}).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1)
+          echo "$sqlite_out" | tee /dev/stderr >/dev/null
+          {
+            echo "<details><summary><code>bun-sqlite-data-layer</code> (acceptance #263)</summary>"
+            echo ""
+            echo '```'
+            echo "$sqlite_out"
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "sqlite_ok=$(echo "$sqlite_out" | grep -c '^OK ')" >> "$GITHUB_OUTPUT"
+
+          # The remaining probes are informational; they don't gate the job.
+          for spec in sharp web-push; do
             echo "<details><summary><code>${spec}</code></summary>" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
-            if [ "$spec" = "better-sqlite3" ]; then
-              bun -e "import('better-sqlite3').then(m=>{const db=new (m.default)(':memory:');db.exec('CREATE TABLE t(x)');db.prepare('INSERT INTO t VALUES (?)').run(1);console.log('OK',db.prepare('SELECT x FROM t').get())}).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1
-            elif [ "$spec" = "sharp" ]; then
-              bun -e "import('sharp').then(m=>console.log('OK sharp',m.default.versions.sharp)).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1
+            if [ "$spec" = "sharp" ]; then
+              bun -e "import('sharp').then(m=>console.log('OK sharp',m.default.versions.sharp)).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1 || true
             elif [ "$spec" = "web-push" ]; then
-              bun -e "import('web-push').then(m=>console.log('OK web-push',typeof m.generateVAPIDKeys)).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1
+              bun -e "import('web-push').then(m=>console.log('OK web-push',typeof m.generateVAPIDKeys)).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1 || true
             fi
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "</details>" >> "$GITHUB_STEP_SUMMARY"
           done
+
+          # Gate the SQLite path specifically. A regression here fails the job;
+          # the node:test-under-Bun step below keeps its own continue-on-error
+          # (still expected to fail, out of scope per #263).
+          if [ "${sqlite_ok}" != "1" ]; then
+            echo "::error::SQLite data layer did not print OK under Bun (regression of #263)"
+            exit 1
+          fi
 
       - name: Attempt server test suite under Bun runtime
         id: bun-tests

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -192,9 +192,14 @@ jobs:
             echo
           } > "$GITHUB_STEP_SUMMARY"
 
-          # SQLite data layer — the unblocked path from #263. This MUST print
-          # OK; if it regresses the whole canary should fail (acceptance #2).
+          # SQLite data layer — the unblocked path from #263. The bun command
+          # exits non-zero on any failure (mismatch or thrown error), and prints
+          # "OK" on success. We gate on the exit code (authoritative) and also
+          # confirm "OK" appeared, since the dotenv banner can prepend lines.
+          set +e
           sqlite_out=$(bun -e "import('./src/database/db.ts').then(async ({createDb,migrateToLatest})=>{const db=await createDb(':memory:');await migrateToLatest(db);await db.insertInto('message').values({tid:'t1',message:'hi',createdAt:'2024-01-01',recipient:'did:web:x'}).execute();const row=await db.selectFrom('message').selectAll().executeTakeFirstOrThrow();await db.destroy();if(row.tid!=='t1')throw new Error('row mismatch '+JSON.stringify(row));console.log('OK',JSON.stringify(row))}).catch(e=>{console.error('FAIL',e.message);process.exit(1)})" 2>&1)
+          sqlite_exit=$?
+          set -e
           echo "$sqlite_out" | tee /dev/stderr >/dev/null
           {
             echo "<details><summary><code>bun-sqlite-data-layer</code> (acceptance #263)</summary>"
@@ -205,7 +210,6 @@ jobs:
             echo ""
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "sqlite_ok=$(echo "$sqlite_out" | grep -c '^OK ')" >> "$GITHUB_OUTPUT"
 
           # The remaining probes are informational; they don't gate the job.
           for spec in sharp web-push; do
@@ -222,11 +226,13 @@ jobs:
             echo "</details>" >> "$GITHUB_STEP_SUMMARY"
           done
 
-          # Gate the SQLite path specifically. A regression here fails the job;
-          # the node:test-under-Bun step below keeps its own continue-on-error
-          # (still expected to fail, out of scope per #263).
-          if [ "${sqlite_ok}" != "1" ]; then
-            echo "::error::SQLite data layer did not print OK under Bun (regression of #263)"
+          # Gate the SQLite path. The bun command's exit code is authoritative
+          # (non-zero means it threw or the row mismatched); the OK-string check
+          # is a belt-and-suspenders confirmation. A regression here fails the
+          # job; the node:test-under-Bun step below keeps its own
+          # continue-on-error (still expected to fail, out of scope per #263).
+          if [ "$sqlite_exit" -ne 0 ] || ! echo "$sqlite_out" | grep -q 'OK '; then
+            echo "::error::SQLite data layer did not pass under Bun (regression of #263)"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ npm workspaces with two packages:
 - `client/` — React + Vite 7 + TypeScript SPA (Mantine UI 8, React Query, React Router)
 - `server/` — Express + TypeScript API (Kysely ORM, AT Protocol SDK)
 
-**Bun is the package manager** (single root `bun.lock`; installer swapped from npm per issue #250). **Node remains the runtime** for both the client (Vite dev/build, Vitest) and the production server. The Bun runtime as a server execution environment is tracked separately by a non-blocking CI canary (issue #251) — `better-sqlite3` is currently unsupported by Bun, so the production server must stay on Node.
+**Bun is the package manager** (single root `bun.lock`; installer swapped from npm per issue #250). **Node remains the runtime** for the client (Vite dev/build, Vitest) and the production server. The Bun runtime as a server execution environment is tracked by a CI canary (issues #251/#263) — the `better-sqlite3` blocker was resolved by abstracting the dev SQLite driver onto `bun:sqlite` (#263); the remaining blocker is `node:test`'s `mock.module` patterns not translating to Bun's runner.
 
 Root-level `bun run dev` runs both workspaces concurrently via `concurrently` (the html-to-image image renderer is also started this way but remains a standalone npm package outside the workspace).
 
@@ -73,7 +73,7 @@ Session is intentionally thin — Bluesky OAuth acts as the authorization proxy.
 
 ### Database
 
-Kysely ORM. SQLite in development (`:memory:` by default), PostgreSQL in production (when `POSTGRESQL_URL` is set).
+Kysely ORM. SQLite in development (`:memory:` by default), PostgreSQL in production (when `POSTGRESQL_URL` is set). The dev SQLite driver is runtime-gated (`src/database/db.ts`): `better-sqlite3` under Node, `bun:sqlite` behind a small adapter under Bun (so the server can run under the Bun runtime — see #263). Kysely's `SqliteDialect` is dialect-agnostic; the adapter only bridges two `bun:sqlite` API deltas (no `reader` flag → derived from `columnNames`; variadic params → spread).
 
 Schema and migrations live entirely in `src/database/db.ts`. Add new migrations as numbered keys (`"007"`, etc.) in the `migrations` object — Kysely applies them in order at startup via `migrateToLatest()`.
 

--- a/bun.lock
+++ b/bun.lock
@@ -103,8 +103,10 @@
       "devDependencies": {
         "@atproto/lex-cli": "^0.10.6",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/bun": "1.3.14",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
+        "@types/node": "^24.10.1",
         "@types/pg": "^8.20.0",
         "@types/serve-static": "^2.2.0",
         "c8": "^12.0.0",
@@ -744,6 +746,8 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
@@ -772,7 +776,7 @@
 
     "@types/keygrip": ["@types/keygrip@1.0.6", "", {}, "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="],
 
-    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+    "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
@@ -955,6 +959,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -1940,7 +1946,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "undici_v6": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
 
@@ -2152,6 +2158,28 @@
 
     "@ts-morph/common/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
+    "@types/better-sqlite3/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/body-parser/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/connect/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/cors/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/express-serve-static-core/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/pg/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/send/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/serve-static/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/set-cookie-parser/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/web-push/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/ws/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -2171,6 +2199,10 @@
     "boxen/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "boxen/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "buffer-image-size/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "bun-types/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "chalk-template/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2195,6 +2227,8 @@
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "happy-dom/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "iron-session/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -2300,6 +2334,28 @@
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
+    "@types/better-sqlite3/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/body-parser/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/connect/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/cors/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/express-serve-static-core/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/send/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/serve-static/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/set-cookie-parser/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/web-push/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -2307,6 +2363,10 @@
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "boxen/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "buffer-image-size/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "chalk-template/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2321,6 +2381,8 @@
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -305,3 +305,11 @@ The following files are excluded from coverage metrics entirely. See the root-le
 - `src/tests/**`, `src/main.tsx`, `src/Theme.tsx` — test infra and entry point
 - `src/vite-env.d.ts` — ambient declarations
 - `src/styles/tokens.ts` — pure style constants
+
+## Runtime-gated SQLite driver (`server/src/database/db.ts`)
+
+`db.ts` is already excluded from coverage (it's the Kysely migration runner). It now also contains the runtime-gated driver selection added in #263: under Bun it constructs a small `BunSqliteDatabase`/`BunSqliteStatement` adapter that bridges `bun:sqlite` to Kysely's stock `SqliteDialect`; under Node it keeps `better-sqlite3`. The adapter is not unit-tested in the Node suite because the Bun branch can't be imported under Node (`bun:sqlite` only resolves under Bun). It is instead exercised by the `server-tests-bun-runtime` canary in `.github/workflows/Tests.yml`, which runs the real `createDb` → `migrateToLatest` → insert/select path under the Bun runtime and gates on `OK`. The Node branch continues to be covered transitively by the existing server test suite's migration runs.
+
+The two API deltas the adapter bridges (both verified locally under Bun):
+- `bun:sqlite`'s `Statement` has no `reader` flag — derived as `columnNames.length > 0`, the same rule `better-sqlite3` uses internally to set its `reader` flag.
+- `bun:sqlite`'s `Statement.all/run/iterate` take variadic params, not an array — the adapter spreads the params array Kysely passes.

--- a/server/package.json
+++ b/server/package.json
@@ -87,6 +87,8 @@
   "devDependencies": {
     "@atproto/lex-cli": "^0.10.6",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/bun": "1.3.14",
+    "@types/node": "^24.10.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/pg": "^8.20.0",
@@ -109,6 +111,7 @@
     "format": "esm",
     "splitting": false,
     "sourcemap": true,
-    "clean": true
+    "clean": true,
+    "external": ["bun:sqlite"]
   }
 }

--- a/server/src/auth/e2e-agent-store.ts
+++ b/server/src/auth/e2e-agent-store.ts
@@ -2,20 +2,26 @@
 
 // In-memory store for app-password agents created during E2E testing.
 // Only populated when E2E_TESTING=true; always empty in production/unit tests.
-import type { Agent } from "@atproto/api";
+import type { Agent, AtpAgent } from "@atproto/api";
+
+// The E2E login route builds an AtpAgent (app-password auth), while the OAuth
+// path produces an Agent. Both expose the same API surface the app calls
+// (getProfile, post, com.atproto.repo.*, app.bsky.*), so the store accepts
+// either and callers treat the result as an Agent-compatible client.
+export type E2EAgent = Agent | AtpAgent;
 
 interface E2EEntry {
-  agent: Agent;
+  agent: E2EAgent;
   handle: string;
 }
 
 const store = new Map<string, E2EEntry>();
 
-export function setE2EAgent(did: string, agent: Agent, handle: string): void {
+export function setE2EAgent(did: string, agent: E2EAgent, handle: string): void {
   store.set(did, { agent, handle });
 }
 
-export function getE2EAgent(did: string): Agent | undefined {
+export function getE2EAgent(did: string): E2EAgent | undefined {
   return store.get(did)?.agent;
 }
 

--- a/server/src/auth/session-agent.ts
+++ b/server/src/auth/session-agent.ts
@@ -1,7 +1,7 @@
 /* v8 ignore start */
 import { Agent } from "@atproto/api";
 
-import { getE2EAgent } from "./e2e-agent-store";
+import { getE2EAgent, type E2EAgent } from "./e2e-agent-store";
 
 import type { AppContext } from "../index";
 
@@ -14,7 +14,10 @@ import type { AppContext } from "../index";
  * enables multi-account switching without a fresh OAuth round-trip.
  */
 /* v8 ignore stop */
-export async function initializeAgentForDid(ctx: AppContext, did: string): Promise<Agent | null> {
+export async function initializeAgentForDid(
+  ctx: AppContext,
+  did: string
+): Promise<E2EAgent | null> {
   // E2E sessions bypass OAuth — agent is stored in-process by the e2e login route.
   const e2eAgent = getE2EAgent(did);
   if (e2eAgent) {
@@ -42,7 +45,7 @@ export async function initializeAgentForDid(ctx: AppContext, did: string): Promi
 export async function initializeAgentFromSession(
   req: Express.Request,
   ctx: AppContext
-): Promise<Agent | null> {
+): Promise<E2EAgent | null> {
   if (!req.session?.did) {
     return null;
   }

--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -9,6 +9,7 @@ import {
   toAccountEntry,
   upsertAccount,
 } from "../auth/session";
+import { errorMessage } from "../lib/errors";
 import { env } from "../lib/env";
 import { pdsRegion } from "../lib/pds-region";
 import { AuthService } from "../services/auth-service";
@@ -35,8 +36,8 @@ export class AuthController {
       const redirectUrl = await this.service.getOAuthRedirectUrl(handle);
       this.ctx.logger.info({ redirectUrl }, "OAuth authorize succeeded");
       return res.json({ redirectUrl });
-    } catch (err: any) {
-      return res.status(500).json({ error: err.message || "couldn't initiate login" });
+    } catch (err: unknown) {
+      return res.status(500).json({ error: errorMessage(err) || "couldn't initiate login" });
     }
   }
 
@@ -141,7 +142,7 @@ export class AuthController {
       let token: string;
       try {
         token = this.service.encryptDid(did);
-      } catch (e: any) {
+      } catch {
         this.ctx.logger.error("OAUTH_TOKEN_SECRET is not set");
         return res.redirect(`${env.CLIENT_URL}/login?error=server_config`);
       }
@@ -166,7 +167,7 @@ export class AuthController {
     let did: string;
     try {
       did = this.service.decryptDid(oauth_token);
-    } catch (e: any) {
+    } catch {
       this.ctx.logger.error("OAUTH_TOKEN_SECRET is not set");
       return res.status(500).json({ error: "Server misconfiguration" });
     }

--- a/server/src/controllers/message-controller.ts
+++ b/server/src/controllers/message-controller.ts
@@ -5,6 +5,7 @@ import { Logger } from "pino";
 
 import { MessageService } from "../services/message-service";
 import { NotificationService } from "../services/notification-service";
+import { errorMessage } from "../lib/errors";
 
 import type { AppContext } from "../index";
 
@@ -108,12 +109,12 @@ export class MessageController {
         replyTo
       );
       return res.json(result);
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.logger.error(
         { err, tid, did },
         "Error in /messages/respond endpoint while trying to post to Bluesky"
       );
-      return res.status(500).json({ error: err.message || "Failed to post to Bluesky" });
+      return res.status(500).json({ error: errorMessage(err) || "Failed to post to Bluesky" });
     }
   };
 
@@ -148,10 +149,11 @@ export class MessageController {
           this.logger.error({ err, did: recipient }, "Failed to send push notification")
         );
       return res.json(result);
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.logger.error({ err, recipient }, "Failed to send message");
-      return res.status(err.message.includes("not found") ? 404 : 500).json({
-        error: err.message || "Failed to send message",
+      const msg = errorMessage(err);
+      return res.status(msg.includes("not found") ? 404 : 500).json({
+        error: msg || "Failed to send message",
       });
     }
   };
@@ -169,8 +171,8 @@ export class MessageController {
     try {
       const messages = await this.messageService.getMessages(recipient);
       return res.json({ messages });
-    } catch (err: any) {
-      if (err.message.includes("not exist")) {
+    } catch (err: unknown) {
+      if (errorMessage(err).includes("not exist")) {
         return res.status(404).json({ error: "User not found (user profile does not exist)" });
       }
       this.logger.error({ err, recipient }, "Failed to fetch messages");
@@ -205,14 +207,11 @@ export class MessageController {
     try {
       await this.messageService.deleteMessage(tid, userSessionDid, agent);
       return res.json({ success: true });
-    } catch (err: any) {
-      const status = err.message.includes("not found")
-        ? 404
-        : err.message.includes("Not authorized")
-          ? 403
-          : 500;
+    } catch (err: unknown) {
+      const msg = errorMessage(err);
+      const status = msg.includes("not found") ? 404 : msg.includes("Not authorized") ? 403 : 500;
 
-      return res.status(status).json({ error: err.message || "Failed to delete message" });
+      return res.status(status).json({ error: msg || "Failed to delete message" });
     }
   };
 
@@ -247,9 +246,9 @@ export class MessageController {
       req.session = null;
       this.logger.info({ did: userSessionDid }, "Account and all data deleted");
       return res.json({ success: true });
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.logger.error({ err, did: userSessionDid }, "Failed to delete account data");
-      return res.status(500).json({ error: err.message || "Failed to delete account data" });
+      return res.status(500).json({ error: errorMessage(err) || "Failed to delete account data" });
     }
   };
 
@@ -286,11 +285,11 @@ export class MessageController {
     try {
       const syncResult = await this.messageService.syncMessages(userSessionDid, agent);
       return res.json(syncResult);
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.logger.error({ err, did: userSessionDid }, "Failed to sync messages to PDS");
       return res.status(500).json({
         error: "Failed to sync messages to PDS",
-        details: err.message,
+        details: errorMessage(err),
       });
     }
   };

--- a/server/src/controllers/profile-controller.ts
+++ b/server/src/controllers/profile-controller.ts
@@ -4,6 +4,7 @@ import { param, query } from "express-validator";
 import { Logger } from "pino";
 
 import { ProfileService } from "../services/profile-service";
+import { errorMessage } from "../lib/errors";
 
 import type { AppContext } from "../index";
 
@@ -36,8 +37,8 @@ export class ProfileController {
     try {
       const profileData = await this.profileService.getPublicProfile(did);
       return res.json(profileData);
-    } catch (err: any) {
-      if (err.message === "Profile not found") {
+    } catch (err: unknown) {
+      if (errorMessage(err) === "Profile not found") {
         return res.status(404).json({ error: "Profile not found" });
       }
       this.logger.error({ err, did }, "Failed to fetch public profile");
@@ -163,8 +164,8 @@ export class ProfileController {
     try {
       const did = await this.profileService.resolveHandleToDid(handle);
       return res.json({ did });
-    } catch (err: any) {
-      if (err.message === "Handle not found") {
+    } catch (err: unknown) {
+      if (errorMessage(err) === "Handle not found") {
         return res.status(404).json({ error: "Handle not found" });
       }
       this.logger.error({ err, handle }, "Failed to resolve handle");

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -1,3 +1,10 @@
+// bun:sqlite resolves only under the Bun runtime; @types/bun provides its types.
+// Scoped to this file rather than added to tsconfig `types` (which would pull
+// the Bun global into the whole Node project) — see issue #263. Triple-slash
+// directives are only honored before any statements in the file, so this must
+// stay above the imports below or TypeScript silently treats it as a comment.
+/// <reference types="bun" />
+
 import { Kysely, SqliteDialect, PostgresDialect, Generated } from "kysely";
 import type { Migration, MigrationProvider } from "kysely/migration";
 import { Migrator } from "kysely/migration";
@@ -79,6 +86,14 @@ export type PushSubscription = {
 type AuthStateJson = string;
 
 type AuthSessionJson = string;
+
+// Schema known to migration 005 when it backfills user_settings from
+// user_profile. Both tables expose {did, createdAt} at that point in the
+// migration sequence, so a narrow local type avoids Kysely<any>.
+type Migration005Schema = {
+  user_profile: { did: string; createdAt: string };
+  user_settings: { did: string; createdAt: string };
+};
 
 // Migrations
 
@@ -170,7 +185,9 @@ migrations["004"] = {
 };
 
 migrations["005"] = {
-  async up(db: Kysely<any>) {
+  // Typed for the backfill SELECT — user_profile (migration 003) and the
+  // freshly-created user_settings both expose {did, createdAt} at this point.
+  async up(db: Kysely<Migration005Schema>) {
     await db.schema
       .createTable("user_settings")
       .addColumn("did", "varchar", (col) => col.primaryKey())
@@ -192,19 +209,19 @@ migrations["005"] = {
 };
 
 migrations["006"] = {
-  async up(db: Kysely<any>) {
+  async up(db: Kysely<unknown>) {
     await db.schema
       .alterTable("user_settings")
       .addColumn("imageTheme", "varchar", (col) => col.notNull().defaultTo("default"))
       .execute();
   },
-  async down(db: Kysely<any>) {
+  async down(db: Kysely<unknown>) {
     await db.schema.alterTable("user_settings").dropColumn("imageTheme").execute();
   },
 };
 
 migrations["007"] = {
-  async up(db: Kysely<any>) {
+  async up(db: Kysely<unknown>) {
     await db.schema
       .createTable("push_subscription")
       .addColumn("id", "serial", (col) => col.primaryKey())
@@ -228,7 +245,7 @@ migrations["007"] = {
 };
 
 migrations["008"] = {
-  async up(db: Kysely<any>) {
+  async up(db: Kysely<unknown>) {
     // SQLite has no native ALTER TABLE for dropping/adding constraints, so
     // this rebuilds the table rather than altering it in place. Existing
     // push subscriptions are dropped along with it; users just need to
@@ -253,7 +270,7 @@ migrations["008"] = {
       .column("did")
       .execute();
   },
-  async down(db: Kysely<any>) {
+  async down(db: Kysely<unknown>) {
     await db.schema.dropIndex("push_subscription_did_idx").ifExists().execute();
     await db.schema.dropTable("push_subscription").ifExists().execute();
 
@@ -275,6 +292,69 @@ migrations["008"] = {
   },
 };
 
+// Kysely's SqliteDialect is duck-typed against a tiny Database/Statement
+// surface (prepare(sql) -> { reader, all, run, iterate } + close()) that
+// better-sqlite3 happens to satisfy. bun:sqlite exposes the same synchronous
+// API with two deltas: its Statement has no `reader` flag, and its methods
+// take variadic params instead of an array. The adapter below bridges those,
+// letting Kysely's stock SqliteDialect drive bun:sqlite under the Bun runtime
+// so `better-sqlite3` is never imported there (it's unsupported by Bun).
+interface KyselySqliteStatement {
+  reader: boolean;
+  all(parameters: ReadonlyArray<unknown>): unknown[];
+  run(parameters: ReadonlyArray<unknown>): {
+    changes: number | bigint;
+    lastInsertRowid: number | bigint;
+  };
+  iterate(parameters: ReadonlyArray<unknown>): IterableIterator<unknown>;
+}
+interface KyselySqliteDatabase {
+  close(): void;
+  prepare(sql: string): KyselySqliteStatement;
+}
+
+class BunSqliteStatement implements KyselySqliteStatement {
+  readonly reader: boolean;
+  #stmt: import("bun:sqlite").Statement;
+
+  constructor(stmt: import("bun:sqlite").Statement) {
+    this.#stmt = stmt;
+    // A statement is a "reader" iff it returns ≥1 column — the same rule
+    // better-sqlite3 uses internally to set its `reader` flag.
+    this.reader = stmt.columnNames.length > 0;
+  }
+
+  all(parameters: ReadonlyArray<unknown>) {
+    return this.#stmt.all(...parameters);
+  }
+
+  run(parameters: ReadonlyArray<unknown>) {
+    return this.#stmt.run(...parameters);
+  }
+
+  iterate(parameters: ReadonlyArray<unknown>) {
+    return this.#stmt.iterate(...parameters);
+  }
+}
+
+class BunSqliteDatabase implements KyselySqliteDatabase {
+  #db: import("bun:sqlite").Database;
+
+  constructor(db: import("bun:sqlite").Database) {
+    this.#db = db;
+  }
+
+  prepare(sql: string) {
+    return new BunSqliteStatement(this.#db.prepare(sql));
+  }
+
+  close() {
+    this.#db.close();
+  }
+}
+
+const isBunRuntime = typeof process.versions.bun !== "undefined";
+
 export const createDb = async (location: string): Promise<Database> => {
   if (env.POSTGRESQL_URL) {
     return new Kysely<DatabaseSchema>({
@@ -285,7 +365,18 @@ export const createDb = async (location: string): Promise<Database> => {
       }),
     });
   }
-  // Lazy import so the native binary is never loaded when PostgreSQL is in use
+  // Under Bun use bun:sqlite (better-sqlite3 is unsupported there); under
+  // Node keep better-sqlite3. Both present the same Database/Statement
+  // surface to Kysely's SqliteDialect, so behavior is identical. Imports are
+  // lazy so the unused native binary is never loaded.
+  if (isBunRuntime) {
+    const { Database } = await import("bun:sqlite");
+    return new Kysely<DatabaseSchema>({
+      dialect: new SqliteDialect({
+        database: new BunSqliteDatabase(new Database(location)),
+      }),
+    });
+  }
   const { default: SqliteDb } = await import("better-sqlite3");
   return new Kysely<DatabaseSchema>({
     dialect: new SqliteDialect({

--- a/server/src/lib/errors.ts
+++ b/server/src/lib/errors.ts
@@ -1,0 +1,12 @@
+// Extracts `.message` from an unknown catch value, or "" if the value isn't
+// Error-shaped. Callers pair it with a fallback (e.g. `errorMessage(err) ||
+// "Failed..."`) so non-Error throws still produce a useful message — matching
+// the pre-`unknown` `err.message || "..."` behavior the tests rely on.
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object" && "message" in err) {
+    const msg = (err as { message: unknown }).message;
+    return typeof msg === "string" ? msg : "";
+  }
+  return "";
+}

--- a/server/src/routes/auth-routes.ts
+++ b/server/src/routes/auth-routes.ts
@@ -5,7 +5,11 @@ import { AuthController } from "../controllers/auth-controller";
 
 import type { AppContext } from "../index";
 
-export function authRoutes(ctx: AppContext, handler: any, checkValidation: any) {
+export function authRoutes(
+  ctx: AppContext,
+  handler: (fn: express.Handler) => express.Handler,
+  checkValidation: express.RequestHandler
+) {
   const router = express.Router();
   const controller = new AuthController(ctx);
 

--- a/server/src/routes/e2e-auth-routes.ts
+++ b/server/src/routes/e2e-auth-routes.ts
@@ -12,7 +12,11 @@ import { AuthService } from "../services/auth-service";
 
 import type { AppContext } from "../index";
 
-export function e2eAuthRoutes(ctx: AppContext, handler: any, checkValidation: any) {
+export function e2eAuthRoutes(
+  ctx: AppContext,
+  handler: (fn: express.Handler) => express.Handler,
+  checkValidation: express.RequestHandler
+) {
   const router = express.Router();
   const authService = new AuthService(ctx);
 
@@ -47,9 +51,8 @@ export function e2eAuthRoutes(ctx: AppContext, handler: any, checkValidation: an
 
       await authService.createOrConfirmUserProfile(did);
 
-      // Cast: AtpAgent implements the same API surface as Agent for our use-cases.
       const handle = agent.session?.handle || identifier;
-      setE2EAgent(did, agent as any, handle);
+      setE2EAgent(did, agent, handle);
       // Preserve any previously remembered accounts (multi-account add flow).
       req.session = req.session ?? {};
       req.session.did = did;

--- a/server/src/routes/message-routes.ts
+++ b/server/src/routes/message-routes.ts
@@ -6,7 +6,11 @@ import { NotificationService } from "../services/notification-service";
 
 import type { AppContext } from "../index";
 
-export function messageRoutes(ctx: AppContext, handler: any, checkValidation: any) {
+export function messageRoutes(
+  ctx: AppContext,
+  handler: (fn: express.Handler) => express.Handler,
+  checkValidation: express.RequestHandler
+) {
   // Initialize service and controller
   const messageService = new MessageService(ctx.db, ctx.resolver, ctx.logger);
   const notificationService = new NotificationService(ctx.db, ctx.resolver, ctx.logger);

--- a/server/src/routes/notification-routes.ts
+++ b/server/src/routes/notification-routes.ts
@@ -5,7 +5,11 @@ import { NotificationService } from "../services/notification-service";
 
 import type { AppContext } from "../index";
 
-export function notificationRoutes(ctx: AppContext, handler: any, checkValidation: any) {
+export function notificationRoutes(
+  ctx: AppContext,
+  handler: (fn: express.Handler) => express.Handler,
+  checkValidation: express.RequestHandler
+) {
   const notificationService = new NotificationService(ctx.db, ctx.resolver, ctx.logger);
   const notificationController = new NotificationController(notificationService, ctx.logger);
 

--- a/server/src/routes/profile-routes.ts
+++ b/server/src/routes/profile-routes.ts
@@ -5,7 +5,11 @@ import { ProfileService } from "../services/profile-service";
 
 import type { AppContext } from "../index";
 
-export function profileRoutes(ctx: AppContext, handler: any, checkValidation: any) {
+export function profileRoutes(
+  ctx: AppContext,
+  handler: (fn: express.Handler) => express.Handler,
+  checkValidation: express.RequestHandler
+) {
   // Initialize service and controller
   const profileService = new ProfileService(ctx.db, ctx.resolver, ctx.logger);
   const profileController = new ProfileController(profileService, ctx.logger, ctx);

--- a/server/src/routes/settings-routes.ts
+++ b/server/src/routes/settings-routes.ts
@@ -5,7 +5,11 @@ import { SettingsService } from "../services/settings-service";
 
 import type { AppContext } from "../index";
 
-export function settingsRoutes(ctx: AppContext, handler: any, checkValidation: any) {
+export function settingsRoutes(
+  ctx: AppContext,
+  handler: (fn: express.Handler) => express.Handler,
+  checkValidation: express.RequestHandler
+) {
   // Initialize service and controller
   const settingsService = new SettingsService(ctx.db, ctx.logger);
   const settingsController = new SettingsController(settingsService, ctx.logger, ctx);

--- a/server/src/services/auth-service.ts
+++ b/server/src/services/auth-service.ts
@@ -24,9 +24,13 @@ export class AuthService {
           "atproto repo:app.bsky.feed.post repo:app.navyfragen.message blob:image/* rpc:app.bsky.actor.getProfile?aud=* rpc:app.bsky.graph.getFollows?aud=*",
       });
       return url.toString();
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.ctx.logger.error(
-        { handle, err: err?.message, stack: err?.stack },
+        {
+          handle,
+          err: err instanceof Error ? err.message : err,
+          stack: err instanceof Error ? err.stack : undefined,
+        },
         "[oauth] oauthClient.authorize threw"
       );
       if (err instanceof OAuthResolverError) throw new Error(err.message, { cause: err });
@@ -84,7 +88,7 @@ export class AuthService {
     await this.ctx.db
       .insertInto("user_profile")
       .values({ did, createdAt: new Date().toISOString() })
-      .onConflict((oc: any) => oc.column("did").doNothing())
+      .onConflict((oc) => oc.column("did").doNothing())
       .execute();
   }
 

--- a/server/src/services/message-service.ts
+++ b/server/src/services/message-service.ts
@@ -1,8 +1,9 @@
 /* v8 ignore start */
-import { RichText, Agent } from "@atproto/api";
+import { AppBskyEmbedImages, AppBskyFeedPost, RichText, Agent } from "@atproto/api";
 import { Logger } from "pino";
 
 import { type Database } from "../database/db";
+import { errorMessage } from "../lib/errors";
 import { ids } from "../lexicon/lexicons";
 import { type Record as MessageSchemaRecord } from "../lexicon/types/app/navyfragen/message";
 import { imageGenerator } from "../lib/image-generator";
@@ -206,7 +207,7 @@ export class MessageService {
       const rt = new RichText({ text: response });
       await rt.detectFacets(agent);
 
-      const postRecord: any = {
+      const postRecord: Partial<AppBskyFeedPost.Record> = {
         text: rt.text,
         facets: rt.facets || [],
         createdAt: new Date().toISOString(),
@@ -245,7 +246,7 @@ export class MessageService {
         const uploadedImage = await agent.uploadBlob(imageBlob, {
           encoding: "image/png",
         });
-        const imageEmbed: any = {
+        const imageEmbed: AppBskyEmbedImages.Image = {
           image: uploadedImage.data.blob,
           alt: imageAltText || "Image of the anonymous question",
         };
@@ -409,11 +410,11 @@ export class MessageService {
             record: recordToCreate,
           });
           syncedCount++;
-        } catch (err: any) {
+        } catch (err: unknown) {
           errorCount++;
           syncErrors.push({
             tid: dbMessage.tid,
-            error: err.message || "Unknown error during PDS record creation",
+            error: errorMessage(err) || "Unknown error during PDS record creation",
           });
         }
       }
@@ -434,11 +435,11 @@ export class MessageService {
             .onConflict((oc) => oc.column("tid").doNothing())
             .execute();
           importedCount++;
-        } catch (err: any) {
+        } catch (err: unknown) {
           errorCount++;
           syncErrors.push({
             tid: pdsRecord.rkey,
-            error: err.message || "Unknown error during DB import",
+            error: errorMessage(err) || "Unknown error during DB import",
           });
         }
       }
@@ -455,7 +456,7 @@ export class MessageService {
         errorCount,
         errors: syncErrors,
       };
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.logger.error({ did: userDid, error: err }, "Error during message sync process");
       throw new Error("Failed to sync messages to PDS", { cause: err });
     }

--- a/server/src/services/profile-service.ts
+++ b/server/src/services/profile-service.ts
@@ -1,7 +1,8 @@
 /* v8 ignore start */
 import { AtpAgent, Agent } from "@atproto/api";
-import { Kysely } from "kysely";
 import { Logger } from "pino";
+
+import type { Database } from "../database/db";
 
 export interface ProfileResolver {
   resolveDidToHandle(did: string): Promise<string | undefined>;
@@ -12,7 +13,7 @@ export class ProfileService {
   private agent: AtpAgent;
 
   constructor(
-    private db: Kysely<any>,
+    private db: Database,
     private resolver: ProfileResolver,
     private logger: Logger
   ) {
@@ -26,7 +27,7 @@ export class ProfileService {
    * @returns The user's public profile and whether they're registered on Navyfragen
    */
   async getPublicProfile(did: string): Promise<{
-    profile: any;
+    profile: Awaited<ReturnType<AtpAgent["getProfile"]>>["data"];
     exists: boolean;
   }> {
     let profileResponse: Awaited<ReturnType<typeof this.agent.getProfile>>;

--- a/server/src/tests/errors.test.ts
+++ b/server/src/tests/errors.test.ts
@@ -1,0 +1,34 @@
+/* v8 ignore start */
+import assert from "node:assert";
+import { test, describe } from "node:test";
+
+import { errorMessage } from "../lib/errors";
+/* v8 ignore stop */
+
+describe("errorMessage", () => {
+  test("extracts .message from an Error", () => {
+    assert.strictEqual(errorMessage(new Error("boom")), "boom");
+  });
+
+  test("extracts .message from an Error subclass", () => {
+    assert.strictEqual(errorMessage(new TypeError("bad type")), "bad type");
+  });
+
+  test("extracts .message from a plain object with a string message", () => {
+    assert.strictEqual(errorMessage({ message: "object error" }), "object error");
+  });
+
+  test("returns empty string when object .message is not a string", () => {
+    assert.strictEqual(errorMessage({ message: 42 }), "");
+  });
+
+  test("returns empty string for a plain string throw (fallback path)", () => {
+    assert.strictEqual(errorMessage("non-Error string"), "");
+  });
+
+  test("returns empty string for other primitives", () => {
+    assert.strictEqual(errorMessage(null), "");
+    assert.strictEqual(errorMessage(undefined), "");
+    assert.strictEqual(errorMessage(123), "");
+  });
+});


### PR DESCRIPTION
Closes #263.

## Summary

Two bodies of work in one PR — the #263 data-layer abstraction, plus a cleanup of every `any` in non-test source that was flagged along the way.

### Data layer (issue #263)

`better-sqlite3` is unsupported by Bun ([oven-sh/bun#4290](https://github.com/oven-sh/bun/issues/4290)), which was the sole blocker for running `server` under the Bun runtime. Kysely's `SqliteDialect` is dialect-agnostic at the query level but duck-types against a tiny `Database`/`Statement` surface that `bun:sqlite` matches with two small API deltas. Rather than pull a community dialect, a ~30-line adapter bridges those deltas so Kysely's stock `SqliteDialect` drives `bun:sqlite` under Bun — no new dependencies.

- **`createDb` is now runtime-gated**: `bun:sqlite` under Bun, `better-sqlite3` under Node. Both present the same interface to `SqliteDialect`; behavior is identical. Imports stay lazy so the unused native binary is never loaded.
- **Adapter** bridges: no `reader` flag → derived from `columnNames.length`; variadic params → spread.
- **Types**: `@types/bun` (matching local Bun 1.3.14) provides `bun:sqlite` types via a file-scoped `/// <reference types="bun" />` (avoids pulling the Bun global into the whole Node project). `tsup` marks `bun:sqlite` external so the production Node bundle resolves.
- **CI canary** (`server-tests-bun-runtime` in `Tests.yml`): the SQLite probe now exercises the real data layer (`createDb → migrateToLatest → insert → select`) under Bun and gates on `OK`. The `node:test`-under-Bun step stays non-blocking (out of scope per #263). The job's job-level `continue-on-error` was removed so a SQLite regression now fails CI.

### Type cleanup — eliminate `any` from non-test source

Every `any` in non-test `.ts` files is now gone (warnings 289 → 248):

- **Migrations**: `Kysely<any>` → `Kysely<unknown>` (DDL migrations); migration 005 gets a narrow local `Migration005Schema` type for its backfill `SELECT` (the only migration doing DML).
- **`profile-service`**: `Kysely<any>` → `Database`; `profile: any` → the real `getProfile` return type.
- **`message-service`**: `postRecord: any` / `imageEmbed: any` → `Partial<AppBskyFeedPost.Record>` / `AppBskyEmbedImages.Image`; `(oc: any)` onConflict annotation removed (Kysely infers it).
- **`catch (e: any)`** across all controllers/services → `catch (e: unknown)`, using a new `errorMessage()` helper (`src/lib/errors.ts`) that preserves the `err.message || "fallback"` semantics the non-Error-throw tests assert on. Unused-error catches became optional `catch {}`.
- **Route files**: `handler: any, checkValidation: any` → real Express types (`(fn: express.Handler) => express.Handler` / `express.RequestHandler`).
- **`e2e-agent-store`**: widened from `Agent` to `Agent | AtpAgent` (`E2EAgent`), removing an `as any` cast in the E2E login route; `session-agent.ts` return types widened accordingly.

## Validation

- `bun run test` — **298/298** pass under Node
- `bun run typecheck` — clean
- `bun run lint` — **0 errors** (248 warnings, down from 289)
- `bun run build` — succeeds
- Bun data-layer smoke check — prints `OK` (`createDb` → `migrateToLatest` → insert → select via `bun:sqlite`)
- Node dev/test path unchanged (same `better-sqlite3` branch)

## Out of scope (matching #263)
- Migrating off `node:test`
- Production datastore changes (`pg` stays)