### PR TITLE
html-to-image: cap concurrent renders and recycle the browser

### DIFF
--- a/html-to-image/app.js
+++ b/html-to-image/app.js
@@ -13,6 +13,39 @@ const FORMATS = {
   webp: { contentType: 'image/webp', args: { type: 'webp' } },
 };
 
+// Chromium's multi-process architecture spawns a new renderer subprocess per
+// tab (no --single-process). Without a cap, a burst of concurrent requests
+// spawns one renderer per request, multiplying RSS. Excess requests queue
+// instead of piling onto the browser at once.
+export const MAX_CONCURRENT_RENDERS = 3;
+
+class Semaphore {
+  constructor(max) {
+    this.max = max;
+    this.current = 0;
+    this.queue = [];
+  }
+
+  acquire() {
+    if (this.current < this.max) {
+      this.current++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.queue.push(() => {
+        this.current++;
+        resolve();
+      });
+    });
+  }
+
+  release() {
+    this.current--;
+    const next = this.queue.shift();
+    if (next) next();
+  }
+}
+
 // Bounded deadline for waiting on images/fonts to load before a screenshot.
 // Long enough to absorb a slow CDN fetch (banners/avatars live on cdn.bsky.app,
 // fonts on fonts.googleapis.com), short enough that a hung host can't stall a
@@ -52,8 +85,9 @@ async function waitForVisualReadiness(page) {
   ]);
 }
 
-export function createApp(getBrowser) {
+export function createApp(getBrowser, { onRenderComplete = () => {} } = {}) {
   const app = express();
+  const renderSemaphore = new Semaphore(MAX_CONCURRENT_RENDERS);
 
   app.use(cors());
   app.use(express.json({ limit: '2mb' }));
@@ -84,40 +118,46 @@ export function createApp(getBrowser) {
   });
 
   app.post('/', async (req, res) => {
-    let browser;
+    await renderSemaphore.acquire();
     try {
-      browser = await getBrowser();
-    } catch (err) {
-      return res.status(503).json({ error: 'Browser unavailable: ' + err.message });
-    }
-
-    const { source, format: formatName, options = {} } = req.body;
-    const format = FORMATS[formatName];
-    const tmpoutput = tmp.fileSync({ prefix: 'htmltoimage-' });
-    const tmpinput = tmp.fileSync({ prefix: 'htmltoimage-', postfix: '.html' });
-
-    try {
-      await fs.promises.writeFile(tmpinput.name, source);
-
-      const page = await browser.newPage();
+      let browser;
       try {
-        await page.setViewport({ width: options.width || 1920, height: options.height || 1080 });
-        await page.goto('file://' + tmpinput.name);
-        await waitForVisualReadiness(page);
-        await page.screenshot(Object.assign({}, options.args, format.args, { path: tmpoutput.name }));
-      } finally {
-        await page.close();
+        browser = await getBrowser();
+      } catch (err) {
+        return res.status(503).json({ error: 'Browser unavailable: ' + err.message });
       }
 
-      res.header('Content-Type', format.contentType);
-      fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
+      const { source, format: formatName, options = {} } = req.body;
+      const format = FORMATS[formatName];
+      const tmpoutput = tmp.fileSync({ prefix: 'htmltoimage-' });
+      const tmpinput = tmp.fileSync({ prefix: 'htmltoimage-', postfix: '.html' });
+
+      try {
+        await fs.promises.writeFile(tmpinput.name, source);
+
+        const page = await browser.newPage();
+        try {
+          await page.setViewport({ width: options.width || 1920, height: options.height || 1080 });
+          await page.goto('file://' + tmpinput.name);
+          await waitForVisualReadiness(page);
+          await page.screenshot(Object.assign({}, options.args, format.args, { path: tmpoutput.name }));
+        } finally {
+          await page.close();
+        }
+
+        res.header('Content-Type', format.contentType);
+        fs.createReadStream(tmpoutput.name).pipe(res).on('close', () => {
+          tmpoutput.removeCallback();
+          tmpinput.removeCallback();
+        });
+      } catch (err) {
         tmpoutput.removeCallback();
         tmpinput.removeCallback();
-      });
-    } catch (err) {
-      tmpoutput.removeCallback();
-      tmpinput.removeCallback();
-      res.status(500).json({ error: err.message || 'Image generation failed' });
+        res.status(500).json({ error: err.message || 'Image generation failed' });
+      }
+    } finally {
+      renderSemaphore.release();
+      onRenderComplete(renderSemaphore.current);
     }
   });
 
@@ -152,7 +192,39 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     return browser;
   }
 
-  const app = createApp(getBrowser);
+  // A single Chromium instance run for a long time accumulates RSS growth
+  // (cache/heap fragmentation across many renders) even though every page is
+  // closed correctly. Recycling the process periodically bounds that growth.
+  const RENDERS_BEFORE_RECYCLE = 100;
+  const BROWSER_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+  let rendersSinceLaunch = 0;
+  let browserLaunchedAt = Date.now();
+
+  // Only swaps when no render is in flight (activeRenders === 0), so the
+  // browser is never pulled out from under a request that's mid-screenshot.
+  // A request that starts in the brief window between this check and the
+  // actual swap can hit a closed browser and get a 500 — an accepted
+  // tradeoff for keeping the recycle logic lock-free.
+  async function recycleBrowserIfDue(activeRenders) {
+    if (activeRenders > 0) return;
+    const due = rendersSinceLaunch >= RENDERS_BEFORE_RECYCLE || Date.now() - browserLaunchedAt >= BROWSER_MAX_AGE_MS;
+    if (!due) return;
+
+    const staleBrowserPromise = browserPromise;
+    rendersSinceLaunch = 0;
+    browserLaunchedAt = Date.now();
+    browserPromise = launchBrowser();
+
+    const staleBrowser = await staleBrowserPromise.catch(() => null);
+    if (staleBrowser) await staleBrowser.close().catch(() => {});
+  }
+
+  function onRenderComplete(activeRenders) {
+    rendersSinceLaunch++;
+    recycleBrowserIfDue(activeRenders).catch((err) => console.error('Browser recycle failed:', err));
+  }
+
+  const app = createApp(getBrowser, { onRenderComplete });
   // Bind to :: so Railway's IPv6 internal network can reach this service.
   app.listen(port, '::', () => console.log(`html-to-image listening on port ${port}`));
 

--- a/html-to-image/app.test.js
+++ b/html-to-image/app.test.js
@@ -2,17 +2,27 @@ import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import fs from 'node:fs/promises';
-import { createApp } from './app.js';
+import { createApp, MAX_CONCURRENT_RENDERS } from './app.js';
 
 // Starts the app on a random port and returns { server, url }.
-function startServer(getBrowser) {
+function startServer(getBrowser, options) {
   return new Promise((resolve, reject) => {
-    const server = http.createServer(createApp(getBrowser));
+    const server = http.createServer(createApp(getBrowser, options));
     server.listen(0, '127.0.0.1', () => {
       resolve({ server, url: `http://127.0.0.1:${server.address().port}` });
     });
     server.on('error', reject);
   });
+}
+
+// Polls a predicate until it's true, rather than sleeping a fixed amount —
+// avoids flakiness from arbitrary timing assumptions.
+async function waitFor(predicate, { timeoutMs = 2000, intervalMs = 5 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error('waitFor: timed out');
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
 }
 
 function stopServer(server) {
@@ -310,5 +320,105 @@ describe('POST / screenshot failure', () => {
     assert.equal(res.status, 500);
     const body = await res.json();
     assert.match(body.error, /screenshot failed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrency limiting
+// ---------------------------------------------------------------------------
+describe('POST / concurrency limiting', () => {
+  test(`caps concurrent renders at MAX_CONCURRENT_RENDERS (${MAX_CONCURRENT_RENDERS})`, async () => {
+    let inFlight = 0;
+    let maxObservedInFlight = 0;
+    let releaseGate;
+    const gate = new Promise((resolve) => { releaseGate = resolve; });
+
+    const page = {
+      setViewport: async () => {},
+      goto: async () => {},
+      evaluate: async () => {},
+      waitForFunction: async () => {},
+      screenshot: async (args) => {
+        inFlight++;
+        maxObservedInFlight = Math.max(maxObservedInFlight, inFlight);
+        await gate;
+        inFlight--;
+        if (args.path) await fs.writeFile(args.path, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      },
+      close: async () => {},
+    };
+    const browser = { newPage: async () => page, connected: true };
+    const { server, url } = await startServer(async () => browser);
+
+    try {
+      const requestCount = MAX_CONCURRENT_RENDERS + 2;
+      const responses = Array.from({ length: requestCount }, () =>
+        post(url, { source: '<h1>hi</h1>', format: 'png' })
+      );
+
+      // Let every request attempt entry; only MAX_CONCURRENT_RENDERS should
+      // make it into the screenshot section, the rest queue on the semaphore.
+      await waitFor(() => maxObservedInFlight === MAX_CONCURRENT_RENDERS);
+      assert.equal(inFlight, MAX_CONCURRENT_RENDERS, 'excess requests should be queued, not running');
+
+      releaseGate();
+      const results = await Promise.all(responses);
+      for (const res of results) assert.equal(res.status, 200);
+      assert.equal(maxObservedInFlight, MAX_CONCURRENT_RENDERS, 'cap should never be exceeded, even across queued waves');
+    } finally {
+      await stopServer(server);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onRenderComplete callback (browser recycling hook)
+// ---------------------------------------------------------------------------
+describe('POST / onRenderComplete callback', () => {
+  test('invokes onRenderComplete with the remaining active-render count on success', async () => {
+    const { browser } = makeMockBrowser();
+    const observed = [];
+    const { server, url } = await startServer(async () => browser, {
+      onRenderComplete: (activeRenders) => observed.push(activeRenders),
+    });
+
+    try {
+      const res = await post(url, { source: '<h1>hi</h1>', format: 'png' });
+      assert.equal(res.status, 200);
+      assert.deepEqual(observed, [0]);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  test('invokes onRenderComplete even when the render fails', async () => {
+    const { browser } = makeMockBrowser({ failScreenshot: true });
+    const observed = [];
+    const { server, url } = await startServer(async () => browser, {
+      onRenderComplete: (activeRenders) => observed.push(activeRenders),
+    });
+
+    try {
+      const res = await post(url, { source: '<h1>hi</h1>', format: 'png' });
+      assert.equal(res.status, 500);
+      assert.deepEqual(observed, [0]);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  test('invokes onRenderComplete when the browser is unavailable', async () => {
+    const observed = [];
+    const { server, url } = await startServer(async () => { throw new Error('crashed'); }, {
+      onRenderComplete: (activeRenders) => observed.push(activeRenders),
+    });
+
+    try {
+      const res = await post(url, { source: '<h1>hi</h1>', format: 'png' });
+      assert.equal(res.status, 503);
+      assert.deepEqual(observed, [0]);
+    } finally {
+      await stopServer(server);
+    }
   });
 });


### PR DESCRIPTION
## Summary

The `html-to-image` Puppeteer/Chromium render service was using a lot of RAM on Railway. Chromium's own memory footprint is inherent to running a full browser engine (any language wrapping Puppeteer/Playwright/Rod/headless_chrome would pay the same cost), but this service had two implementation gaps that made it worse: no cap on concurrent renders, and no recycling of the long-lived browser process.

## Related issue

Closes #

## Scope

- [ ] client
- [ ] server
- [ ] opengraph-service
- [x] html-to-image
- [ ] docker / infra (caddy, anubis)
- [ ] docs

## Changes

- Add a `Semaphore`-based concurrency limiter (`MAX_CONCURRENT_RENDERS = 3`) around the render path in `createApp`'s `POST /` handler. Chromium spawns a separate renderer subprocess per tab (no `--single-process`), so a burst of concurrent requests was multiplying RSS by spinning up one renderer per request instead of queuing.
- Add periodic browser recycling in the entry-point bootstrap (`RENDERS_BEFORE_RECYCLE = 100`, `BROWSER_MAX_AGE_MS = 6h`) to bound RSS growth from a single Chromium instance running indefinitely. Recycling only swaps the browser when no render is in flight (via a new `onRenderComplete(activeRenders)` hook passed into `createApp`), so an in-progress render is never pulled out from under.
- `MAX_CONCURRENT_RENDERS` is exported for test use.

Chromium's own background-networking/telemetry flags (`--disable-background-networking`, `--disable-dev-shm-usage`, etc.) were **not** added — verified these are already part of Puppeteer's `DEFAULT_ARGS` and applied automatically since the code doesn't set `ignoreDefaultArgs`.

## Testing

- [x] Unit/integration tests pass locally (`cd html-to-image && node --test app.test.js` — 28/28 passing)
- [ ] E2E (Playwright) passes for affected flows
- [ ] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account
- Added new tests: concurrency cap is enforced under a burst of requests, and `onRenderComplete` fires with the correct in-flight count on success, render failure, and browser-unavailable paths.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [ ] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens
- [ ] Docs updated if user-facing behavior or setup changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01D1bE3fP2cCrVLM7cgRQmsx)_