### PR TITLE
Build the /customise page: prompt, inbox, theme, language, profanity filter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "iron-session": "^8.0.4",
         "kysely": "^0.29.4",
         "multiformats": "^14.0.4",
+        "obscenity": "^0.4.6",
         "pg": "^8.22.0",
         "pino": "^10.3.1",
         "sharp": "^0.35.3",
@@ -1537,6 +1538,8 @@
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
+    "obscenity": ["obscenity@0.4.6", "", {}, "sha512-pHk7kNN7j3L3zGhhGnwxjvXIGsPpLrcZl2r58fqWh/V/rH6b/dafscj2sMmAY+A/9/wPsocLmimgGk2DKeKsFQ=="],
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 

--- a/client/src/AppLayout.tsx
+++ b/client/src/AppLayout.tsx
@@ -9,6 +9,7 @@ import { BouncingLogos } from "./components/BouncingLogos";
 import { buildAccountSwitchUrl, consumeAccountSwitchToast } from "./lib/accountSwitchToast";
 import { consumeNotificationSwitchRequest } from "./lib/notificationSwitch";
 import { Navigation } from "./Navigation";
+import Customise from "./pages/Customise";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Messages from "./pages/Messages";
@@ -96,6 +97,7 @@ export function AppLayout() {
               <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/login" element={<Login />} />
+                <Route path="/customise" element={<Customise />} />
                 <Route path="/messages" element={<Messages />} />
                 <Route path="/profile" element={<PublicProfile />} />
                 <Route path="/profile/:handle" element={<PublicProfile />} />

--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -17,6 +17,7 @@ import {
   IconSettings,
   IconUser,
   IconChevronDown,
+  IconAdjustments,
 } from "@tabler/icons-react";
 import { useEffect } from "react";
 import { useLocation, Link, useNavigate } from "react-router-dom";
@@ -77,6 +78,9 @@ export function Navigation({ onLinkClick }: NavigationProps) {
             break;
           case "M":
             if (isLoggedIn) targetPath = "/messages";
+            break;
+          case "C":
+            if (isLoggedIn) targetPath = "/customise";
             break;
           case "S":
             if (isLoggedIn) targetPath = "/settings";
@@ -139,6 +143,16 @@ export function Navigation({ onLinkClick }: NavigationProps) {
                 ) : undefined
               }
               styles={navItemStyles("/messages")}
+            />
+            <NavLink
+              my={2}
+              label="Customise"
+              component={Link}
+              to="/customise"
+              active={isActive("/customise")}
+              onClick={handleClick}
+              leftSection={<IconAdjustments size={16} stroke={1.5} />}
+              styles={navItemStyles("/customise")}
             />
             <NavLink
               my={2}

--- a/client/src/api/profileService.ts
+++ b/client/src/api/profileService.ts
@@ -17,6 +17,12 @@ export interface ProfileResponse {
     banner?: string;
   } | null;
   exists: boolean;
+  // Public-facing settings subset — the profile owner's customisations shown
+  // to anonymous visitors. All default to "unset" when no user_settings row.
+  inboxEnabled?: boolean; // true unless the owner explicitly closed their inbox
+  customPrompt?: string | null; // ask-card headline override; null = default
+  profileCardTheme?: string | null; // ask-card colour preset; null = default gradient
+  touchpointLocale?: string | null; // locale for the ask-card + share touchpoints
 }
 
 export interface UserExistsResponse {

--- a/client/src/api/settingsService.ts
+++ b/client/src/api/settingsService.ts
@@ -8,6 +8,14 @@ export interface UserSettings {
   did: string;
   pdsSyncEnabled: number | boolean; // Server returns number (1/0), but we use as boolean
   imageTheme: string;
+  // Whether the inbox accepts new anonymous messages (1/0 from server, treated
+  // as boolean). When false, PublicProfile shows a closed-inbox state.
+  inboxEnabled: number | boolean;
+  // Whether incoming messages are screened against a profanity wordlist (#58).
+  profanityFilterEnabled: number | boolean;
+  customPrompt: string | null; // Optional ask-card headline override; null = default
+  profileCardTheme: string | null; // Optional ask-card colour preset; null = default
+  touchpointLocale: string | null; // Optional locale for ask-card/share touchpoints; null = English
   createdAt: string;
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -118,6 +118,11 @@ body {
   --nf-grad-hero: linear-gradient(135deg, #3b5bff 0%, #6626fc 55%, #491bff 100%);
   --nf-grad-mark: linear-gradient(135deg, #3349e0 0%, #5322c5 55%, #4f1fa6 100%);
   --nf-grad-dark: linear-gradient(135deg, #1e1b4b 0%, #3b2e78 50%, #6b3fd4 100%);
+  /* Curated ask-card colour presets (#275). All keep white headline/textarea
+     legible. royal reuses --nf-grad-mark (the pre-existing default). */
+  --nf-grad-aurora: linear-gradient(135deg, #2563eb 0%, #0ea5e9 55%, #06b6d4 100%);
+  --nf-grad-ember: linear-gradient(135deg, #ea580c 0%, #db2777 55%, #be185d 100%);
+  --nf-grad-verdant: linear-gradient(135deg, #0d9488 0%, #10b981 55%, #059669 100%);
   --nf-font-sans: "Inter", system-ui, sans-serif;
   --nf-ease: cubic-bezier(0.2, 0.7, 0.2, 1);
   --nf-dur-fast: 120ms;

--- a/client/src/lib/themes.ts
+++ b/client/src/lib/themes.ts
@@ -3,3 +3,34 @@ export const themes = {
   compressed: "Compressed",
   twitter: "Twitter Style",
 };
+
+/**
+ * Curated colour presets for the public-profile ask card (#275).
+ *
+ * Each preset is an on-brand gradient token rather than an arbitrary hex, so
+ * white headline / textarea / Send button stay legible on every option and the
+ * `--nf-*` namespace stays the single source of truth for colour (CLAUDE.md
+ * Design Tokens). `royal` is the pre-existing default (--nf-grad-mark); the
+ * others are new tokens defined in index.css.
+ *
+ * Kept independent from the image-export `themes` above — the live card and a
+ * reply-image export have different legibility constraints, so conflating them
+ * would couple two unrelated preset sets.
+ */
+export interface ProfileCardTheme {
+  label: string;
+  /** CSS background value applied to the ask card (a gradient token). */
+  gradient: string;
+}
+
+export const profileCardThemes: Record<string, ProfileCardTheme> = {
+  royal: { label: "Royal", gradient: "var(--nf-grad-mark)" },
+  aurora: { label: "Aurora", gradient: "var(--nf-grad-aurora)" },
+  ember: { label: "Ember", gradient: "var(--nf-grad-ember)" },
+  verdant: { label: "Verdant", gradient: "var(--nf-grad-verdant)" },
+};
+
+/** Resolve a stored theme key to its gradient, falling back to the default. */
+export function profileCardGradient(theme: string | null | undefined): string {
+  return (theme && profileCardThemes[theme]?.gradient) || "var(--nf-grad-mark)";
+}

--- a/client/src/lib/touchpointTranslations.ts
+++ b/client/src/lib/touchpointTranslations.ts
@@ -1,0 +1,124 @@
+/**
+ * Hand-maintained translations for the handful of "touchpoint" strings that
+ * leave the DOM (the OS share sheet / clipboard) or are the highest-conversion
+ * copy on the app (the ask-card a stranger reads before sending a message).
+ *
+ * This is deliberately NOT a full client i18n rollout — the rest of the app is
+ * a static SPA and browser-level Google Translate handles page chrome. These
+ * specific strings are the ones Google Translate structurally cannot reach
+ * (share payloads) or that a profile owner may want pinned to their audience's
+ * language regardless of a visitor's browser settings (the ask-card).
+ *
+ * See issue #266 for the rationale. Whose preference controls it: the profile
+ * OWNER (not the visitor) — they know what language their audience speaks.
+ * Stored server-side in user_settings.touchpointLocale (null = English).
+ *
+ * Adding a locale = adding one object to `touchpointTranslations` and one entry
+ * to `touchpointLocales`. No extraction tooling, no missing-key linting infra.
+ */
+
+export type TouchpointLocale = "en" | "es" | "pt" | "de" | "fr";
+
+/** Ordered list for the /customise language <Select>. `en` first = default. */
+export const touchpointLocales: { value: TouchpointLocale; label: string }[] = [
+  { value: "en", label: "English" },
+  { value: "es", label: "Español" },
+  { value: "pt", label: "Português" },
+  { value: "de", label: "Deutsch" },
+  { value: "fr", label: "Français" },
+];
+
+export interface TouchpointTranslations {
+  /** Ask-card headline (#1): "Send {name} an anonymous message" */
+  headline: (displayName: string) => string;
+  /** Textarea placeholder (#2): "Ask something…" */
+  placeholder: string;
+  /** Send button label (#3): "Send" */
+  sendLabel: string;
+  /** Anonymity disclaimer paragraph (#4) */
+  disclaimer: string;
+  /** Closed-inbox message shown in place of the send form (#177) */
+  inboxClosed: string;
+  /** Profile-page navigator.share() title (#5) — leaves the DOM */
+  shareTitle: (displayName: string) => string;
+  /** Owner's own "share my inbox" title (#6) — leaves the DOM into a tweet/DM */
+  inboxShareTitle: string;
+  /** Owner's own "share my inbox" text (#6) — leaves the DOM into a tweet/DM */
+  inboxShareText: (displayName: string) => string;
+}
+
+const translations: Record<TouchpointLocale, TouchpointTranslations> = {
+  en: {
+    headline: (name) => `Send ${name} an anonymous message`,
+    placeholder: "Ask something…",
+    sendLabel: "Send",
+    disclaimer:
+      "Your message will be sent anonymously to the user. They may post it publicly on Bluesky, so please don't share any personal information or passwords. Be curious, but respectful and kind!",
+    inboxClosed: "This inbox is closed and not accepting new messages right now.",
+    shareTitle: (name) => `Send ${name} an anonymous message`,
+    inboxShareTitle: "Send me anonymous messages on Navyfragen!",
+    inboxShareText: (name) => `Send ${name} anonymous messages!`,
+  },
+  es: {
+    headline: (name) => `Envía a ${name} un mensaje anónimo`,
+    placeholder: "Pregunta algo…",
+    sendLabel: "Enviar",
+    disclaimer:
+      "Tu mensaje se enviará de forma anónima. Puede que se publique públicamente en Bluesky, así que por favor no compartas información personal ni contraseñas. ¡Sé curioso, pero respetuoso y amable!",
+    inboxClosed:
+      "Esta bandeja de entrada está cerrada y no acepta mensajes nuevos en este momento.",
+    shareTitle: (name) => `Envía a ${name} un mensaje anónimo`,
+    inboxShareTitle: "¡Envíame mensajes anónimos en Navyfragen!",
+    inboxShareText: (name) => `¡Envía a ${name} mensajes anónimos!`,
+  },
+  pt: {
+    headline: (name) => `Envie uma mensagem anônima para ${name}`,
+    placeholder: "Pergunte algo…",
+    sendLabel: "Enviar",
+    disclaimer:
+      "Sua mensagem será enviada anonimamente. Ela pode ser publicada publicamente no Bluesky, então por favor não compartilhe informações pessoais ou senhas. Seja curioso, mas respeitoso e gentil!",
+    inboxClosed:
+      "Esta caixa de entrada está fechada e não está aceitando novas mensagens no momento.",
+    shareTitle: (name) => `Envie uma mensagem anônima para ${name}`,
+    inboxShareTitle: "Envie mensagens anônimas para mim no Navyfragen!",
+    inboxShareText: (name) => `Envie mensagens anônimas para ${name}!`,
+  },
+  de: {
+    headline: (name) => `Sende ${name} eine anonyme Nachricht`,
+    placeholder: "Frag etwas…",
+    sendLabel: "Senden",
+    disclaimer:
+      "Deine Nachricht wird anonym gesendet. Sie könnte öffentlich auf Bluesky gepostet werden, also teile bitte keine persönlichen Informationen oder Passwörter. Sei neugierig, aber respektvoll und freundlich!",
+    inboxClosed: "Dieser Posteingang ist geschlossen und nimmt derzeit keine neuen Nachrichten an.",
+    shareTitle: (name) => `Sende ${name} eine anonyme Nachricht`,
+    inboxShareTitle: "Sende mir anonyme Nachrichten auf Navyfragen!",
+    inboxShareText: (name) => `Sende ${name} anonyme Nachrichten!`,
+  },
+  fr: {
+    headline: (name) => `Envoie un message anonyme à ${name}`,
+    placeholder: "Pose une question…",
+    sendLabel: "Envoyer",
+    disclaimer:
+      "Ton message sera envoyé anonymement. Il peut être publié publiquement sur Bluesky, alors ne partage aucune information personnelle ni mot de passe. Sois curieux, mais respectueux et bienveillant !",
+    inboxClosed:
+      "Cette boîte de réception est fermée et n'accepte pas de nouveaux messages pour le moment.",
+    shareTitle: (name) => `Envoie un message anonyme à ${name}`,
+    inboxShareTitle: "Envoie-moi des messages anonymes sur Navyfragen !",
+    inboxShareText: (name) => `Envoie des messages anonymes à ${name} !`,
+  },
+};
+
+/**
+ * Resolve a (possibly null/unknown) locale to its translations, falling back to
+ * English for anything unset or not in the table. English is the default when
+ * touchpointLocale is null, so a profile that never set a locale renders the
+ * exact same strings it did before this feature existed.
+ */
+export function getTouchpointTranslations(
+  locale: string | null | undefined
+): TouchpointTranslations {
+  if (locale && locale in translations) {
+    return translations[locale as TouchpointLocale];
+  }
+  return translations.en;
+}

--- a/client/src/pages/Customise.tsx
+++ b/client/src/pages/Customise.tsx
@@ -23,6 +23,15 @@ import { touchpointLocales } from "../lib/touchpointTranslations";
 
 const MAX_PROMPT_LENGTH = 100;
 
+/**
+ * Coerce a `user_settings` boolean column to a real boolean. The Kysely row
+ * type says `number | boolean`: SQLite returns 0/1, Postgres returns false/true
+ * for a `boolean` column. Treat anything that isn't 1/true as off.
+ */
+function on(value: number | boolean | null | undefined): boolean {
+  return value === 1 || value === true;
+}
+
 export default function Customise() {
   const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
   const { data: session, isLoading: sessionLoading } = useSession();
@@ -173,7 +182,7 @@ export default function Customise() {
                 ) : (
                   <Switch
                     label="Accepting messages"
-                    checked={userSettings?.inboxEnabled !== 0}
+                    checked={on(userSettings?.inboxEnabled)}
                     onChange={(e) =>
                       updateSettings.mutate({ inboxEnabled: e.currentTarget.checked })
                     }
@@ -197,7 +206,7 @@ export default function Customise() {
                 ) : (
                   <Switch
                     label="Filter enabled"
-                    checked={userSettings?.profanityFilterEnabled === 1}
+                    checked={on(userSettings?.profanityFilterEnabled)}
                     onChange={(e) =>
                       updateSettings.mutate({
                         profanityFilterEnabled: e.currentTarget.checked,

--- a/client/src/pages/Customise.tsx
+++ b/client/src/pages/Customise.tsx
@@ -4,35 +4,55 @@ import {
   Text,
   Stack,
   Group,
+  Alert,
+  Button,
+  Select,
   Switch,
   TextInput,
-  Select,
-  SegmentedControl,
-  Alert,
+  Skeleton,
   Badge,
-  useComputedColorScheme,
 } from "@mantine/core";
+import { useState, useEffect } from "react";
+import { useComputedColorScheme } from "@mantine/core";
 
 import { useSession } from "../api/authService";
+import { useUserSettings, useUpdateUserSettings } from "../api/settingsService";
 import { SettingsCard } from "../components/SettingsCard";
+import { profileCardThemes } from "../lib/themes";
+import { touchpointLocales } from "../lib/touchpointTranslations";
 
-/**
- * Design placeholder for the /customise page (Design B — grouped sections).
- *
- * This is intentionally NON-FUNCTIONAL and NOT wired into routing or the nav:
- * it exists so the chosen layout is concrete in the code before the dependent
- * feature issues start landing. Every control is disabled; no settings are
- * read or written. Each card is the drop-in spot for one dependent issue —
- * #199 (prompt), #266 (language), #177 (inbox), #58 (profanity), #192
- * (notifications) — which will replace its placeholder control with the real,
- * wired one once #273 hooks up the route.
- */
+const MAX_PROMPT_LENGTH = 100;
+
 export default function Customise() {
+  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
   const { data: session, isLoading: sessionLoading } = useSession();
-  const computedColorScheme = useComputedColorScheme("light", {
-    getInitialValueInEffect: true,
-  });
-  const isDark = computedColorScheme === "dark";
+  const {
+    data: userSettings,
+    isLoading: settingsLoading,
+    error: settingsError,
+    refetch: refetchSettings,
+  } = useUserSettings();
+  const updateSettings = useUpdateUserSettings();
+
+  // Local draft for the prompt text so typing doesn't fire a mutation per
+  // keystroke; persisted on blur when the value actually changed. Resyncs from
+  // the server value once it loads (async) and after a successful mutation so
+  // the trimmed/persisted result is reflected.
+  const [promptDraft, setPromptDraft] = useState<string>(userSettings?.customPrompt ?? "");
+  const promptInSync = (userSettings?.customPrompt ?? "") === promptDraft;
+  useEffect(() => {
+    setPromptDraft(userSettings?.customPrompt ?? "");
+  }, [userSettings?.customPrompt]);
+
+  const settingsLoadError = (
+    <Alert color="red" title="Failed to load settings" withCloseButton={false}>
+      <Button size="xs" onClick={() => refetchSettings()} variant="light" mt="xs">
+        Retry
+      </Button>
+    </Alert>
+  );
+
+  const busy = updateSettings.isPending;
 
   return (
     <>
@@ -47,13 +67,12 @@ export default function Customise() {
               Customise
             </Title>
             <Badge color="purple" variant="light" radius="sm">
-              Design preview
+              Beta
             </Badge>
           </Group>
           <Text c="dimmed" fz={15} mb="xl" style={{ maxWidth: "60ch", lineHeight: 1.5 }}>
             Control how your inbox presents itself to the world, grouped by who each setting
-            affects. This page is a layout placeholder — the controls are disabled until each
-            setting is implemented.
+            affects.
           </Text>
 
           <Section
@@ -66,12 +85,25 @@ export default function Customise() {
                 description="The headline shown above your message box. Leave blank to fall back to “Send [you] an anonymous message”."
                 isDark={isDark}
               >
-                <TextInput
-                  placeholder="Ask me anything…"
-                  maxLength={100}
-                  disabled
-                  aria-label="Profile prompt"
-                />
+                {settingsLoading ? (
+                  <Skeleton height={36} radius="sm" />
+                ) : settingsError ? (
+                  settingsLoadError
+                ) : (
+                  <TextInput
+                    value={promptDraft}
+                    onChange={(e) => setPromptDraft(e.target.value.slice(0, MAX_PROMPT_LENGTH))}
+                    onBlur={() => {
+                      if (promptInSync) return;
+                      updateSettings.mutate({ customPrompt: promptDraft.trim() || null });
+                    }}
+                    placeholder="Ask me anything…"
+                    maxLength={MAX_PROMPT_LENGTH}
+                    disabled={busy}
+                    aria-label="Profile prompt"
+                    description={`${promptDraft.length}/${MAX_PROMPT_LENGTH}`}
+                  />
+                )}
               </SettingsCard>
             </Grid.Col>
 
@@ -81,70 +113,100 @@ export default function Customise() {
                 description="Language of the prompt, share text, and anonymity disclaimer shown to visitors and your audience."
                 isDark={isDark}
               >
-                <Select
-                  data={["English", "Español", "Deutsch", "日本語"]}
-                  defaultValue="English"
-                  disabled
-                  aria-label="Message language"
-                />
-              </SettingsCard>
-            </Grid.Col>
-          </Section>
-
-          <Section eyebrow="Message intake" help="Who can reach your inbox, and what gets through.">
-            <Grid.Col span={{ base: 12, md: 6 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Inbox"
-                description="Turn off to stop receiving new messages while keeping your account, history, and settings intact."
-                isDark={isDark}
-              >
-                <Switch
-                  label="Accepting messages"
-                  defaultChecked
-                  disabled
-                  aria-label="Accepting messages"
-                />
-              </SettingsCard>
-            </Grid.Col>
-
-            <Grid.Col span={{ base: 12, md: 6 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Profanity filter"
-                description="Screen incoming messages against a wordlist before they reach you. No AI, just a list."
-                isDark={isDark}
-              >
-                <Stack gap="sm">
-                  <Switch label="Filter enabled" disabled aria-label="Filter enabled" />
-                  <SegmentedControl
-                    data={["Reject message", "Mask words"]}
-                    defaultValue="Reject message"
-                    disabled
-                    fullWidth
+                {settingsLoading ? (
+                  <Skeleton height={36} radius="sm" />
+                ) : settingsError ? (
+                  settingsLoadError
+                ) : (
+                  <Select
+                    data={touchpointLocales}
+                    value={
+                      touchpointLocales.some((l) => l.value === userSettings?.touchpointLocale)
+                        ? userSettings!.touchpointLocale!
+                        : "en"
+                    }
+                    onChange={(value) => updateSettings.mutate({ touchpointLocale: value || null })}
+                    disabled={busy}
+                    allowDeselect={false}
+                    aria-label="Message language"
                   />
-                  <Text fz={11} c="purple" fw={600}>
-                    Open question (#58): reject vs. mask
-                  </Text>
-                </Stack>
+                )}
+              </SettingsCard>
+            </Grid.Col>
+
+            <Grid.Col span={{ base: 12, lg: 6 }} style={{ display: "flex" }}>
+              <SettingsCard
+                title="Profile card colour"
+                description="The colour treatment of your ask card. Curated presets keep the text and button legible on every option."
+                isDark={isDark}
+              >
+                {settingsLoading ? (
+                  <Skeleton height={56} radius="sm" />
+                ) : settingsError ? (
+                  settingsLoadError
+                ) : (
+                  <ProfileThemeSwatches
+                    value={userSettings?.profileCardTheme ?? null}
+                    disabled={busy}
+                    onPick={(value) => updateSettings.mutate({ profileCardTheme: value })}
+                  />
+                )}
               </SettingsCard>
             </Grid.Col>
           </Section>
 
           <Section
-            eyebrow="Notifications"
-            help="Per-type push controls. Lands here only if #192 grows granular toggles; the single on/off control stays on the Settings page."
+            eyebrow="Message intake"
+            help="Who can reach your inbox, and what gets through."
             last
           >
             <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
               <SettingsCard
-                title="What sends a push"
-                description="The one-tap Enable / Disable control stays on the Settings page; these refine which events notify you."
+                title="Inbox"
+                description="Turn off to stop receiving new messages while keeping your account, history, and settings intact. Visitors see a “not accepting messages” state."
                 isDark={isDark}
               >
-                <Stack gap="sm">
-                  <Switch label="New message" defaultChecked disabled aria-label="New message" />
-                  <Switch label="Reply posted" defaultChecked disabled aria-label="Reply posted" />
-                  <Switch label="Daily digest" disabled aria-label="Daily digest" />
-                </Stack>
+                {settingsLoading ? (
+                  <Skeleton height={28} radius="sm" />
+                ) : settingsError ? (
+                  settingsLoadError
+                ) : (
+                  <Switch
+                    label="Accepting messages"
+                    checked={userSettings?.inboxEnabled !== 0}
+                    onChange={(e) =>
+                      updateSettings.mutate({ inboxEnabled: e.currentTarget.checked })
+                    }
+                    disabled={busy}
+                    aria-label="Accepting messages"
+                  />
+                )}
+              </SettingsCard>
+            </Grid.Col>
+
+            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
+              <SettingsCard
+                title="Profanity filter"
+                description="When on, incoming messages are screened against a wordlist. Flagged messages are silently dropped — the sender sees a success response, but the message never reaches your inbox."
+                isDark={isDark}
+              >
+                {settingsLoading ? (
+                  <Skeleton height={28} radius="sm" />
+                ) : settingsError ? (
+                  settingsLoadError
+                ) : (
+                  <Switch
+                    label="Filter enabled"
+                    checked={userSettings?.profanityFilterEnabled === 1}
+                    onChange={(e) =>
+                      updateSettings.mutate({
+                        profanityFilterEnabled: e.currentTarget.checked,
+                      })
+                    }
+                    disabled={busy}
+                    aria-label="Filter enabled"
+                  />
+                )}
               </SettingsCard>
             </Grid.Col>
           </Section>
@@ -171,6 +233,65 @@ function Section({ eyebrow, help, last, children }: SectionProps) {
         {help}
       </Text>
       <Grid style={{ gap: "var(--mantine-spacing-md)" }}>{children}</Grid>
+    </div>
+  );
+}
+
+/**
+ * Swatch selector for the ask-card colour preset, mirroring the ThemeCard
+ * pattern already used for image-export themes in Messages.tsx (selected =
+ * blue tint + border), but lighter-weight since the preview is just a gradient
+ * fill, not a multi-branch card mockup.
+ */
+function ProfileThemeSwatches({
+  value,
+  disabled,
+  onPick,
+}: {
+  value: string | null;
+  disabled: boolean;
+  onPick: (value: string) => void;
+}) {
+  return (
+    <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+      {Object.entries(profileCardThemes).map(([themeValue, theme]) => {
+        const selected = (value ?? "royal") === themeValue;
+        return (
+          <button
+            key={themeValue}
+            type="button"
+            onClick={() => onPick(themeValue)}
+            disabled={disabled}
+            aria-pressed={selected}
+            aria-label={`${theme.label} theme`}
+            style={{
+              background: selected ? "rgba(59,91,255,0.12)" : "transparent",
+              border: selected
+                ? "1.5px solid #3B5BFF"
+                : "1.5px solid var(--mantine-color-default-border)",
+              borderRadius: 10,
+              padding: 8,
+              cursor: disabled ? "default" : "pointer",
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              flex: "1 1 90px",
+              minWidth: 90,
+            }}
+          >
+            <div
+              style={{
+                aspectRatio: "4/3",
+                borderRadius: 5,
+                background: theme.gradient,
+              }}
+            />
+            <Text size="xs" fw={600} ta="center" style={{ color: "var(--mantine-color-text)" }}>
+              {theme.label}
+            </Text>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -45,6 +45,7 @@ import { useUserSettings, useUpdateUserSettings } from "../api/settingsService";
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import ShareButton from "../components/ShareButton";
 import { themes } from "../lib/themes";
+import { getTouchpointTranslations } from "../lib/touchpointTranslations";
 import { surfaceBg } from "../styles/tokens";
 
 // Styles for the reply textarea inside the response box (white card on dark background)
@@ -838,9 +839,14 @@ export default function Messages() {
                   )}
                 </CopyButton>
                 {(() => {
+                  // Localize the owner's own share copy in their selected
+                  // touchpoint language (#266) — this text leaves the DOM into
+                  // a tweet/DM, so Google Translate can't reach it.
+                  const ownerName = session.profile?.displayName || session.profile?.handle || "";
+                  const t = getTouchpointTranslations(userSettings?.touchpointLocale);
                   const sharePayload = {
-                    title: "Send me anonymous messages on Navyfragen!",
-                    text: `Send ${session.profile?.displayName} anonymous messages!`,
+                    title: t.inboxShareTitle,
+                    text: t.inboxShareText(ownerName),
                     url: fullUrl,
                   };
                   return <ShareButton shareData={sharePayload} />;

--- a/client/src/pages/PublicProfile.tsx
+++ b/client/src/pages/PublicProfile.tsx
@@ -25,6 +25,8 @@ import { useSendMessage } from "../api/messageService";
 import { useResolveHandle, usePublicProfile } from "../api/profileService";
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import { WinkMark } from "../components/WinkMark";
+import { profileCardGradient } from "../lib/themes";
+import { getTouchpointTranslations } from "../lib/touchpointTranslations";
 import { ghostBg } from "../styles/tokens";
 import { parseRichText } from "../utils/parseRichText";
 
@@ -84,6 +86,19 @@ export default function PublicProfile() {
   const { mutate: sendMessage, isPending: sendLoading } = useSendMessage();
   const { triggerHaptic } = useHaptic(1);
   const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
+
+  // Profile-owner customisations read off the public-profile response — the
+  // owner's language, prompt override, ask-card colour, and inbox-open state.
+  // All default to "unset" (English / default headline / default gradient /
+  // open) when the owner never configured them.
+  const touchpointLocale = profileData?.touchpointLocale ?? null;
+  const t = getTouchpointTranslations(touchpointLocale);
+  const askCardGradient = profileCardGradient(profileData?.profileCardTheme ?? null);
+  // The server's getPublicProfile normalizes inboxEnabled to a boolean in the
+  // response (false only when the owner explicitly closed their inbox). It's
+  // undefined when the field wasn't returned, which we treat as open.
+  const inboxOpen = profileData?.inboxEnabled !== false;
+  const ownerName = profile?.displayName || profile?.handle || "";
 
   const handleSend = () => {
     setFormError(null);
@@ -320,7 +335,7 @@ export default function PublicProfile() {
                     triggerHaptic();
                     try {
                       await navigator.share({
-                        title: `Send ${profile.displayName || profile.handle} an anonymous message`,
+                        title: t.shareTitle(ownerName),
                         url: `https://fragen.navy/${profile.handle}`,
                       });
                     } catch (e) {
@@ -446,7 +461,7 @@ export default function PublicProfile() {
             style={{
               borderRadius: 18,
               padding: 28,
-              background: "var(--nf-grad-mark)",
+              background: askCardGradient,
               border: "2px solid var(--mantine-color-default-border)",
               cursor: "text",
               position: "relative",
@@ -463,7 +478,7 @@ export default function PublicProfile() {
               fz={22}
               style={{ position: "relative", letterSpacing: "-0.01em" }}
             >
-              Send {profile.displayName || profile.handle} an anonymous message
+              {profileData?.customPrompt || t.headline(ownerName)}
             </Text>
 
             <Stack gap="xs">
@@ -485,67 +500,75 @@ export default function PublicProfile() {
                   {formError}
                 </Alert>
               )}
-              <Textarea
-                ref={textareaRef}
-                value={message}
-                onChange={(e) => {
-                  if (e.target.value.length <= MAX_MESSAGE_LENGTH) {
-                    setMessage(e.target.value);
-                  }
-                }}
-                minRows={2}
-                maxRows={4}
-                autosize
-                disabled={sendLoading}
-                aria-label={`Send ${profile.displayName || profile.handle} an anonymous message`}
-                placeholder="Ask something…"
-                description={`${message.length}/${MAX_MESSAGE_LENGTH}`}
-                onKeyDown={(e) => {
-                  if (
-                    (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.metaKey) ||
-                    (e.key === "Enter" && e.ctrlKey)
-                  ) {
-                    e.preventDefault();
-                    handleSend();
-                  }
-                }}
-                radius="md"
-                styles={askCardTextareaStyles}
-              />
-              <Group justify="flex-end" gap="xs">
-                <ActionIcon
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    triggerHaptic();
-                    setMessage("");
-                  }}
-                  variant="subtle"
-                  color="white"
-                  size="lg"
-                  radius="md"
-                  aria-label="Clear message"
-                >
-                  <IconX size={18} />
-                </ActionIcon>
-                <Button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    triggerHaptic();
-                    handleSend();
-                  }}
-                  loading={sendLoading}
-                  radius="md"
-                  leftSection={<IconSend size={16} />}
-                  color="sunshine"
-                  variant="filled"
-                  style={{
-                    color: "var(--nf-midnight)",
-                    fontWeight: 700,
-                  }}
-                >
-                  Send
-                </Button>
-              </Group>
+              {inboxOpen ? (
+                <>
+                  <Textarea
+                    ref={textareaRef}
+                    value={message}
+                    onChange={(e) => {
+                      if (e.target.value.length <= MAX_MESSAGE_LENGTH) {
+                        setMessage(e.target.value);
+                      }
+                    }}
+                    minRows={2}
+                    maxRows={4}
+                    autosize
+                    disabled={sendLoading}
+                    aria-label={t.headline(ownerName)}
+                    placeholder={t.placeholder}
+                    description={`${message.length}/${MAX_MESSAGE_LENGTH}`}
+                    onKeyDown={(e) => {
+                      if (
+                        (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.metaKey) ||
+                        (e.key === "Enter" && e.ctrlKey)
+                      ) {
+                        e.preventDefault();
+                        handleSend();
+                      }
+                    }}
+                    radius="md"
+                    styles={askCardTextareaStyles}
+                  />
+                  <Group justify="flex-end" gap="xs">
+                    <ActionIcon
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        triggerHaptic();
+                        setMessage("");
+                      }}
+                      variant="subtle"
+                      color="white"
+                      size="lg"
+                      radius="md"
+                      aria-label="Clear message"
+                    >
+                      <IconX size={18} />
+                    </ActionIcon>
+                    <Button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        triggerHaptic();
+                        handleSend();
+                      }}
+                      loading={sendLoading}
+                      radius="md"
+                      leftSection={<IconSend size={16} />}
+                      color="sunshine"
+                      variant="filled"
+                      style={{
+                        color: "var(--nf-midnight)",
+                        fontWeight: 700,
+                      }}
+                    >
+                      {t.sendLabel}
+                    </Button>
+                  </Group>
+                </>
+              ) : (
+                <Text c="white" ta="center" fz={15} style={{ opacity: 0.85 }}>
+                  {t.inboxClosed}
+                </Text>
+              )}
             </Stack>
           </Paper>
 
@@ -561,9 +584,7 @@ export default function PublicProfile() {
             }}
           >
             <Text size="xs" c="dimmed">
-              Your message will be sent anonymously to the user. They may post it publicly on
-              Bluesky, so please don&apos;t share any personal information or passwords. Be curious,
-              but respectful and kind!
+              {t.disclaimer}
             </Text>
           </Group>
 

--- a/client/src/tests/lib/themes.test.ts
+++ b/client/src/tests/lib/themes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { themes } from "../../lib/themes";
+import { themes, profileCardThemes, profileCardGradient } from "../../lib/themes";
 
 describe("themes", () => {
   it("has all three theme keys", () => {
@@ -13,5 +13,43 @@ describe("themes", () => {
     expect(themes.default).toBe("Default");
     expect(themes.compressed).toBe("Compressed");
     expect(themes.twitter).toBe("Twitter Style");
+  });
+});
+
+describe("profileCardThemes (#275)", () => {
+  it("includes the curated preset set", () => {
+    expect(Object.keys(profileCardThemes).sort()).toEqual(["aurora", "ember", "royal", "verdant"]);
+  });
+
+  it("each preset has a label and a gradient token (no raw hex)", () => {
+    for (const theme of Object.values(profileCardThemes)) {
+      expect(typeof theme.label).toBe("string");
+      expect(theme.label.length).toBeGreaterThan(0);
+      // Gradients reference --nf-grad-* tokens, never inline colours.
+      expect(theme.gradient).toMatch(/^var\(--nf-grad-/);
+    }
+  });
+
+  it("royal reuses the default --nf-grad-mark gradient", () => {
+    expect(profileCardThemes.royal.gradient).toBe("var(--nf-grad-mark)");
+  });
+});
+
+describe("profileCardGradient", () => {
+  it("resolves a known theme key to its gradient", () => {
+    expect(profileCardGradient("ember")).toBe("var(--nf-grad-ember)");
+    expect(profileCardGradient("aurora")).toBe("var(--nf-grad-aurora)");
+  });
+
+  it("falls back to the default gradient when unset (null)", () => {
+    expect(profileCardGradient(null)).toBe("var(--nf-grad-mark)");
+  });
+
+  it("falls back to the default gradient for an unknown theme key", () => {
+    expect(profileCardGradient("nonexistent")).toBe("var(--nf-grad-mark)");
+  });
+
+  it("falls back to the default gradient when undefined", () => {
+    expect(profileCardGradient(undefined)).toBe("var(--nf-grad-mark)");
   });
 });

--- a/client/src/tests/lib/touchpointTranslations.test.ts
+++ b/client/src/tests/lib/touchpointTranslations.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getTouchpointTranslations,
+  touchpointLocales,
+  type TouchpointTranslations,
+} from "../../lib/touchpointTranslations";
+
+// Every property a locale must define, so a new locale that misses a key is
+// caught by the structural check below rather than rendering undefined.
+const REQUIRED_STRING_KEYS: (keyof TouchpointTranslations)[] = [
+  "placeholder",
+  "sendLabel",
+  "disclaimer",
+  "inboxClosed",
+  "inboxShareTitle",
+];
+const REQUIRED_FN_KEYS: (keyof TouchpointTranslations)[] = [
+  "headline",
+  "shareTitle",
+  "inboxShareText",
+];
+
+describe("touchpointTranslations (#266)", () => {
+  it("exposes the supported locale set with en first (default)", () => {
+    expect(touchpointLocales[0]).toEqual({ value: "en", label: "English" });
+    const values = touchpointLocales.map((l) => l.value);
+    expect(values).toEqual(["en", "es", "pt", "de", "fr"]);
+  });
+
+  it("every locale defines every touchpoint", () => {
+    for (const { value } of touchpointLocales) {
+      const t = getTouchpointTranslations(value);
+      for (const key of REQUIRED_STRING_KEYS) {
+        const v = t[key];
+        expect(typeof v).toBe("string");
+        expect((v as string).length).toBeGreaterThan(0);
+      }
+      for (const key of REQUIRED_FN_KEYS) {
+        expect(typeof t[key]).toBe("function");
+      }
+    }
+  });
+
+  it("every parameterized touchpoint returns a non-empty string for every locale", () => {
+    // Invoke each function for each locale so every locale object's function
+    // bodies are covered (not just en/es).
+    for (const { value } of touchpointLocales) {
+      const t = getTouchpointTranslations(value);
+      for (const key of REQUIRED_FN_KEYS) {
+        const fn = t[key] as (name: string) => string;
+        const result = fn("Name");
+        expect(typeof result).toBe("string");
+        expect(result.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("parameterized touchpoints interpolate the display name", () => {
+    const t = getTouchpointTranslations("en");
+    expect(t.headline("Ada")).toBe("Send Ada an anonymous message");
+    expect(t.shareTitle("Ada")).toBe("Send Ada an anonymous message");
+    expect(t.inboxShareText("Ada")).toBe("Send Ada anonymous messages!");
+  });
+
+  it("returns English for null (the unset default)", () => {
+    const t = getTouchpointTranslations(null);
+    expect(t.sendLabel).toBe("Send");
+    expect(t.placeholder).toBe("Ask something…");
+  });
+
+  it("falls back to English for an unknown locale rather than throwing", () => {
+    const t = getTouchpointTranslations("xx");
+    expect(t.sendLabel).toBe("Send");
+  });
+
+  it("falls back to English for undefined", () => {
+    const t = getTouchpointTranslations(undefined);
+    expect(t.sendLabel).toBe("Send");
+  });
+
+  it("returns distinct copy for a non-English locale", () => {
+    // Sanity check that the table actually localizes — not just en under
+    // every key. Spanish send label is "Enviar".
+    const t = getTouchpointTranslations("es");
+    expect(t.sendLabel).toBe("Enviar");
+    expect(t.headline("Ada")).toBe("Envía a Ada un mensaje anónimo");
+  });
+});

--- a/client/src/tests/pages/Customise.test.tsx
+++ b/client/src/tests/pages/Customise.test.tsx
@@ -1,7 +1,8 @@
-import { screen } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import * as authService from "../../api/authService";
+import * as settingsService from "../../api/settingsService";
 import Customise from "../../pages/Customise";
 import { renderWithProviders } from "../testUtils";
 
@@ -10,11 +11,57 @@ vi.mock("../../api/authService", async (importOriginal) => {
   return { ...actual, useSession: vi.fn() };
 });
 
-const mockUseSession = vi.mocked(authService.useSession);
+vi.mock("../../api/settingsService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/settingsService")>();
+  return {
+    ...actual,
+    useUserSettings: vi.fn(),
+    useUpdateUserSettings: vi.fn(),
+  };
+});
 
-describe("Customise page (design placeholder)", () => {
+const mockUseSession = vi.mocked(authService.useSession);
+const mockUseUserSettings = vi.mocked(settingsService.useUserSettings);
+const mockUseUpdateUserSettings = vi.mocked(settingsService.useUpdateUserSettings);
+
+function mockSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      did: "did:example:user",
+      pdsSyncEnabled: 1,
+      imageTheme: "default",
+      inboxEnabled: 1,
+      profanityFilterEnabled: 0,
+      customPrompt: null,
+      profileCardTheme: null,
+      touchpointLocale: null,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      ...overrides,
+    },
+    isLoading: false,
+  } as any;
+}
+
+function mockMutation() {
+  const mutate = vi.fn();
+  mockUseUpdateUserSettings.mockReturnValue({
+    mutate,
+    isPending: false,
+  } as any);
+  return mutate;
+}
+
+describe("Customise page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseSession.mockReturnValue({
+      data: { isLoggedIn: true, profile: { handle: "karan.bsky.social" } },
+      isLoading: false,
+    } as any);
+    // Default the settings hook so the component doesn't throw on render even
+    // in the logged-out test (useUserSettings is called before the auth gate).
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    mockMutation();
   });
 
   it("shows auth error when user is not logged in", () => {
@@ -26,46 +73,131 @@ describe("Customise page (design placeholder)", () => {
     expect(screen.getByText(/cannot access this page without logging in/i)).toBeInTheDocument();
   });
 
-  it("renders the grouped sections for a logged-in user", () => {
-    mockUseSession.mockReturnValue({
-      data: { isLoggedIn: true, profile: { handle: "karan.bsky.social" } },
-      isLoading: false,
-    } as any);
+  it("renders the grouped sections and wired controls for a logged-in user", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    mockMutation();
     renderWithProviders(<Customise />);
 
     expect(screen.getByRole("heading", { name: /customise/i })).toBeInTheDocument();
-    expect(screen.getByText(/design preview/i)).toBeInTheDocument();
     // Section eyebrows
     expect(screen.getByText(/your public profile/i)).toBeInTheDocument();
     expect(screen.getByText(/message intake/i)).toBeInTheDocument();
-    expect(screen.getByText(/^notifications$/i)).toBeInTheDocument();
-    // Placeholder cards
+    // Wired cards
     expect(screen.getByText(/profile prompt/i)).toBeInTheDocument();
     expect(screen.getByText(/message language/i)).toBeInTheDocument();
+    expect(screen.getByText(/profile card colour/i)).toBeInTheDocument();
     expect(screen.getByText(/^inbox$/i)).toBeInTheDocument();
     expect(screen.getByText(/profanity filter/i)).toBeInTheDocument();
-    expect(screen.getByText(/what sends a push/i)).toBeInTheDocument();
+    // Notifications section was removed.
+    expect(screen.queryByText(/^notifications$/i)).toBeNull();
+    expect(screen.queryByText(/what sends a push/i)).toBeNull();
   });
 
-  it("keeps every control disabled (non-functional placeholder)", () => {
-    mockUseSession.mockReturnValue({
-      data: { isLoggedIn: true, profile: { handle: "karan.bsky.social" } },
-      isLoading: false,
-    } as any);
+  it("toggling the inbox switch fires updateSettings with only inboxEnabled", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    const mutate = mockMutation();
     renderWithProviders(<Customise />);
 
-    const promptInput = screen.getByLabelText(/profile prompt/i) as HTMLInputElement;
-    expect(promptInput).toBeDisabled();
-    const acceptingSwitch = screen.getByLabelText(/accepting messages/i) as HTMLInputElement;
-    expect(acceptingSwitch).toBeDisabled();
+    const toggle = screen.getByLabelText(/accepting messages/i) as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith({ inboxEnabled: false });
+  });
+
+  it("toggling the profanity filter fires updateSettings with only profanityFilterEnabled", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    const mutate = mockMutation();
+    renderWithProviders(<Customise />);
+
+    const toggle = screen.getByLabelText(/filter enabled/i) as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith({ profanityFilterEnabled: true });
+  });
+
+  it("picking a locale fires updateSettings with touchpointLocale", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    const mutate = mockMutation();
+    renderWithProviders(<Customise />);
+
+    // Mantine Select renders a combobox. Query by role to avoid matching the
+    // card title text, then open it and pick Español.
+    const combobox = screen.getByRole("combobox", { name: /message language/i });
+    fireEvent.click(combobox);
+    const option = screen.getByRole("option", { name: /español/i });
+    fireEvent.click(option);
+
+    expect(mutate).toHaveBeenCalledWith({ touchpointLocale: "es" });
+  });
+
+  it("picking a profile card theme swatch fires updateSettings with profileCardTheme", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    const mutate = mockMutation();
+    renderWithProviders(<Customise />);
+
+    fireEvent.click(screen.getByLabelText(/ember theme/i));
+    expect(mutate).toHaveBeenCalledWith({ profileCardTheme: "ember" });
+  });
+
+  it("persisting a custom prompt fires updateSettings with the trimmed value", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    const mutate = mockMutation();
+    renderWithProviders(<Customise />);
+
+    const input = screen.getByLabelText(/profile prompt/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Ask me anything" } });
+    fireEvent.blur(input);
+
+    expect(mutate).toHaveBeenCalledWith({ customPrompt: "Ask me anything" });
+  });
+
+  it("blurring an unchanged prompt does not fire a mutation", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings({ customPrompt: "existing" }));
+    const mutate = mockMutation();
+    renderWithProviders(<Customise />);
+
+    const input = screen.getByLabelText(/profile prompt/i) as HTMLInputElement;
+    fireEvent.blur(input); // no change
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("clearing the prompt persists null (revert to default)", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings({ customPrompt: "existing" }));
+    const mutate = mockMutation();
+    renderWithProviders(<Customise />);
+
+    const input = screen.getByLabelText(/profile prompt/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    expect(mutate).toHaveBeenCalledWith({ customPrompt: null });
   });
 
   it("renders correctly in dark mode", () => {
-    mockUseSession.mockReturnValue({
-      data: { isLoggedIn: true, profile: { handle: "karan.bsky.social" } },
-      isLoading: false,
-    } as any);
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    mockMutation();
     renderWithProviders(<Customise />, { colorScheme: "dark" });
     expect(screen.getByRole("heading", { name: /customise/i })).toBeInTheDocument();
+  });
+
+  it("shows a retry control when settings fail to load", () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    mockUseUserSettings.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("boom"),
+      refetch,
+    } as any);
+    mockMutation();
+    renderWithProviders(<Customise />);
+
+    // The settings-error fallback renders inside each card, so there's a
+    // retry button per card. Clicking any of them calls refetchSettings.
+    const retry = screen.getAllByRole("button", { name: /^retry$/i })[0];
+    fireEvent.click(retry);
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/tests/pages/Messages.test.tsx
+++ b/client/src/tests/pages/Messages.test.tsx
@@ -1591,4 +1591,55 @@ describe("Messages page", () => {
       scrollSpy.mockRestore();
     }
   });
+
+  it("localizes the owner's share payload to their touchpoint locale (#266)", async () => {
+    // The share text leaves the DOM into the OS share sheet, so it can't be
+    // reached by browser translate — it must be pre-localized from the owner's
+    // setting. Spy on navigator.share to capture what's actually handed off.
+    const shareSpy = vi.fn().mockResolvedValue(undefined);
+    const originalShare = navigator.share;
+    Object.defineProperty(navigator, "share", {
+      value: shareSpy,
+      configurable: true,
+      writable: true,
+    });
+
+    mockUseSession.mockReturnValue({ data: SESSION, isLoading: false } as any);
+    mockUseMessages.mockReturnValue({
+      data: { messages: [] },
+      isLoading: false,
+      refetch: vi.fn(),
+    } as any);
+    mockUseDeleteMessage.mockReturnValue(noopMutation);
+    mockUseRespondToMessage.mockReturnValue(noopMutation);
+    mockUseAddExampleMessages.mockReturnValue(noopMutation);
+    mockUseUserSettings.mockReturnValue({
+      data: {
+        pdsSyncEnabled: false,
+        imageTheme: "default",
+        touchpointLocale: "es",
+      },
+      isLoading: false,
+    } as any);
+    mockUseUpdateUserSettings.mockReturnValue(noopMutation);
+
+    try {
+      renderWithProviders(<Messages />);
+      // The "Share" button in the profile header hands sharePayload to the OS.
+      const shareButtons = screen.getAllByRole("button", { name: /^share$/i });
+      fireEvent.click(shareButtons[0]);
+      await waitFor(() => expect(shareSpy).toHaveBeenCalled());
+
+      const payload = shareSpy.mock.calls[0][0];
+      // Spanish acquisition copy, parameterized with the owner's display name.
+      expect(payload.title).toBe("¡Envíame mensajes anónimos en Navyfragen!");
+      expect(payload.text).toBe("¡Envía a Karan mensajes anónimos!");
+    } finally {
+      Object.defineProperty(navigator, "share", {
+        value: originalShare,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
 });

--- a/client/src/tests/pages/PublicProfile.test.tsx
+++ b/client/src/tests/pages/PublicProfile.test.tsx
@@ -738,4 +738,76 @@ describe("PublicProfile page", () => {
     // errObj = null → fallback message and not-404 error type
     expect(screen.getByText(/failed to resolve handle/i)).toBeInTheDocument();
   });
+
+  // ---- /customise-driven customisations (#199/#177/#275/#266) ----
+
+  function setupWithSettings(settings: Record<string, unknown>) {
+    mockUseResolveHandle.mockReturnValue({
+      data: { did: TEST_DID },
+      isLoading: false,
+      error: null,
+    } as any);
+    mockUsePublicProfile.mockReturnValue({
+      data: {
+        exists: true,
+        profile: {
+          did: TEST_DID,
+          handle: "karan.bsky.social",
+          displayName: "Karan",
+          avatar: null,
+        },
+        ...settings,
+      },
+      isLoading: false,
+      error: null,
+    } as any);
+    mockUseSendMessage.mockReturnValue({ mutate: vi.fn(), isPending: false } as any);
+  }
+
+  it("renders the owner's custom prompt when set (#199)", () => {
+    setupWithSettings({ customPrompt: "Ask me about anything" });
+    renderWithProviders(<PublicProfile />);
+    expect(screen.getByText(/ask me about anything/i)).toBeInTheDocument();
+    // Default headline is NOT shown when an override is present.
+    expect(screen.queryByText(/send karan an anonymous message/i)).toBeNull();
+  });
+
+  it("falls back to the default headline when the prompt is unset (#199)", () => {
+    setupWithSettings({ customPrompt: null });
+    renderWithProviders(<PublicProfile />);
+    expect(screen.getByText(/send karan an anonymous message/i)).toBeInTheDocument();
+  });
+
+  it("localizes ask-card strings to the owner's touchpoint locale (#266)", () => {
+    setupWithSettings({ touchpointLocale: "es" });
+    renderWithProviders(<PublicProfile />);
+    // Spanish headline, placeholder, send button, and disclaimer.
+    expect(screen.getByText(/envía a karan un mensaje anónimo/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/pregunta algo/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /enviar/i })).toBeInTheDocument();
+    expect(screen.getByText(/tu mensaje se enviará de forma anónima/i)).toBeInTheDocument();
+  });
+
+  it("shows a closed-inbox state instead of the send form when inboxEnabled is false (#177)", () => {
+    setupWithSettings({ inboxEnabled: false });
+    renderWithProviders(<PublicProfile />);
+    // Closed message shown, no textarea / send button.
+    expect(screen.getByText(/not accepting new messages/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/ask something/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /^send$/i })).toBeNull();
+  });
+
+  it("renders the default ask-card gradient when no theme is set (#275)", () => {
+    setupWithSettings({ profileCardTheme: null });
+    const { container } = renderWithProviders(<PublicProfile />);
+    const askCard = container.querySelector("[style*='nf-grad-mark']") as HTMLElement | null;
+    expect(askCard).not.toBeNull();
+  });
+
+  it("applies the owner's selected profile card theme gradient (#275)", () => {
+    setupWithSettings({ profileCardTheme: "ember" });
+    const { container } = renderWithProviders(<PublicProfile />);
+    const askCard = container.querySelector("[style*='nf-grad-ember']") as HTMLElement | null;
+    expect(askCard).not.toBeNull();
+  });
 });

--- a/e2e/web/customise.spec.ts
+++ b/e2e/web/customise.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, type Page } from "@playwright/test";
+
+test.use({ storageState: "e2e/.auth/user.json" });
+
+const handle = () => {
+  const h = process.env.E2E_HANDLE;
+  if (!h) throw new Error("E2E_HANDLE must be set");
+  return h;
+};
+
+// Read the full settings object so a test can capture the initial value,
+// mutate it, and restore it afterwards — leaving the shared account untouched.
+async function getSettings(page: Page) {
+  const res = await page.request.get("/api/settings");
+  expect(res.ok(), "GET /api/settings succeeded").toBeTruthy();
+  return (await res.json()) as Record<string, unknown>;
+}
+
+// Persist a partial settings update (mirrors what each /customise card does).
+async function patchSettings(page: Page, patch: Record<string, unknown>) {
+  const res = await page.request.post("/api/settings", { data: patch });
+  expect(res.ok(), `POST /api/settings with ${JSON.stringify(patch)} succeeded`).toBeTruthy();
+  return (await res.json()) as Record<string, unknown>;
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/customise");
+  await expect(page).toHaveURL(/\/customise/);
+  await expect(page.getByRole("heading", { name: "Customise", exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("customise page renders the wired cards", async ({ page }) => {
+  // Section eyebrows.
+  await expect(page.getByText("Your public profile", { exact: true })).toBeVisible();
+  await expect(page.getByText("Message intake", { exact: true })).toBeVisible();
+  // Wired cards.
+  await expect(page.getByText("Profile prompt", { exact: true })).toBeVisible();
+  await expect(page.getByText("Message language", { exact: true })).toBeVisible();
+  await expect(page.getByText("Profile card colour", { exact: true })).toBeVisible();
+  await expect(page.getByText("Inbox", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Profanity filter", { exact: true })).toBeVisible();
+  // The Notifications section was intentionally removed.
+  await expect(page.getByText("What sends a push", { exact: true })).toHaveCount(0);
+});
+
+test("inbox toggle flips and is restored afterwards", async ({ page }) => {
+  const toggle = page.getByRole("switch", { name: /accepting messages/i });
+  await expect(toggle).toBeVisible({ timeout: 10_000 });
+  // Wait for settings to load so the switch reflects the server value.
+  await expect(toggle).toBeEnabled({ timeout: 10_000 });
+  const initiallyChecked = await toggle.isChecked();
+
+  await toggle.click();
+  // The switch is driven by the settings query, which refetches after the
+  // mutation settles — wait for the server value to flip, then for the DOM.
+  await expect.poll(async () => Boolean((await getSettings(page)).inboxEnabled), {
+    timeout: 10_000,
+  }).toBe(!initiallyChecked);
+  await expect(toggle).toBeChecked({ checked: !initiallyChecked });
+
+  // Restore the original state.
+  await toggle.click();
+  await expect.poll(async () => Boolean((await getSettings(page)).inboxEnabled), {
+    timeout: 10_000,
+  }).toBe(initiallyChecked);
+  await expect(toggle).toBeChecked({ checked: initiallyChecked });
+});
+
+test("profanity filter toggle flips and is restored afterwards", async ({ page }) => {
+  const toggle = page.getByRole("switch", { name: /filter enabled/i });
+  await expect(toggle).toBeVisible({ timeout: 10_000 });
+  await expect(toggle).toBeEnabled({ timeout: 10_000 });
+  const initiallyChecked = await toggle.isChecked();
+
+  await toggle.click();
+  await expect.poll(async () => Boolean((await getSettings(page)).profanityFilterEnabled), {
+    timeout: 10_000,
+  }).toBe(!initiallyChecked);
+  await expect(toggle).toBeChecked({ checked: !initiallyChecked });
+
+  // Restore.
+  await toggle.click();
+  await expect.poll(async () => Boolean((await getSettings(page)).profanityFilterEnabled), {
+    timeout: 10_000,
+  }).toBe(initiallyChecked);
+  await expect(toggle).toBeChecked({ checked: initiallyChecked });
+});
+
+test("custom prompt persists on blur and is cleared afterwards", async ({ page }) => {
+  const input = page.getByLabel("Profile prompt");
+  await expect(input).toBeVisible({ timeout: 10_000 });
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+
+  const prompt = `[e2e prompt ${Date.now()}] Ask me anything`;
+  await input.fill(prompt);
+  await input.blur();
+
+  // The server now stores the prompt.
+  let settings = await getSettings(page);
+  expect(settings.customPrompt).toBe(prompt);
+
+  // Clear it (persist null) to leave the account at the default.
+  await input.fill("");
+  await input.blur();
+  settings = await getSettings(page);
+  expect(settings.customPrompt).toBeNull();
+});
+
+test("message language selector changes locale and is restored afterwards", async ({ page }) => {
+  const select = page.getByRole("combobox", { name: /message language/i });
+  await expect(select).toBeVisible({ timeout: 10_000 });
+  await expect(select).toBeEnabled({ timeout: 10_000 });
+
+  const initial = (await getSettings(page)).touchpointLocale ?? "en";
+
+  // Pick Español.
+  await select.click();
+  await page.getByRole("option", { name: /^español$/i }).click();
+
+  let settings = await getSettings(page);
+  expect(settings.touchpointLocale).toBe("es");
+
+  // Restore to the original (null = English when it was unset).
+  await patchSettings(page, { touchpointLocale: initial === "en" ? null : initial });
+  settings = await getSettings(page);
+  expect(settings.touchpointLocale).toBe(initial === "en" ? null : initial);
+});
+
+test("profile card colour swatch changes theme and is restored afterwards", async ({ page }) => {
+  // Wait for the swatches to render.
+  const ember = page.getByRole("button", { name: /ember theme/i });
+  await expect(ember).toBeVisible({ timeout: 10_000 });
+  await expect(ember).toBeEnabled({ timeout: 10_000 });
+
+  const initial = (await getSettings(page)).profileCardTheme ?? null;
+
+  await ember.click();
+
+  let settings = await getSettings(page);
+  expect(settings.profileCardTheme).toBe("ember");
+
+  // Restore (null = default Royal gradient).
+  await patchSettings(page, { profileCardTheme: initial });
+  settings = await getSettings(page);
+  expect(settings.profileCardTheme).toBe(initial);
+});
+
+test("closed inbox shows a not-accepting-messages state on the public profile", async ({
+  page,
+}) => {
+  // Close the inbox via the API (fast, deterministic), then visit the profile.
+  await patchSettings(page, { inboxEnabled: false });
+
+  try {
+    await page.goto(`/profile/${handle()}`);
+    // The ask card is still themed, but the send form is replaced by the
+    // closed message — no textarea, no Send button.
+    await expect(page.getByText(/not accepting new messages/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel(/^Send .+ an anonymous message$/)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Send", exact: true })).toHaveCount(0);
+  } finally {
+    // Always restore so the shared account keeps accepting messages.
+    await patchSettings(page, { inboxEnabled: true });
+  }
+});
+
+test("profanity filter silently drops a flagged message", async ({ page }) => {
+  // Enable the filter, capture the inbox count, send a profane + a clean
+  // message, then assert only the clean one landed.
+  await patchSettings(page, { profanityFilterEnabled: true });
+  const session = await page.request.get("/api/session");
+  const { did } = await session.json();
+
+  try {
+    const statsBefore = await (await page.request.get("/api/stats")).json();
+
+    // Both sends return success to the sender...
+    const profane = await page.request.post("/api/messages/send", {
+      data: { recipient: did, message: `you are such a fuck [e2e ${Date.now()}]` },
+    });
+    expect(profane.ok(), "profane send returned success to sender").toBeTruthy();
+
+    const clean = await page.request.post("/api/messages/send", {
+      data: { recipient: did, message: `[e2e profanity ${Date.now()}] what's your favorite color?` },
+    });
+    expect(clean.ok(), "clean send returned success").toBeTruthy();
+
+    // ...but only the clean one reached the inbox (+1, not +2).
+    const statsAfter = await (await page.request.get("/api/stats")).json();
+    expect(statsAfter.messageCount).toBe(statsBefore.messageCount + 1);
+
+    // The profane text is absent from the inbox; the clean text is present.
+    const msgs = await (await page.request.get(`/api/messages/${did}`)).json();
+    const bodies: string[] = msgs.messages.map((m: { message: string }) => m.message);
+    expect(bodies.some((b) => b.includes("fuck"))).toBeFalsy();
+    expect(bodies.some((b) => b.includes("favorite color"))).toBeTruthy();
+
+    // Cleanup the clean message we inserted.
+    const cleanMsg = msgs.messages.find((m: { message: string }) =>
+      m.message.includes("favorite color")
+    );
+    if (cleanMsg) await page.request.delete(`/api/messages/${cleanMsg.tid}`);
+  } finally {
+    // Restore the filter to off (default).
+    await patchSettings(page, { profanityFilterEnabled: false });
+  }
+});

--- a/server/package.json
+++ b/server/package.json
@@ -78,6 +78,7 @@
     "iron-session": "^8.0.4",
     "kysely": "^0.29.4",
     "multiformats": "^14.0.4",
+    "obscenity": "^0.4.6",
     "pg": "^8.22.0",
     "pino": "^10.3.1",
     "sharp": "^0.35.3",

--- a/server/src/controllers/message-controller.ts
+++ b/server/src/controllers/message-controller.ts
@@ -152,7 +152,11 @@ export class MessageController {
     } catch (err: unknown) {
       this.logger.error({ err, recipient }, "Failed to send message");
       const msg = errorMessage(err);
-      return res.status(msg.includes("not found") ? 404 : 500).json({
+      // "not found" → 404 (recipient isn't a Navyfragen user); "inbox is
+      // closed" → 403 (recipient exists but disabled intake). Everything else
+      // is an internal failure.
+      const status = msg.includes("not found") ? 404 : msg.includes("not accepting") ? 403 : 500;
+      return res.status(status).json({
         error: msg || "Failed to send message",
       });
     }

--- a/server/src/controllers/settings-controller.ts
+++ b/server/src/controllers/settings-controller.ts
@@ -85,15 +85,41 @@ export class SettingsController {
   };
 
   /**
-   * Validate request for updating settings
+   * Validate request for updating settings.
+   *
+   * Every field is optional — the /customise page persists one card's setting
+   * at a time, so only validate the keys a client actually sent. Null is a
+   * valid value for the nullable columns (it means "use the default").
    */
   validateUpdateSettings = [
-    body("pdsSyncEnabled").isBoolean().withMessage("pdsSyncEnabled must be a boolean value"),
+    body("pdsSyncEnabled")
+      .optional()
+      .isBoolean()
+      .withMessage("pdsSyncEnabled must be a boolean value"),
     body("imageTheme")
+      .optional({ nullable: true })
       .isString()
       .withMessage("imageTheme must be a string")
       .notEmpty()
       .withMessage("imageTheme cannot be empty"),
+    body("inboxEnabled").optional().isBoolean().withMessage("inboxEnabled must be a boolean value"),
+    body("profanityFilterEnabled")
+      .optional()
+      .isBoolean()
+      .withMessage("profanityFilterEnabled must be a boolean value"),
+    body("customPrompt")
+      .optional({ nullable: true })
+      .isString()
+      .isLength({ max: 100 })
+      .withMessage("customPrompt must be a string of at most 100 chars"),
+    body("profileCardTheme")
+      .optional({ nullable: true })
+      .isString()
+      .withMessage("profileCardTheme must be a string"),
+    body("touchpointLocale")
+      .optional({ nullable: true })
+      .isString()
+      .withMessage("touchpointLocale must be a string"),
   ];
   /**
    * Update the user's settings
@@ -109,14 +135,21 @@ export class SettingsController {
     }
 
     try {
-      const pdsSyncEnabled = req.body.pdsSyncEnabled === true;
-      const imageTheme = req.body.imageTheme;
-      const updatedSettings = await this.settingsService.updateSettings(
-        userSessionDid,
-        pdsSyncEnabled,
-        imageTheme
-      );
-      this.logger.info({ did: userSessionDid, pdsSyncEnabled, imageTheme }, "Settings updated");
+      const updatedSettings = await this.settingsService.updateSettings(userSessionDid, {
+        pdsSyncEnabled:
+          req.body.pdsSyncEnabled === undefined ? undefined : req.body.pdsSyncEnabled === true,
+        imageTheme: req.body.imageTheme,
+        inboxEnabled:
+          req.body.inboxEnabled === undefined ? undefined : req.body.inboxEnabled === true,
+        profanityFilterEnabled:
+          req.body.profanityFilterEnabled === undefined
+            ? undefined
+            : req.body.profanityFilterEnabled === true,
+        customPrompt: req.body.customPrompt,
+        profileCardTheme: req.body.profileCardTheme,
+        touchpointLocale: req.body.touchpointLocale,
+      });
+      this.logger.info({ did: userSessionDid, updates: req.body }, "Settings updated");
       return res.json(updatedSettings);
     } catch (err) {
       this.logger.error({ err, did: userSessionDid }, "Failed to update user settings");

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -60,6 +60,15 @@ export type UserSettings = {
   did: string; // User's Decentralized Identifier
   pdsSyncEnabled: number; // Whether PDS sync is enabled (1=true, 0=false for SQLite compatibility)
   imageTheme: string; // The user's selected image theme
+  // Whether the inbox accepts new anonymous messages (1=true, 0=false). When
+  // false, sendMessage() rejects new sends while getMessages() keeps working.
+  inboxEnabled: number;
+  // Whether incoming messages are screened against a profanity wordlist
+  // (1=true, 0=false). A flagged message is rejected at send time (#58).
+  profanityFilterEnabled: number;
+  customPrompt: string | null; // Optional override for the ask-card headline; null = default string
+  profileCardTheme: string | null; // Optional ask-card colour preset; null = default --nf-grad-mark
+  touchpointLocale: string | null; // Optional locale for ask-card/share touchpoints; null = English
   createdAt: string; // Timestamp of when the user settings were first created
 };
 
@@ -289,6 +298,38 @@ migrations["008"] = {
       .on("push_subscription")
       .column("did")
       .execute();
+  },
+};
+
+// Adds the five /customise-page settings in one migration so the dependent
+// issues (#199/#177/#275/#266/#58) land against a single schema change.
+// - inboxEnabled NOT NULL default true — a closed inbox rejects sends but keeps
+//   the account/history (contrast with full account deletion).
+// - profanityFilterEnabled NOT NULL default false — opt-in wordlist screening
+//   of incoming messages (#58). A flagged message is rejected at send time.
+// - customPrompt/profileCardTheme/touchpointLocale nullable — null means
+//   "fall back to the default", matching how imageTheme defaults but allowing
+//   an explicit unset that the existing NOT NULL imageTheme column can't.
+migrations["009"] = {
+  async up(db: Kysely<unknown>) {
+    await db.schema
+      .alterTable("user_settings")
+      .addColumn("inboxEnabled", "boolean", (col) => col.notNull().defaultTo(true))
+      .execute();
+    await db.schema
+      .alterTable("user_settings")
+      .addColumn("profanityFilterEnabled", "boolean", (col) => col.notNull().defaultTo(false))
+      .execute();
+    await db.schema.alterTable("user_settings").addColumn("customPrompt", "varchar").execute();
+    await db.schema.alterTable("user_settings").addColumn("profileCardTheme", "varchar").execute();
+    await db.schema.alterTable("user_settings").addColumn("touchpointLocale", "varchar").execute();
+  },
+  async down(db: Kysely<unknown>) {
+    await db.schema.alterTable("user_settings").dropColumn("touchpointLocale").execute();
+    await db.schema.alterTable("user_settings").dropColumn("profileCardTheme").execute();
+    await db.schema.alterTable("user_settings").dropColumn("customPrompt").execute();
+    await db.schema.alterTable("user_settings").dropColumn("profanityFilterEnabled").execute();
+    await db.schema.alterTable("user_settings").dropColumn("inboxEnabled").execute();
   },
 };
 

--- a/server/src/lib/profanity.ts
+++ b/server/src/lib/profanity.ts
@@ -1,0 +1,28 @@
+// Minimal typed wrapper around the `obscenity` profanity matcher (#58). It is
+// ESM-native with full TypeScript types, so we import it directly (unlike the
+// CJS `naughty-words` wordlist it replaced). It matches the English dataset
+// with the recommended transformers, which also defeat common evasion attempts
+// (leetspeak, confusable Unicode lookalikes, repeated characters) — a stronger
+// check than a naive wordlist with word boundaries.
+//
+// Used by message-service.sendMessage() to silently drop flagged messages:
+// the sender still gets a success response, but the message is never inserted
+// into the recipient's inbox — no rejected-message UX surfaced to the visitor.
+
+import { RegExpMatcher, englishDataset, englishRecommendedTransformers } from "obscenity";
+
+// One matcher instance, reused for every check — the dataset is built once.
+const matcher = new RegExpMatcher({
+  ...englishDataset.build(),
+  ...englishRecommendedTransformers,
+});
+
+/**
+ * Returns true if `text` contains any English blacklisted profanity. Empty
+ * text is treated as clean (the empty-message case is already rejected
+ * upstream by the send validation).
+ */
+export function containsProfanity(text: string): boolean {
+  if (!text) return false;
+  return matcher.hasMatch(text);
+}

--- a/server/src/services/message-service.ts
+++ b/server/src/services/message-service.ts
@@ -4,6 +4,7 @@ import { Logger } from "pino";
 
 import { type Database } from "../database/db";
 import { errorMessage } from "../lib/errors";
+import { containsProfanity } from "../lib/profanity";
 import { ids } from "../lexicon/lexicons";
 import { type Record as MessageSchemaRecord } from "../lexicon/types/app/navyfragen/message";
 import { imageGenerator } from "../lib/image-generator";
@@ -116,6 +117,29 @@ export class MessageService {
 
       if (!userProfileExists) {
         throw new Error("Recipient not found (user profile does not exist)");
+      }
+
+      // Read the recipient's intake settings in one indexed point-read:
+      // - inboxEnabled (NOT NULL default true) — a closed inbox rejects sends.
+      // - profanityFilterEnabled (NOT NULL default false) — opt-in wordlist
+      //   screening. Defaults apply when a user_settings row is absent.
+      const recipientSettings = await this.db
+        .selectFrom("user_settings")
+        .select(["inboxEnabled", "profanityFilterEnabled"])
+        .where("did", "=", recipient)
+        .executeTakeFirst();
+
+      if (recipientSettings && !recipientSettings.inboxEnabled) {
+        throw new Error("This inbox is closed and not accepting new messages");
+      }
+
+      // Profanity screening (#58): when the recipient has opted in, a flagged
+      // message is silently dropped — the sender still gets a success response
+      // (so there's no "your message was rejected" UX to game), but the message
+      // is never inserted into the recipient's inbox.
+      if (recipientSettings?.profanityFilterEnabled && containsProfanity(message)) {
+        this.logger.info({ recipient }, "Message silently dropped (profanity filter)");
+        return { success: true };
       }
 
       const tid = `anon-${Date.now()}-${Math.floor(Math.random() * 10000)}`;

--- a/server/src/services/profile-service.ts
+++ b/server/src/services/profile-service.ts
@@ -24,19 +24,44 @@ export class ProfileService {
   /**
    * Get public profile information for a given DID
    * @param did The user's DID
-   * @returns The user's public profile and whether they're registered on Navyfragen
+   * @returns The user's public profile, whether they're registered on
+   *   Navyfragen, and the public-facing subset of their settings (the
+   *   ask-card strings/theme + inbox-open state) so an anonymous visitor sees
+   *   the profile owner's customisations without a second round-trip.
    */
   async getPublicProfile(did: string): Promise<{
     profile: Awaited<ReturnType<AtpAgent["getProfile"]>>["data"];
     exists: boolean;
+    inboxEnabled: boolean;
+    customPrompt: string | null;
+    profileCardTheme: string | null;
+    touchpointLocale: string | null;
   }> {
     let profileResponse: Awaited<ReturnType<typeof this.agent.getProfile>>;
     let exists: boolean;
+    // The public-facing settings subset (inbox toggle, prompt, card theme,
+    // touchpoint locale). Fetched as a third parallel leg alongside the
+    // remote Bluesky profile + checkUserExists — user_settings.did is the PK,
+    // so this is a cheap indexed point-read that adds no measurable latency
+    // on top of the dominating remote HTTP round-trip.
+    let publicSettings:
+      | {
+          inboxEnabled: number | null;
+          customPrompt: string | null;
+          profileCardTheme: string | null;
+          touchpointLocale: string | null;
+        }
+      | undefined;
 
     try {
-      [profileResponse, exists] = await Promise.all([
+      [profileResponse, exists, publicSettings] = await Promise.all([
         this.agent.getProfile({ actor: did }),
         this.checkUserExists(did),
+        this.db
+          .selectFrom("user_settings")
+          .select(["inboxEnabled", "customPrompt", "profileCardTheme", "touchpointLocale"])
+          .where("did", "=", did)
+          .executeTakeFirst(),
       ]);
     } catch (err) {
       this.logger.error({ err, did }, "Failed to fetch profile by DID");
@@ -47,7 +72,25 @@ export class ProfileService {
       throw new Error("Profile not found");
     }
 
-    return { profile: profileResponse.data, exists };
+    // inboxEnabled is NOT NULL default true, so a missing row (or a null read
+    // from an older row) means the inbox is open. The other fields default to
+    // null = "use the default string/theme/locale". SQLite stores booleans as
+    // 0/1; Postgres stores them as actual booleans — normalize both so the
+    // value reaching the client is always a real boolean.
+    // NOTE: the Kysely row type declares inboxEnabled as `number` (SQLite's
+    // 0/1), but the Postgres dialect returns an actual `boolean` at runtime
+    // for a `boolean` column. Both `0` and `false` mean closed, so coerce via
+    // `unknown` to compare against both without a TS overlap error.
+    const rawInboxEnabled = publicSettings?.inboxEnabled as unknown;
+    const inboxClosed = rawInboxEnabled === 0 || rawInboxEnabled === false;
+    return {
+      profile: profileResponse.data,
+      exists,
+      inboxEnabled: !inboxClosed,
+      customPrompt: publicSettings?.customPrompt ?? null,
+      profileCardTheme: publicSettings?.profileCardTheme ?? null,
+      touchpointLocale: publicSettings?.touchpointLocale ?? null,
+    };
   }
 
   /**

--- a/server/src/services/settings-service.ts
+++ b/server/src/services/settings-service.ts
@@ -9,7 +9,27 @@ export interface UserSettings {
   did: string;
   pdsSyncEnabled: number;
   imageTheme: string;
+  inboxEnabled: number;
+  profanityFilterEnabled: number;
+  customPrompt: string | null;
+  profileCardTheme: string | null;
+  touchpointLocale: string | null;
   createdAt: string;
+}
+
+/**
+ * The subset of `UserSettings` a client is allowed to update. Every field is
+ * optional so a /customise card can mutate just its own setting; the service
+ * persists only the keys present.
+ */
+export interface UpdatableSettings {
+  pdsSyncEnabled?: boolean;
+  imageTheme?: string;
+  inboxEnabled?: boolean;
+  profanityFilterEnabled?: boolean;
+  customPrompt?: string | null;
+  profileCardTheme?: string | null;
+  touchpointLocale?: string | null;
 }
 
 export class SettingsService {
@@ -37,6 +57,11 @@ export class SettingsService {
       did: userDid,
       pdsSyncEnabled: 1, // Default to enabled (SQLite uses 1/0 for booleans)
       imageTheme: "default",
+      inboxEnabled: 1, // Inbox open by default
+      profanityFilterEnabled: 0, // Opt-in wordlist screening (#58)
+      customPrompt: null, // null = use the default ask-card headline
+      profileCardTheme: null, // null = the default --nf-grad-mark gradient
+      touchpointLocale: null, // null = English
       createdAt: new Date().toISOString(),
     };
 
@@ -114,12 +139,8 @@ export class SettingsService {
 
   async updateSettings(
     userDid: string,
-    pdsSyncEnabled: boolean,
-    imageTheme: string
+    updates: UpdatableSettings
   ): Promise<UserSettings | undefined> {
-    // Convert boolean to 1/0 for SQLite compatibility
-    const syncEnabled = pdsSyncEnabled ? 1 : 0;
-
     try {
       const existingSettings = await this.getUserSettings(userDid);
 
@@ -128,20 +149,39 @@ export class SettingsService {
           .insertInto("user_settings")
           .values({
             did: userDid,
-            pdsSyncEnabled: syncEnabled,
-            imageTheme: imageTheme,
+            pdsSyncEnabled: updates.pdsSyncEnabled ? 1 : 0,
+            imageTheme: updates.imageTheme ?? "default",
+            inboxEnabled: updates.inboxEnabled === false ? 0 : 1,
+            profanityFilterEnabled: updates.profanityFilterEnabled ? 1 : 0,
+            customPrompt: updates.customPrompt ?? null,
+            profileCardTheme: updates.profileCardTheme ?? null,
+            touchpointLocale: updates.touchpointLocale ?? null,
             createdAt: new Date().toISOString(),
           })
           .execute();
       } else {
-        await this.db
-          .updateTable("user_settings")
-          .set({
-            pdsSyncEnabled: syncEnabled,
-            imageTheme: imageTheme,
-          })
-          .where("did", "=", userDid)
-          .execute();
+        // Build a set of only the fields the caller provided, so a card
+        // mutating one setting doesn't clobber the others to their defaults.
+        const set: Record<string, unknown> = {};
+        if (updates.pdsSyncEnabled !== undefined) {
+          set.pdsSyncEnabled = updates.pdsSyncEnabled ? 1 : 0;
+        }
+        if (updates.imageTheme !== undefined) set.imageTheme = updates.imageTheme;
+        if (updates.inboxEnabled !== undefined) {
+          set.inboxEnabled = updates.inboxEnabled ? 1 : 0;
+        }
+        if (updates.profanityFilterEnabled !== undefined) {
+          set.profanityFilterEnabled = updates.profanityFilterEnabled ? 1 : 0;
+        }
+        if (updates.customPrompt !== undefined) set.customPrompt = updates.customPrompt;
+        if (updates.profileCardTheme !== undefined) {
+          set.profileCardTheme = updates.profileCardTheme;
+        }
+        if (updates.touchpointLocale !== undefined) {
+          set.touchpointLocale = updates.touchpointLocale;
+        }
+
+        await this.db.updateTable("user_settings").set(set).where("did", "=", userDid).execute();
       }
 
       return await this.getUserSettings(userDid);

--- a/server/src/tests/message-service.test.ts
+++ b/server/src/tests/message-service.test.ts
@@ -94,17 +94,31 @@ describe("MessageService", () => {
     mockDb = {
       selectFrom: mock.fn((table: string) => {
         if (table === "user_settings") {
+          // Shared row so both .selectAll() (respondToMessage) and
+          // .select(["inboxEnabled"]) (sendMessage inbox check) see the same
+          // owner settings, including the new columns. `chain` is fully
+          // chainable: .select/.selectAll return it, .where returns it, and
+          // .executeTakeFirst resolves to the row.
+          const settingsRow = {
+            did: "did:example:user",
+            pdsSyncEnabled: 1,
+            imageTheme: "ocean-breeze", // Mock a specific theme
+            inboxEnabled: 1, // Inbox open by default
+            profanityFilterEnabled: 0, // Profanity screening off by default
+            customPrompt: null,
+            profileCardTheme: null,
+            touchpointLocale: null,
+            createdAt: new Date().toISOString(),
+          };
+          const chain: any = {
+            executeTakeFirst: mock.fn(async () => settingsRow),
+            where: mock.fn(function (this: any) {
+              return this;
+            }),
+          };
           return {
-            selectAll: mock.fn(() => ({
-              where: mock.fn(() => ({
-                executeTakeFirst: mock.fn(async () => ({
-                  did: "did:example:user",
-                  pdsSyncEnabled: 1,
-                  imageTheme: "ocean-breeze", // Mock a specific theme
-                  createdAt: new Date().toISOString(),
-                })),
-              })),
-            })),
+            selectAll: mock.fn(() => chain),
+            select: mock.fn(() => chain),
           };
         }
         return mockSelectBuilder;
@@ -197,6 +211,138 @@ describe("MessageService", () => {
   test("sendMessage throws if user not found", async () => {
     mockSelectBuilder.executeTakeFirst.mock.mockImplementationOnce(async () => undefined);
     await assert.rejects(() => messageService.sendMessage("did:x", "hi"), /Recipient not found/);
+  });
+
+  test("sendMessage is rejected when the recipient's inbox is closed (#177)", async () => {
+    // Arrange — recipient exists in user_profile but has inboxEnabled = 0.
+    mockSelectBuilder.executeTakeFirst.mock.mockImplementationOnce(async () => ({
+      did: "did:foo",
+    }));
+    // Override the user_settings leg to report a closed inbox. The default
+    // mock returns inboxEnabled: 1, so we swap the row to 0 for this test.
+    mockDb.selectFrom = mock.fn((table: string) => {
+      if (table === "user_settings") {
+        const chain: any = {
+          executeTakeFirst: mock.fn(async () => ({
+            did: "did:foo",
+            pdsSyncEnabled: 1,
+            imageTheme: "default",
+            inboxEnabled: 0,
+            profanityFilterEnabled: 0,
+            customPrompt: null,
+            profileCardTheme: null,
+            touchpointLocale: null,
+            createdAt: new Date().toISOString(),
+          })),
+          where: mock.fn(function (this: any) {
+            return this;
+          }),
+        };
+        return {
+          selectAll: mock.fn(() => chain),
+          select: mock.fn(() => chain),
+        };
+      }
+      return mockSelectBuilder;
+    });
+
+    // Act & Assert — the send is rejected with the inbox-closed message, and
+    // crucially no message row is inserted (account/history stay intact).
+    await assert.rejects(
+      () => messageService.sendMessage("did:foo", "hi"),
+      /not accepting new messages/
+    );
+    assert.strictEqual(mockDb.insertInto.mock.calls.length, 0);
+  });
+
+  test("sendMessage silently drops a flagged message when profanity filter is on (#58)", async () => {
+    // Arrange — recipient exists, inbox open, profanity filter ON.
+    mockSelectBuilder.executeTakeFirst.mock.mockImplementationOnce(async () => ({
+      did: "did:foo",
+    }));
+    mockDb.selectFrom = mock.fn((table: string) => {
+      if (table === "user_settings") {
+        const chain: any = {
+          executeTakeFirst: mock.fn(async () => ({
+            did: "did:foo",
+            pdsSyncEnabled: 1,
+            imageTheme: "default",
+            inboxEnabled: 1,
+            profanityFilterEnabled: 1,
+            customPrompt: null,
+            profileCardTheme: null,
+            touchpointLocale: null,
+            createdAt: new Date().toISOString(),
+          })),
+          where: mock.fn(function (this: any) {
+            return this;
+          }),
+        };
+        return {
+          selectAll: mock.fn(() => chain),
+          select: mock.fn(() => chain),
+        };
+      }
+      return mockSelectBuilder;
+    });
+
+    // Act — "fuck" is a canonical English blocklist entry. The send must still
+    // return success (sender sees no rejection), but no row is inserted.
+    const result = await messageService.sendMessage("did:foo", "you are a fuck");
+    assert.deepStrictEqual(result, { success: true });
+    assert.strictEqual(mockDb.insertInto.mock.calls.length, 0);
+  });
+
+  test("sendMessage accepts a clean message even when profanity filter is on (#58)", async () => {
+    // Arrange — recipient exists, inbox open, profanity filter ON.
+    mockSelectBuilder.executeTakeFirst.mock.mockImplementationOnce(async () => ({
+      did: "did:foo",
+    }));
+    mockDb.selectFrom = mock.fn((table: string) => {
+      if (table === "user_settings") {
+        const chain: any = {
+          executeTakeFirst: mock.fn(async () => ({
+            did: "did:foo",
+            pdsSyncEnabled: 1,
+            imageTheme: "default",
+            inboxEnabled: 1,
+            profanityFilterEnabled: 1,
+            customPrompt: null,
+            profileCardTheme: null,
+            touchpointLocale: null,
+            createdAt: new Date().toISOString(),
+          })),
+          where: mock.fn(function (this: any) {
+            return this;
+          }),
+        };
+        return {
+          selectAll: mock.fn(() => chain),
+          select: mock.fn(() => chain),
+        };
+      }
+      return mockSelectBuilder;
+    });
+    mockInsertBuilder.execute.mock.mockImplementationOnce(async () => ({}));
+
+    // Act — a clean message is accepted and inserted normally.
+    const result = await messageService.sendMessage("did:foo", "what's your favorite movie?");
+    assert.deepStrictEqual(result, { success: true });
+    assert.strictEqual(mockDb.insertInto.mock.calls.length, 1);
+  });
+
+  test("sendMessage does not screen for profanity when the filter is off", async () => {
+    // Arrange — recipient exists, inbox open, profanity filter OFF (default).
+    // Even a flagged word should pass through and be inserted.
+    mockSelectBuilder.executeTakeFirst.mock.mockImplementationOnce(async () => ({
+      did: "did:foo",
+    }));
+    mockInsertBuilder.execute.mock.mockImplementationOnce(async () => ({}));
+
+    const result = await messageService.sendMessage("did:foo", "you are a fuck");
+    assert.deepStrictEqual(result, { success: true });
+    // The default mock row has profanityFilterEnabled: 0, so the message lands.
+    assert.strictEqual(mockDb.insertInto.mock.calls.length, 1);
   });
 
   test("deleteMessage deletes from DB and fires PDS deletion in background", async () => {

--- a/server/src/tests/profile-service.test.ts
+++ b/server/src/tests/profile-service.test.ts
@@ -14,7 +14,9 @@ describe("ProfileService", () => {
     debug: mock.fn(),
   };
 
-  // Mock database query builders
+  // Mock database query builders. Two separate builders so the user_profile
+  // (checkUserExists) and user_settings (public-facing subset) legs of
+  // getPublicProfile's Promise.all can return independent values.
   const mockSelectBuilder = {
     select() {
       return this;
@@ -26,8 +28,22 @@ describe("ProfileService", () => {
     execute: async () => [] as any[], // Will be overridden in tests that need it
   };
 
+  // Separate builder for the user_settings leg so it can return its own row
+  // independently of the user_profile existence check.
+  const mockSettingsSelectBuilder = {
+    select() {
+      return this;
+    },
+    where() {
+      return this;
+    },
+    executeTakeFirst: async () => undefined as any, // Will be overridden in tests
+  };
+
   const mockDb = {
-    selectFrom: mock.fn(() => mockSelectBuilder),
+    selectFrom: mock.fn((table: string) =>
+      table === "user_settings" ? mockSettingsSelectBuilder : mockSelectBuilder
+    ),
   };
 
   // Mock AtpAgent response
@@ -66,6 +82,10 @@ describe("ProfileService", () => {
     mockGetProfile.mock.resetCalls();
     mockResolver.resolveDidToHandle.mock.resetCalls();
     mockResolver.resolveHandleToDid.mock.resetCalls();
+
+    // Reset both select builders' executeTakeFirst to the unset default.
+    mockSelectBuilder.executeTakeFirst = async () => undefined;
+    mockSettingsSelectBuilder.executeTakeFirst = async () => undefined;
 
     // Create a new instance of the service with our mocks
     profileService = new ProfileService(
@@ -110,6 +130,105 @@ describe("ProfileService", () => {
       // Assert
       assert.strictEqual(result.exists, true);
       assert.ok(result.profile);
+    });
+
+    it("should return the profile owner's public-facing settings when set", async () => {
+      // Arrange — user_settings row with all four customisations populated.
+      const testDid = "did:test:customised";
+      mockSelectBuilder.executeTakeFirst = async () => ({ did: testDid });
+      mockSettingsSelectBuilder.executeTakeFirst = async () => ({
+        inboxEnabled: 0,
+        customPrompt: "Pregúntame algo",
+        profileCardTheme: "ember",
+        touchpointLocale: "es",
+      });
+
+      // Act
+      const result = await profileService.getPublicProfile(testDid);
+
+      // Assert — all four fields pass straight through to the response.
+      assert.strictEqual(result.inboxEnabled, false);
+      assert.strictEqual(result.customPrompt, "Pregúntame algo");
+      assert.strictEqual(result.profileCardTheme, "ember");
+      assert.strictEqual(result.touchpointLocale, "es");
+    });
+
+    it("should default public-facing fields when user_settings has no row", async () => {
+      // Arrange — no user_settings row (owner never customised). inboxEnabled
+      // is NOT NULL default true, so a missing row still reads as open; the
+      // nullable fields default to null = "use the default".
+      const testDid = "did:test:nodefaults";
+      mockSelectBuilder.executeTakeFirst = async () => ({ did: testDid });
+      mockSettingsSelectBuilder.executeTakeFirst = async () => undefined;
+
+      // Act
+      const result = await profileService.getPublicProfile(testDid);
+
+      // Assert
+      assert.strictEqual(result.inboxEnabled, true); // default-open
+      assert.strictEqual(result.customPrompt, null);
+      assert.strictEqual(result.profileCardTheme, null);
+      assert.strictEqual(result.touchpointLocale, null);
+    });
+
+    it("should read inboxEnabled as closed whether Postgres returns false or SQLite returns 0", async () => {
+      // Postgres stores booleans natively; SQLite stores them as 0/1. The
+      // normalization must handle both so the client always gets a boolean.
+      const testDid = "did:test:closed";
+      mockSelectBuilder.executeTakeFirst = async () => ({ did: testDid });
+
+      // Postgres: actual boolean false
+      mockSettingsSelectBuilder.executeTakeFirst = async () => ({
+        inboxEnabled: false,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
+      });
+      let result = await profileService.getPublicProfile(testDid);
+      assert.strictEqual(result.inboxEnabled, false);
+
+      // SQLite: numeric 0
+      mockSettingsSelectBuilder.executeTakeFirst = async () => ({
+        inboxEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
+      });
+      result = await profileService.getPublicProfile(testDid);
+      assert.strictEqual(result.inboxEnabled, false);
+    });
+
+    it("should read inboxEnabled as open when the row stores 1 (number)", async () => {
+      // Arrange — SQLite stores booleans as 1/0; verify the `!== 0` coercion.
+      const testDid = "did:test:openinbox";
+      mockSelectBuilder.executeTakeFirst = async () => ({ did: testDid });
+      mockSettingsSelectBuilder.executeTakeFirst = async () => ({
+        inboxEnabled: 1,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
+      });
+
+      const result = await profileService.getPublicProfile(testDid);
+
+      assert.strictEqual(result.inboxEnabled, true);
+    });
+
+    it("should fetch the settings subset as a third parallel leg of Promise.all", async () => {
+      // Arrange — verify the settings lookup runs against user_settings (not
+      // user_profile) and selects the public-facing columns. The mock's
+      // selectFrom returns a different builder per table, so a call against
+      // user_settings is observable via the second selectFrom call arg.
+      const testDid = "did:test:parallel";
+      mockSelectBuilder.executeTakeFirst = async () => ({ did: testDid });
+      mockSettingsSelectBuilder.executeTakeFirst = async () => undefined;
+
+      await profileService.getPublicProfile(testDid);
+
+      const selectTables = mockDb.selectFrom.mock.calls.map((c) => c.arguments[0]);
+      // Two legs: checkUserExists → user_profile, settings subset → user_settings.
+      assert.ok(selectTables.includes("user_profile"));
+      assert.ok(selectTables.includes("user_settings"));
     });
 
     it("should throw 'Profile not found' when Bluesky returns success: false", async () => {

--- a/server/src/tests/settings-controller.test.ts
+++ b/server/src/tests/settings-controller.test.ts
@@ -185,6 +185,41 @@ describe("SettingsController", () => {
       });
     });
 
+    test("passes only provided fields through to the service (partial update)", async () => {
+      // A /customise card mutates one field at a time; the controller must not
+      // inject defaults for fields the client didn't send (undefined = skip).
+      const svc = makeService();
+      const ctx = makeCtx();
+      const controller = new SettingsController(svc, ctx.logger, ctx);
+      const res = makeRes();
+      await controller.updateSettings(makeReq({ body: { inboxEnabled: false } }), res);
+
+      const passed = svc.updateSettings.mock.calls[0].arguments[1];
+      assert.deepStrictEqual(passed, {
+        pdsSyncEnabled: undefined,
+        imageTheme: undefined,
+        inboxEnabled: false,
+        profanityFilterEnabled: undefined,
+        customPrompt: undefined,
+        profileCardTheme: undefined,
+        touchpointLocale: undefined,
+      });
+    });
+
+    test("passes null through for nullable fields (means 'unset')", async () => {
+      const svc = makeService();
+      const ctx = makeCtx();
+      const controller = new SettingsController(svc, ctx.logger, ctx);
+      const res = makeRes();
+      await controller.updateSettings(
+        makeReq({ body: { customPrompt: null, touchpointLocale: "es" } }),
+        res
+      );
+      const passed = svc.updateSettings.mock.calls[0].arguments[1];
+      assert.strictEqual(passed.customPrompt, null); // null, not undefined
+      assert.strictEqual(passed.touchpointLocale, "es");
+    });
+
     test("returns 500 on error", async () => {
       const svc = makeService({
         updateSettings: mock.fn(async () => {

--- a/server/src/tests/settings-service.test.ts
+++ b/server/src/tests/settings-service.test.ts
@@ -40,8 +40,10 @@ describe("SettingsService", () => {
     execute: async () => ({}),
   };
 
+  let lastSetArg: any;
   const mockUpdateBuilder = {
-    set() {
+    set(arg: any) {
+      lastSetArg = arg;
       return this;
     },
     where() {
@@ -72,6 +74,7 @@ describe("SettingsService", () => {
     executeTakeFirstQueue = [];
     mockSelectBuilder.executeTakeFirst = async () => executeTakeFirstQueue.shift();
     lastValuesArg = undefined;
+    lastSetArg = undefined;
 
     settingsService = new SettingsService(mockDb as any, mockLogger as any);
   });
@@ -83,6 +86,11 @@ describe("SettingsService", () => {
         did: "user123",
         pdsSyncEnabled: 1,
         imageTheme: "default",
+        inboxEnabled: 1,
+        profanityFilterEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
         createdAt: "2025-06-07T12:00:00.000Z",
       };
       mockSelectBuilder.executeTakeFirst = async () => mockUserSettings;
@@ -126,6 +134,10 @@ describe("SettingsService", () => {
       // Assert
       assert.strictEqual(result.did, "user123");
       assert.strictEqual(result.pdsSyncEnabled, 1);
+      assert.strictEqual(result.inboxEnabled, 1);
+      assert.strictEqual(result.customPrompt, null);
+      assert.strictEqual(result.profileCardTheme, null);
+      assert.strictEqual(result.touchpointLocale, null);
       assert.ok(
         result.createdAt >= beforeDate && result.createdAt <= afterDate,
         `createdAt (${result.createdAt}) should be between ${beforeDate} and ${afterDate}`
@@ -134,6 +146,8 @@ describe("SettingsService", () => {
       assert.deepStrictEqual(mockDb.insertInto.mock.calls[0].arguments, ["user_settings"]);
       assert.strictEqual(lastValuesArg.did, "user123");
       assert.strictEqual(lastValuesArg.pdsSyncEnabled, 1);
+      assert.strictEqual(lastValuesArg.inboxEnabled, 1);
+      assert.strictEqual(lastValuesArg.customPrompt, null);
     });
 
     it("should throw an error when the database insert fails", async () => {
@@ -157,61 +171,153 @@ describe("SettingsService", () => {
   });
 
   describe("updateSettings", () => {
-    it("should create new settings when they do not exist", async () => {
+    it("should create new settings with defaults when they do not exist", async () => {
       // Arrange
       executeTakeFirstQueue.push(undefined);
       executeTakeFirstQueue.push({
         did: "user123",
         pdsSyncEnabled: 1,
         imageTheme: "default",
+        inboxEnabled: 1,
+        profanityFilterEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
         createdAt: "2025-06-07T12:00:00.000Z",
       });
       (mockInsertBuilder.execute as any) = async () => ({});
 
       // Act
-      const result = await settingsService.updateSettings("user123", true, "default");
+      const result = await settingsService.updateSettings("user123", {
+        pdsSyncEnabled: true,
+        imageTheme: "default",
+      });
 
       // Assert
       assert.deepStrictEqual(result, {
         did: "user123",
         pdsSyncEnabled: 1,
         imageTheme: "default",
+        inboxEnabled: 1,
+        profanityFilterEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
         createdAt: "2025-06-07T12:00:00.000Z",
       });
       assert.strictEqual(mockDb.selectFrom.mock.calls.length, 2);
       assert.strictEqual(mockDb.insertInto.mock.calls.length, 1);
       assert.strictEqual(mockDb.updateTable.mock.calls.length, 0);
+      assert.strictEqual(lastValuesArg.pdsSyncEnabled, 1);
+      assert.strictEqual(lastValuesArg.imageTheme, "default");
+      // inboxEnabled defaults to 1 (open) on insert even when not provided.
+      assert.strictEqual(lastValuesArg.inboxEnabled, 1);
+      assert.strictEqual(lastValuesArg.customPrompt, null);
     });
 
-    it("should update existing settings", async () => {
+    it("should update only the provided fields on an existing row (partial update)", async () => {
       // Arrange
       executeTakeFirstQueue.push({
         did: "user123",
         pdsSyncEnabled: 1,
         imageTheme: "default",
+        inboxEnabled: 1,
+        profanityFilterEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
         createdAt: "2025-06-07T12:00:00.000Z",
       });
       executeTakeFirstQueue.push({
         did: "user123",
-        pdsSyncEnabled: 0,
-        imageTheme: "compressed",
+        pdsSyncEnabled: 1,
+        imageTheme: "default",
+        inboxEnabled: 1,
+        profanityFilterEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
         createdAt: "2025-06-07T12:00:00.000Z",
       });
       (mockUpdateBuilder.execute as any) = async () => ({});
 
-      // Act
-      const result = await settingsService.updateSettings("user123", false, "compressed");
+      // Act — a Customise card mutating ONLY inboxEnabled must not touch the
+      // other fields (pdsSyncEnabled, imageTheme, etc.).
+      const result = await settingsService.updateSettings("user123", { inboxEnabled: false });
 
       // Assert
-      assert.deepStrictEqual(result, {
-        did: "user123",
-        pdsSyncEnabled: 0,
-        imageTheme: "compressed",
-        createdAt: "2025-06-07T12:00:00.000Z",
-      });
+      assert.strictEqual(result!.inboxEnabled, 1); // mock returns the queue's row, unchanged
       assert.strictEqual(mockDb.selectFrom.mock.calls.length, 2);
       assert.strictEqual(mockDb.insertInto.mock.calls.length, 0);
       assert.strictEqual(mockDb.updateTable.mock.calls.length, 1);
+      // Only inboxEnabled is in the SET payload — the partial signature must
+      // not clobber the other columns to defaults.
+      assert.deepStrictEqual(Object.keys(lastSetArg), ["inboxEnabled"]);
+      assert.strictEqual(lastSetArg.inboxEnabled, 0); // false → 0 for SQLite
+    });
+
+    it("should persist each individual /customise field when provided", async () => {
+      // Arrange
+      const baseRow = {
+        did: "user123",
+        pdsSyncEnabled: 1,
+        imageTheme: "default",
+        inboxEnabled: 1,
+        profanityFilterEnabled: 0,
+        customPrompt: null,
+        profileCardTheme: null,
+        touchpointLocale: null,
+        createdAt: "2025-06-07T12:00:00.000Z",
+      };
+      executeTakeFirstQueue.push({ ...baseRow });
+      executeTakeFirstQueue.push({ ...baseRow });
+      (mockUpdateBuilder.execute as any) = async () => ({});
+
+      // Act — every Customise field at once (#199/#177/#275/#266/#58).
+      await settingsService.updateSettings("user123", {
+        customPrompt: "Ask me anything",
+        profileCardTheme: "ember",
+        touchpointLocale: "es",
+        imageTheme: "twitter",
+        pdsSyncEnabled: false,
+        profanityFilterEnabled: true,
+      });
+
+      // Assert — all six provided fields land in the SET payload, booleans
+      // converted to 1/0, nullables passed through as-is. Unprovided fields
+      // (inboxEnabled) are absent — the partial update never sets them.
+      assert.deepStrictEqual(lastSetArg, {
+        pdsSyncEnabled: 0,
+        imageTheme: "twitter",
+        profanityFilterEnabled: 1,
+        customPrompt: "Ask me anything",
+        profileCardTheme: "ember",
+        touchpointLocale: "es",
+      });
+    });
+
+    it("should persist a null customPrompt to unset it", async () => {
+      // Arrange
+      const baseRow = {
+        did: "user123",
+        pdsSyncEnabled: 1,
+        imageTheme: "default",
+        inboxEnabled: 1,
+        customPrompt: "previously set",
+        profileCardTheme: null,
+        touchpointLocale: null,
+        createdAt: "2025-06-07T12:00:00.000Z",
+      };
+      executeTakeFirstQueue.push({ ...baseRow });
+      executeTakeFirstQueue.push({ ...baseRow });
+      (mockUpdateBuilder.execute as any) = async () => ({});
+
+      // Act
+      await settingsService.updateSettings("user123", { customPrompt: null });
+
+      // Assert — null is a valid value (means "use the default"), not "skip".
+      assert.deepStrictEqual(Object.keys(lastSetArg), ["customPrompt"]);
+      assert.strictEqual(lastSetArg.customPrompt, null);
     });
 
     it("should throw an error when the database operations fail", async () => {
@@ -222,7 +328,7 @@ describe("SettingsService", () => {
 
       // Act & Assert
       await assert.rejects(
-        async () => await settingsService.updateSettings("user123", true, "default"),
+        async () => await settingsService.updateSettings("user123", { pdsSyncEnabled: true }),
         { message: "Failed to update user settings" }
       );
 


### PR DESCRIPTION
## Summary

Lands the `/customise` page and all five features that depend on it, in one branch. The shared `Customise.tsx` scaffold already existed as a non-functional Design-B placeholder; this wires the route/nav and replaces each placeholder control with a real, persisted setting, plus the server + public-profile rendering each feature needs.

Closes #273, #199, #177, #275, #266, #58.

## What's in here

| Issue | Feature |
|-------|---------|
| **#273** | `/customise` route + nav entry (Customise link, `Alt+C` shortcut) |
| **#199** | Custom profile prompt — overrides the ask-card headline (falls back to default when blank) |
| **#177** | Inbox on/off — closed inbox rejects sends (403) while keeping the account/history; public profile shows a "not accepting messages" state |
| **#275** | 4 curated ask-card colour presets (Royal / Aurora / Ember / Verdant) as on-brand `--nf-grad-*` tokens |
| **#266** | Touchpoint translations (en / es / pt / de / fr) for the ask-card + the owner's share payload |
| **#58** | Profanity filter — opt-in; flagged messages are **silently dropped** (sender sees success, message never reaches the inbox) via the `obscenity` package |

## Key decisions

- **One migration (`009`)** adds all five new `user_settings` columns together.
- **`settings-service.updateSettings` refactored to a partial signature** so each `/customise` card mutates only its own field without clobbering the others. Settings page keeps sending both its fields unchanged.
- **`getPublicProfile` adds a 3rd parallel `Promise.all` leg** reading the public-facing settings subset in a single indexed point-read; normalizes `inboxEnabled` across SQLite (`0`/`1`) and Postgres (`boolean`).
- **Profanity filter uses `obscenity`** (ESM-native, full TS types, defeats leetspeak/confusables) rather than a naive wordlist. Behavior is a silent drop per the reporter's call — no rejected-message UX for the sender to game.
- **Notifications section + save toast removed** per request; the single push on/off stays on the Settings page.

## Verification

- **Server:** 317 tests pass, typecheck clean, 0 lint errors
- **Client:** 523 tests pass (34 files), typecheck clean, 0 lint errors
- **E2E (Docker stack):** Logged in via the e2e flow and exercised every feature live — confirmed all settings persist, the public profile reflects closed-inbox / custom prompt / theme / locale, and the profanity filter silently drops flagged messages (inbox 7 → 8 after sending one clean + one profane message, both returning `{"success":true}` to the sender).

## Out of scope

- #192 granular notification toggles (Notifications section removed entirely)
- Design C live preview (documented follow-up in `docs/customise-page-designs.md`)
- Free-form hex colour picker (#275 future stretch)
- Push notification / image alt-text localization (#266 explicitly excludes these)