### PR TITLE
fix(customise): uniform card sizing to match Settings grid

### DIFF
--- a/client/src/pages/Customise.tsx
+++ b/client/src/pages/Customise.tsx
@@ -88,7 +88,7 @@ export default function Customise() {
             eyebrow="Your public profile"
             help="What visitors see before they send you an anonymous message."
           >
-            <Grid.Col span={{ base: 12, lg: 8 }} style={{ display: "flex" }}>
+            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
               <SettingsCard
                 title="Profile prompt"
                 description="The headline shown above your message box. Leave blank to fall back to “Send [you] an anonymous message”."
@@ -116,7 +116,7 @@ export default function Customise() {
               </SettingsCard>
             </Grid.Col>
 
-            <Grid.Col span={{ base: 12, lg: 4 }} style={{ display: "flex" }}>
+            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
               <SettingsCard
                 title="Message language"
                 description="Language of the prompt, share text, and anonymity disclaimer shown to visitors and your audience."
@@ -143,7 +143,7 @@ export default function Customise() {
               </SettingsCard>
             </Grid.Col>
 
-            <Grid.Col span={{ base: 12, lg: 6 }} style={{ display: "flex" }}>
+            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
               <SettingsCard
                 title="Profile card colour"
                 description="The colour treatment of your ask card. Curated presets keep the text and button legible on every option."


### PR DESCRIPTION
## Summary

Fixes the uneven / mismatched box sizes on the `/customise` page. The cards had a mix of spans (`lg:8`, `lg:4`, `lg:6`, with missing `md` breakpoints on the first two), producing an inconsistent grid. Every card now uses the same uniform `span={{ base: 12, md: 6, lg: 4 }}` that `Settings.tsx` already uses across all its cards — so `/customise` reads as a consistent 3-up / 2-up / 1-up grid like the rest of the app.

Reported during review of #279 (merged); this is the follow-up.

## Verification
- Client typecheck clean, 523 tests pass (34 files)
- All five `Grid.Col` spans confirmed identical to Settings.tsx's pattern