### PR TITLE
perf(html-to-image): close Chromium when idle so Railway can sleep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,15 @@ Image themes are defined in `src/lib/themes.ts` and stored per-user in `user_set
 
 The image service call uses `fetchWithRetry(url, init, timeoutMs)` (exported from `src/lib/image-generator.ts`) which retries on network errors with exponential backoff until the overall deadline is reached. Each individual request is bounded by an `AbortController`. If retries are exhausted the function throws — image generation failure is **not** silently downgraded to a text-only reply; the whole response attempt fails with the specific error message surfaced to the frontend.
 
+#### Chromium lifecycle (Railway app-sleeping)
+
+The image-gen service runs on Railway with Serverless (app-sleeping) enabled, which sleeps a service after 10 minutes with **no outbound packets**. Chromium must therefore be absent, not merely idle, between renders — a resident browser emits background traffic (component updater, safe-browsing lists, domain reliability, and mDNS/SSDP multicast from MediaRouter/DIAL discovery) that keeps resetting that window, and holds ~500MB RSS while doing nothing.
+
+`createBrowserPool` in `html-to-image/app.js` owns that lifecycle: the browser is launched on the first render, not at boot, and closed after `BROWSER_IDLE_TIMEOUT_MS` (90s, deliberately well under Railway's 10-minute window) or once `RENDERS_BEFORE_RECYCLE` renders have accumulated. `CHROMIUM_LAUNCH_ARGS` disables the background subsystems above so the awake window is quiet too. Two consequences to keep in mind:
+
+- Do not prewarm the browser at startup or on a timer — that reintroduces the exact problem.
+- A request arriving after an idle stretch pays a container wake plus a browser launch, which is why `IMAGE_SERVICE_DEADLINE_MS` in `image-generator.ts` is 30s rather than a warm-render budget.
+
 ## Client Architecture
 
 React Query is the data layer. Each domain (auth, messages, profile, settings) has a service file in `src/api/` that exports plain functions and React Query hooks:

--- a/html-to-image/app.js
+++ b/html-to-image/app.js
@@ -85,6 +85,147 @@ async function waitForVisualReadiness(page) {
   ]);
 }
 
+// Railway's Serverless (app-sleeping) detects inactivity from *outbound
+// packets*: no packets for 10 minutes puts the service to sleep. A resident
+// Chromium never goes that quiet — its background services (component updater,
+// safe-browsing lists, field trials, domain reliability uploads) and its local
+// media-route discovery (mDNS/SSDP multicast for DIAL/Cast) all emit traffic on
+// timers with no page open. These flags shut those subsystems off so an idle
+// container is genuinely silent; the rest trim per-render RSS.
+export const CHROMIUM_LAUNCH_ARGS = [
+  '--no-sandbox',
+  '--no-zygote',
+  '--headless',
+  '--disable-gpu',
+  '--disable-background-networking',
+  '--disable-component-update',
+  '--disable-domain-reliability',
+  '--disable-client-side-phishing-detection',
+  '--disable-sync',
+  '--safebrowsing-disable-auto-update',
+  '--no-pings',
+  '--no-first-run',
+  '--no-default-browser-check',
+  '--disable-default-apps',
+  '--disable-breakpad',
+  '--metrics-recording-only',
+  '--disable-features=Translate,BackForwardCache,MediaRouter,DialMediaRouteProvider,OptimizationHints,InterestFeedContentSuggestions,AcceptCHFrame',
+  '--disable-dev-shm-usage',
+  '--disable-extensions',
+  '--disable-software-rasterizer',
+  '--mute-audio',
+];
+
+// How long the browser may sit idle before it's closed. Must be comfortably
+// under Railway's 10-minute inactivity window so a silent stretch can actually
+// accumulate after the browser exits.
+export const BROWSER_IDLE_TIMEOUT_MS = 90_000;
+
+// A Chromium instance accumulates RSS across many renders (cache/heap
+// fragmentation) even with every page closed. Under sustained traffic the idle
+// timer never fires, so this bounds growth by forcing a close at the first
+// moment nothing is in flight.
+export const RENDERS_BEFORE_RECYCLE = 100;
+
+// createBrowserPool owns the Chromium lifecycle: launch on first use, close
+// once idle. Keeping the browser out of the process while nothing is rendering
+// is what lets the container fall silent (and drops idle RSS from ~500MB to
+// just the Node process).
+export function createBrowserPool({
+  launch,
+  idleTimeoutMs = BROWSER_IDLE_TIMEOUT_MS,
+  rendersBeforeRecycle = RENDERS_BEFORE_RECYCLE,
+  log = () => {},
+} = {}) {
+  let browserPromise = null;
+  let rendersSinceLaunch = 0;
+  let idleTimer = null;
+
+  function cancelIdleClose() {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  }
+
+  function scheduleIdleClose() {
+    cancelIdleClose();
+    idleTimer = setTimeout(() => {
+      idleTimer = null;
+      closeBrowser('idle');
+    }, idleTimeoutMs);
+    // Never let the idle timer be the reason the process stays alive.
+    idleTimer.unref?.();
+  }
+
+  function startBrowser() {
+    rendersSinceLaunch = 0;
+    log('Launching browser...');
+    browserPromise = launch().then((browser) => {
+      log('Browser ready.');
+      return browser;
+    });
+    return browserPromise;
+  }
+
+  async function discard(promise) {
+    const browser = await promise.catch(() => null);
+    if (browser) await browser.close().catch(() => {});
+  }
+
+  function closeBrowser(reason) {
+    cancelIdleClose();
+    const stale = browserPromise;
+    browserPromise = null;
+    if (!stale) return Promise.resolve();
+    log(`Closing browser (${reason}).`);
+    return discard(stale);
+  }
+
+  // A rejected launch must not be cached, or every later request inherits the
+  // same failure and the service never recovers without a redeploy.
+  async function resolveOrForget(promise) {
+    try {
+      return await promise;
+    } catch (err) {
+      if (browserPromise === promise) browserPromise = null;
+      throw err;
+    }
+  }
+
+  async function getBrowser() {
+    cancelIdleClose();
+    const pending = browserPromise ?? startBrowser();
+    const browser = await resolveOrForget(pending);
+    if (browser.connected) return browser;
+
+    // The browser crashed out from under us. Relaunch, unless a concurrent
+    // caller already noticed and did so.
+    if (browserPromise === pending) {
+      discard(pending);
+      startBrowser();
+    }
+    return resolveOrForget(browserPromise ?? startBrowser());
+  }
+
+  function onRenderComplete(activeRenders) {
+    rendersSinceLaunch++;
+    // Closing mid-render would pull the browser out from under a request.
+    if (activeRenders > 0) return;
+    if (rendersSinceLaunch >= rendersBeforeRecycle) {
+      closeBrowser(`recycle after ${rendersSinceLaunch} renders`);
+    } else {
+      scheduleIdleClose();
+    }
+  }
+
+  return {
+    getBrowser,
+    onRenderComplete,
+    shutdown: () => closeBrowser('shutdown'),
+  };
+}
+
 export function createApp(getBrowser, { onRenderComplete = () => {} } = {}) {
   const app = express();
   const renderSemaphore = new Semaphore(MAX_CONCURRENT_RENDERS);
@@ -172,65 +313,22 @@ export function createApp(getBrowser, { onRenderComplete = () => {} } = {}) {
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const port = 3033;
 
-  function launchBrowser() {
-    console.log('Launching browser...');
-    return puppeteer.launch({
-      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
-      defaultViewport: { width: 1920, height: 1080 },
-      args: ['--no-sandbox', '--no-zygote', '--headless', '--disable-gpu'],
-    }).then(b => { console.log('Browser ready.'); return b; });
-  }
+  const pool = createBrowserPool({
+    launch: () =>
+      puppeteer.launch({
+        executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+        defaultViewport: { width: 1920, height: 1080 },
+        args: CHROMIUM_LAUNCH_ARGS,
+      }),
+    log: (message) => console.log(message),
+  });
 
-  let browserPromise = launchBrowser();
-
-  async function getBrowser() {
-    const browser = await browserPromise;
-    if (!browser.connected) {
-      browserPromise = launchBrowser();
-      return browserPromise;
-    }
-    return browser;
-  }
-
-  // A single Chromium instance run for a long time accumulates RSS growth
-  // (cache/heap fragmentation across many renders) even though every page is
-  // closed correctly. Recycling the process periodically bounds that growth.
-  const RENDERS_BEFORE_RECYCLE = 100;
-  const BROWSER_MAX_AGE_MS = 6 * 60 * 60 * 1000;
-  let rendersSinceLaunch = 0;
-  let browserLaunchedAt = Date.now();
-
-  // Only swaps when no render is in flight (activeRenders === 0), so the
-  // browser is never pulled out from under a request that's mid-screenshot.
-  // A request that starts in the brief window between this check and the
-  // actual swap can hit a closed browser and get a 500 — an accepted
-  // tradeoff for keeping the recycle logic lock-free.
-  async function recycleBrowserIfDue(activeRenders) {
-    if (activeRenders > 0) return;
-    const due = rendersSinceLaunch >= RENDERS_BEFORE_RECYCLE || Date.now() - browserLaunchedAt >= BROWSER_MAX_AGE_MS;
-    if (!due) return;
-
-    const staleBrowserPromise = browserPromise;
-    rendersSinceLaunch = 0;
-    browserLaunchedAt = Date.now();
-    browserPromise = launchBrowser();
-
-    const staleBrowser = await staleBrowserPromise.catch(() => null);
-    if (staleBrowser) await staleBrowser.close().catch(() => {});
-  }
-
-  function onRenderComplete(activeRenders) {
-    rendersSinceLaunch++;
-    recycleBrowserIfDue(activeRenders).catch((err) => console.error('Browser recycle failed:', err));
-  }
-
-  const app = createApp(getBrowser, { onRenderComplete });
+  const app = createApp(pool.getBrowser, { onRenderComplete: pool.onRenderComplete });
   // Bind to :: so Railway's IPv6 internal network can reach this service.
   app.listen(port, '::', () => console.log(`html-to-image listening on port ${port}`));
 
   async function shutdown() {
-    const browser = await browserPromise.catch(() => null);
-    if (browser) await browser.close().catch(() => {});
+    await pool.shutdown();
     process.exit(0);
   }
 

--- a/html-to-image/app.test.js
+++ b/html-to-image/app.test.js
@@ -2,7 +2,7 @@ import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import fs from 'node:fs/promises';
-import { createApp, MAX_CONCURRENT_RENDERS } from './app.js';
+import { createApp, createBrowserPool, CHROMIUM_LAUNCH_ARGS, MAX_CONCURRENT_RENDERS } from './app.js';
 
 // Starts the app on a random port and returns { server, url }.
 function startServer(getBrowser, options) {
@@ -420,5 +420,193 @@ describe('POST / onRenderComplete callback', () => {
     } finally {
       await stopServer(server);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Browser pool lifecycle
+// ---------------------------------------------------------------------------
+describe('createBrowserPool', () => {
+  // Tracks launches and closes so tests can assert on lifecycle transitions
+  // rather than on wall-clock timing.
+  function makeLaunchSpy({ failFirst = false } = {}) {
+    const launched = [];
+    const launch = async () => {
+      if (failFirst && launched.length === 0) {
+        launched.push(null);
+        throw new Error('launch failed');
+      }
+      const browser = {
+        connected: true,
+        closed: false,
+        close: async () => { browser.closed = true; browser.connected = false; },
+      };
+      launched.push(browser);
+      return browser;
+    };
+    return { launch, launched };
+  }
+
+  test('does not launch a browser until the first render is requested', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    createBrowserPool({ launch });
+    assert.equal(launched.length, 0, 'browser must not launch at boot — an idle Chromium keeps Railway awake');
+  });
+
+  test('launches on first getBrowser and reuses the same instance', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch });
+
+    const first = await pool.getBrowser();
+    const second = await pool.getBrowser();
+
+    assert.equal(launched.length, 1);
+    assert.equal(first, second);
+  });
+
+  test('closes the browser once idle so the container falls silent', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch, idleTimeoutMs: 5 });
+
+    await pool.getBrowser();
+    pool.onRenderComplete(0);
+
+    await waitFor(() => launched[0].closed);
+    assert.ok(launched[0].closed);
+  });
+
+  test('does not close while a render is still in flight', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch, idleTimeoutMs: 5 });
+
+    await pool.getBrowser();
+    pool.onRenderComplete(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(launched[0].closed, false);
+  });
+
+  test('a new request before the idle deadline cancels the close', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch, idleTimeoutMs: 30 });
+
+    const first = await pool.getBrowser();
+    pool.onRenderComplete(0);
+    const second = await pool.getBrowser();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(first, second);
+    assert.equal(launched.length, 1);
+    assert.equal(launched[0].closed, false, 'idle timer should have been cancelled by the new request');
+  });
+
+  test('relaunches after an idle close', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch, idleTimeoutMs: 5 });
+
+    await pool.getBrowser();
+    pool.onRenderComplete(0);
+    await waitFor(() => launched[0].closed);
+
+    const revived = await pool.getBrowser();
+    assert.equal(launched.length, 2);
+    assert.equal(revived, launched[1]);
+    assert.equal(revived.closed, false);
+  });
+
+  test('closes immediately once the render budget is spent', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch, idleTimeoutMs: 60_000, rendersBeforeRecycle: 2 });
+
+    await pool.getBrowser();
+    pool.onRenderComplete(0);
+    assert.equal(launched[0].closed, false);
+
+    pool.onRenderComplete(0);
+    await waitFor(() => launched[0].closed);
+  });
+
+  test('the render budget resets on relaunch', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch, idleTimeoutMs: 60_000, rendersBeforeRecycle: 2 });
+
+    await pool.getBrowser();
+    pool.onRenderComplete(0);
+    pool.onRenderComplete(0);
+    await waitFor(() => launched[0].closed);
+
+    await pool.getBrowser();
+    pool.onRenderComplete(0);
+    assert.equal(launched[1].closed, false, 'counter should restart with the new browser');
+  });
+
+  test('a failed launch is not cached — the next request retries', async () => {
+    const { launch, launched } = makeLaunchSpy({ failFirst: true });
+    const pool = createBrowserPool({ launch });
+
+    await assert.rejects(() => pool.getBrowser(), /launch failed/);
+    const browser = await pool.getBrowser();
+
+    assert.equal(launched.length, 2);
+    assert.equal(browser.connected, true);
+  });
+
+  test('replaces a crashed browser', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch });
+
+    const first = await pool.getBrowser();
+    first.connected = false;
+
+    const second = await pool.getBrowser();
+    assert.notEqual(second, first);
+    assert.equal(second.connected, true);
+    assert.equal(launched.length, 2);
+  });
+
+  test('shutdown closes a running browser', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch });
+
+    await pool.getBrowser();
+    await pool.shutdown();
+
+    assert.equal(launched[0].closed, true);
+  });
+
+  test('shutdown is a no-op when no browser was ever launched', async () => {
+    const { launch, launched } = makeLaunchSpy();
+    const pool = createBrowserPool({ launch });
+
+    await pool.shutdown();
+    assert.equal(launched.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chromium launch flags
+// ---------------------------------------------------------------------------
+describe('CHROMIUM_LAUNCH_ARGS', () => {
+  test('disables the background subsystems that keep the container chattering', () => {
+    // Each of these emits outbound packets on a timer with no page open, which
+    // resets Railway's 10-minute inactivity window and blocks app-sleeping.
+    for (const flag of [
+      '--disable-background-networking',
+      '--disable-component-update',
+      '--disable-domain-reliability',
+      '--safebrowsing-disable-auto-update',
+      '--no-pings',
+    ]) {
+      assert.ok(CHROMIUM_LAUNCH_ARGS.includes(flag), `missing ${flag}`);
+    }
+    // MediaRouter/DIAL do mDNS + SSDP multicast discovery on a loop.
+    const features = CHROMIUM_LAUNCH_ARGS.find((arg) => arg.startsWith('--disable-features='));
+    assert.match(features, /MediaRouter/);
+    assert.match(features, /DialMediaRouteProvider/);
+  });
+
+  test('keeps the container-required sandbox and shm flags', () => {
+    assert.ok(CHROMIUM_LAUNCH_ARGS.includes('--no-sandbox'));
+    assert.ok(CHROMIUM_LAUNCH_ARGS.includes('--disable-dev-shm-usage'));
   });
 });

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -30,6 +30,12 @@ const BASE_CSS = `
   body { overflow: hidden; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-synthesis: none; }
 `;
 
+// The image service runs with Railway's Serverless (app-sleeping) enabled and
+// launches Chromium lazily, so a request that arrives after an idle stretch
+// pays a container wake plus a browser launch before it can render. The
+// deadline has to cover both, not just a warm render.
+const IMAGE_SERVICE_DEADLINE_MS = 30_000;
+
 // Retries a fetch on network errors (ECONNREFUSED, ETIMEDOUT, etc.) for up to
 // timeoutMs. Does not retry HTTP error responses — those mean the service is up.
 // Each individual request is bounded by an AbortController so a hanging
@@ -108,7 +114,7 @@ export async function generateQuestionImage(
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       },
-      10_000
+      IMAGE_SERVICE_DEADLINE_MS
     );
 
     if (response.ok) {


### PR DESCRIPTION
## Summary

The image-gen service has Serverless (app-sleeping) enabled on Railway but never sleeps, and holds **0.30–0.52 GB RSS around the clock at ~0% CPU**.

Railway decides a service is inactive from **outbound packets** — 10 minutes of silence puts it to sleep. The service launched Chromium at boot and kept it resident forever, and a resident Chromium is never silent: the component updater, safe-browsing list fetches, domain reliability uploads, and the MediaRouter/DIAL mDNS+SSDP discovery loop all emit traffic on timers with no page open. The inactivity window kept resetting, so the container stayed awake and the browser stayed in RAM.

So Chromium now has to be *absent* between renders, not merely idle.

## Related issue

Closes #

## Scope

- [ ] client
- [x] server
- [ ] opengraph-service
- [x] docker / infra (caddy, anubis)
- [x] docs

## Changes

- **`createBrowserPool` owns the Chromium lifecycle** (`html-to-image/app.js`): launch on the first render rather than at boot, close after 90s idle — deliberately well under Railway's 10-minute window so a silent stretch can actually accumulate. Idle RSS drops to just the Node process.
- **`CHROMIUM_LAUNCH_ARGS`** disables the background subsystems listed above, so the awake window is quiet too, and trims per-render RSS (`--disable-dev-shm-usage`, no extensions, no software rasterizer).
- **Renders-before-recycle survives as an immediate close.** `BROWSER_MAX_AGE_MS` is gone — a browser can no longer outlive an idle window, so age-based recycling has nothing left to do.
- **A failed launch is no longer cached.** Previously one rejected launch poisoned `browserPromise` and every subsequent request inherited the same failure until a redeploy.
- **`IMAGE_SERVICE_DEADLINE_MS` 10s → 30s** (`server/src/lib/image-generator.ts`): a request arriving after an idle stretch now pays a container wake *plus* a browser launch, which a warm-render budget doesn't cover.

## Testing

- [x] Unit/integration tests pass locally — 42 html-to-image, 317 server
- [ ] E2E (Playwright) passes for affected flows
- [x] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account

Verified end-to-end against real Chromium (not just the mock browser): no browser process at boot → PNG renders correctly with the new flags → the Chromium process exits after the idle timeout → relaunches on the next request → `shutdown()` reaps it. 14 new unit tests cover the pool's lifecycle transitions and the launch flags.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens
- [x] Docs updated if user-facing behavior or setup changed

## Note for review

Expect a visible cold-start on the first image render after an idle period (Railway wake + ~1s Chromium launch). That's the cost of the service actually sleeping; `fetchWithRetry`'s 30s deadline absorbs it.

Separately, worth knowing: the Railway service is configured with the **Railpack** builder, so `html-to-image/Dockerfile` is not what ships to production. Nothing here depends on that, but the Dockerfile and the deployed image can drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6gnLVJZKEFoQDptbTMgom
