### PR TITLE
fix: survive the image service waking instead of failing the render

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -297,6 +297,35 @@ jobs:
         # the race detector; setup-go enables it by default on linux.
         run: go test -race -count=1 ./...
 
+  html-to-image-tests:
+    name: HTML-to-Image Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: html-to-image
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # html-to-image is deliberately outside the bun workspaces (it ships as a
+      # standalone container), so it carries its own package-lock.json and
+      # installs with npm rather than the root bun install.
+      - name: Install dependencies
+        # The tests never launch a browser — they drive createApp/createBrowserPool
+        # through fakes — so the ~150MB Chrome download is pure CI cost. The
+        # production image supplies Alpine's system Chromium instead.
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+        run: npm ci --no-audit --no-fund
+
+      - name: Run tests
+        run: node --test app.test.js
+
   coveralls-finish:
     name: Coveralls Finish
     needs: [client-tests, server-tests]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,15 @@ The image-gen service runs on Railway with Serverless (app-sleeping) enabled, wh
 
 - Do not prewarm the browser at startup or on a timer — that reintroduces the exact problem.
 - A request arriving after an idle stretch pays a container wake plus a browser launch, which is why `IMAGE_SERVICE_DEADLINE_MS` in `image-generator.ts` is 30s rather than a warm-render budget.
+- The Dockerfile runs `tini` as PID 1. Chromium's children are reparented to PID 1 on browser exit and Node does not reap orphans, so without an init the launch/close cycle leaks zombie PIDs until the table is exhausted. Do not drop the `ENTRYPOINT`.
+
+Railway builds this service from `html-to-image/Dockerfile`. That is now pinned in `html-to-image/railway.json` — previously it relied on Railway's "a Dockerfile always wins" auto-detection while the dashboard/API still reported the `RAILPACK` default, which reads as though the Dockerfile were dead config.
+
+#### Calling the image service
+
+Both callers — `fetchWithRetry` in `server/src/lib/image-generator.ts` and `HTMLToImageRenderer.Render` in `opengraph-service/internal/shim/renderer.go` — must retry on **wake-shaped HTTP statuses** (408/502/503/504), not just on network errors. A sleeping service answers before it is ready: Railway's edge returns 502 while the container boots, and the service itself returns 503 while Chromium launches. Both are HTTP responses, so treating any response as final turns every wake into a user-visible failure. 4xx and 429 are deliberately *not* retried — a rejected payload fails identically every time, and retrying a limiter that is already shedding only adds load.
+
+Retry budgets are per-attempt, not per-loop: a single hung connection must not consume the whole deadline and starve the retry that would have succeeded.
 
 ## Client Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,9 @@ Windows users: use `http://127.0.0.1` instead of `localhost` for cookies to work
 
 **Client**: Uses Vitest + `@testing-library/react` + `happy-dom`. MSW is available for API mocking. Test setup file at `src/tests/setupTests.ts`.
 
-CI runs all tests in a single unified workflow `.github/workflows/Tests.yml` targeting Node 24. The workflow has separate jobs for client, server, and html-to-image tests.
+CI runs all tests in a single unified workflow `.github/workflows/Tests.yml` targeting Node 24, with separate jobs for client, server, the Bun-runtime canary, `opengraph-service` (Go), and `html-to-image`.
+
+The `html-to-image` job installs with `npm ci` rather than the root `bun install` — the service is deliberately outside the workspaces — and sets `PUPPETEER_SKIP_DOWNLOAD=true`, since its tests drive `createApp`/`createBrowserPool` through fakes and never launch a browser.
 
 The `html-to-image/` service at the repo root is a standalone Express + Puppeteer image renderer. It has its own `app.test.js` using Node.js built-in `node:test`. Run its tests with:
 ```bash

--- a/html-to-image/Dockerfile
+++ b/html-to-image/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
       harfbuzz \
       ca-certificates \
       ttf-freefont \
-      font-noto-emoji
+      font-noto-emoji \
+      tini
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
@@ -21,4 +22,10 @@ COPY app.js ./
 
 EXPOSE 3033
 
+# Chromium's children are reparented to PID 1 when the browser exits. Node does
+# not reap orphans, so running it as PID 1 turns every browser close into a
+# handful of permanent zombie entries — and since the pool now launches and
+# closes Chromium once per idle cycle rather than once per container lifetime,
+# those accumulate until the PID table is exhausted. tini reaps them.
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["node", "app.js"]

--- a/html-to-image/railway.json
+++ b/html-to-image/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  }
+}

--- a/opengraph-service/internal/shim/renderer.go
+++ b/opengraph-service/internal/shim/renderer.go
@@ -24,14 +24,39 @@ type ImageRenderer interface {
 	Render(ctx context.Context, htmlSrc string) ([]byte, error)
 }
 
+// A sleeping html-to-image answers before it is ready, and those answers are
+// HTTP responses rather than network errors: Railway's edge returns 502 while
+// the container is still waking, and the service itself returns 503 while
+// Chromium is still launching. Mirrors WAKE_RETRYABLE_STATUSES in
+// server/src/lib/image-generator.ts — 4xx and 429 are deliberately absent.
+var wakeRetryableStatuses = map[int]bool{
+	http.StatusRequestTimeout:     true,
+	http.StatusBadGateway:         true,
+	http.StatusServiceUnavailable: true,
+	http.StatusGatewayTimeout:     true,
+}
+
+// maxRenderBackoff caps exponential growth so a long deadline cannot produce a
+// single sleep that swallows the entire remaining budget.
+const maxRenderBackoff = 2 * time.Second
+
+// defaultAttemptTimeout bounds one attempt. A cold attempt pays a container
+// wake plus a Chromium launch plus the render; anything beyond this is a hang,
+// and retrying beats waiting out the whole budget on a dead connection.
+const defaultAttemptTimeout = 15 * time.Second
+
 // HTMLToImageRenderer POSTs the composite HTML to the sibling html-to-image
 // service and returns the rendered PNG bytes. It mirrors the TS
-// image-generator.ts call shape and retry discipline (bounded deadline, retry
-// on network errors only — not on HTTP errors).
+// image-generator.ts call shape and retry discipline: a bounded overall
+// deadline, retry on network errors and on not-awake-yet statuses.
 type HTMLToImageRenderer struct {
 	URL     string
 	Client  *http.Client
 	Timeout time.Duration // overall deadline including retries
+	// AttemptTimeout bounds a single attempt. The overall Timeout must not be
+	// used here: one hung connection would consume the entire budget and leave
+	// nothing for the retry that would have succeeded.
+	AttemptTimeout time.Duration
 }
 
 // NewHTMLToImageRenderer constructs a renderer for the given service URL. The
@@ -43,10 +68,17 @@ func NewHTMLToImageRenderer(url string, timeout time.Duration) *HTMLToImageRende
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
+	attempt := defaultAttemptTimeout
+	if timeout < attempt {
+		attempt = timeout
+	}
 	return &HTMLToImageRenderer{
-		URL:     url,
-		Client:  &http.Client{Timeout: timeout},
-		Timeout: timeout,
+		URL: url,
+		// No Client.Timeout: each attempt carries its own context deadline, and a
+		// client-level timeout would apply to the whole loop rather than one try.
+		Client:         &http.Client{},
+		Timeout:        timeout,
+		AttemptTimeout: attempt,
 	}
 }
 
@@ -58,10 +90,11 @@ type renderRequest struct {
 	Options map[string]any `json:"options"`
 }
 
-// Render POSTs the HTML and returns the image bytes. Network errors are retried
-// with exponential backoff until the deadline; HTTP 4xx/5xx are not retried (a
-// response means the service is up — retrying the same payload won't help). Any
-// failure surfaces as ErrRenderFailed so callers can handle one typed error.
+// Render POSTs the HTML and returns the image bytes. Network errors and
+// not-awake-yet statuses are retried with capped exponential backoff until the
+// deadline; other non-2xx responses are final (retrying a rejected payload
+// won't help). Any failure surfaces as ErrRenderFailed so callers can handle
+// one typed error.
 func (r *HTMLToImageRenderer) Render(ctx context.Context, htmlSrc string) ([]byte, error) {
 	body, err := json.Marshal(renderRequest{
 		Source: htmlSrc,
@@ -78,40 +111,85 @@ func (r *HTMLToImageRenderer) Render(ctx context.Context, htmlSrc string) ([]byt
 	deadline := time.Now().Add(r.Timeout)
 	delay := 500 * time.Millisecond
 	var lastErr error
+
 	for {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("%w: %v", ErrRenderFailed, ctxErr)
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.URL, bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("%w: build request: %v", ErrRenderFailed, err)
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
 		}
-		req.Header.Set("Content-Type", "application/json")
 
-		resp, err := r.Client.Do(req)
-		if err != nil {
-			// Network error: retryable.
+		respBytes, status, err := r.attempt(ctx, body, minDuration(r.attemptTimeout(), remaining))
+		switch {
+		case err != nil:
 			lastErr = err
-			if time.Now().After(deadline) {
-				break
-			}
-			time.Sleep(delay)
-			delay *= 2
-			continue
-		}
-		respBytes, readErr := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if readErr != nil {
-			return nil, fmt.Errorf("%w: read response: %v", ErrRenderFailed, readErr)
-		}
-		if resp.StatusCode/100 != 2 {
+		case wakeRetryableStatuses[status]:
+			lastErr = fmt.Errorf("html-to-image %d: %s", status, strings.TrimSpace(string(respBytes)))
+		case status/100 != 2:
 			return nil, fmt.Errorf("%w: html-to-image %d: %s",
-				ErrRenderFailed, resp.StatusCode, strings.TrimSpace(string(respBytes)))
-		}
-		if len(respBytes) == 0 {
+				ErrRenderFailed, status, strings.TrimSpace(string(respBytes)))
+		case len(respBytes) == 0:
 			return nil, fmt.Errorf("%w: empty response", ErrRenderFailed)
+		default:
+			return respBytes, nil
 		}
-		return respBytes, nil
+
+		wait := minDuration(delay, time.Until(deadline))
+		if wait <= 0 {
+			break
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("%w: %v", ErrRenderFailed, ctx.Err())
+		case <-timer.C:
+		}
+		delay = minDuration(delay*2, maxRenderBackoff)
 	}
 	return nil, fmt.Errorf("%w: after retries: %v", ErrRenderFailed, lastErr)
+}
+
+// attempt performs one POST under its own deadline and returns the body and
+// status. A transport error yields a zero status, which the caller treats as
+// retryable.
+func (r *HTMLToImageRenderer) attempt(ctx context.Context, body []byte, timeout time.Duration) ([]byte, int, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.URL, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.Client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// A truncated read mid-wake is transient; report it as retryable rather
+		// than failing the whole render on one bad connection.
+		return nil, 0, err
+	}
+	return respBytes, resp.StatusCode, nil
+}
+
+func (r *HTMLToImageRenderer) attemptTimeout() time.Duration {
+	if r.AttemptTimeout > 0 {
+		return r.AttemptTimeout
+	}
+	return defaultAttemptTimeout
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/opengraph-service/internal/shim/renderer_test.go
+++ b/opengraph-service/internal/shim/renderer_test.go
@@ -1,0 +1,191 @@
+package shim
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// wakeServer answers the first failCount requests with status, then serves the
+// PNG — the shape of a Railway service coming out of sleep.
+func wakeServer(t *testing.T, status int, failCount int32, png string) (*httptest.Server, *int32) {
+	t.Helper()
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n <= failCount {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte("Application failed to respond"))
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte(png))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func newTestRenderer(url string, timeout time.Duration) *HTMLToImageRenderer {
+	r := NewHTMLToImageRenderer(url, timeout)
+	r.AttemptTimeout = timeout
+	return r
+}
+
+func TestRenderRetriesWakeStatuses(t *testing.T) {
+	// Railway's edge answers 502 while the container is still waking, and the
+	// image service answers 503 while Chromium is still launching. Neither means
+	// the render is impossible.
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		srv, calls := wakeServer(t, status, 2, "PNGDATA")
+		r := newTestRenderer(srv.URL, 10*time.Second)
+
+		got, err := r.Render(context.Background(), "<h1>hi</h1>")
+		if err != nil {
+			t.Fatalf("status %d: expected success after wake, got %v", status, err)
+		}
+		if string(got) != "PNGDATA" {
+			t.Fatalf("status %d: got body %q", status, got)
+		}
+		if n := atomic.LoadInt32(calls); n != 3 {
+			t.Fatalf("status %d: expected 3 attempts, got %d", status, n)
+		}
+	}
+}
+
+func TestRenderDoesNotRetryClientErrors(t *testing.T) {
+	// A rejected payload fails identically on every attempt; retrying only burns
+	// the deadline.
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnsupportedMediaType, http.StatusTooManyRequests} {
+		srv, calls := wakeServer(t, status, 100, "")
+		r := newTestRenderer(srv.URL, 5*time.Second)
+
+		_, err := r.Render(context.Background(), "<h1>hi</h1>")
+		if !errors.Is(err, ErrRenderFailed) {
+			t.Fatalf("status %d: expected ErrRenderFailed, got %v", status, err)
+		}
+		if n := atomic.LoadInt32(calls); n != 1 {
+			t.Fatalf("status %d: expected exactly 1 attempt, got %d", status, n)
+		}
+	}
+}
+
+func TestRenderRetriesNetworkErrors(t *testing.T) {
+	srv, _ := wakeServer(t, http.StatusOK, 0, "PNGDATA")
+	dead := srv.URL
+	srv.Close() // nothing is listening — every dial fails
+
+	r := newTestRenderer(dead, 1500*time.Millisecond)
+	start := time.Now()
+	_, err := r.Render(context.Background(), "<h1>hi</h1>")
+	if !errors.Is(err, ErrRenderFailed) {
+		t.Fatalf("expected ErrRenderFailed, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("retry loop overran its deadline: %v", elapsed)
+	}
+}
+
+func TestRenderGivesUpAfterDeadlineOnPersistentWakeStatus(t *testing.T) {
+	srv, calls := wakeServer(t, http.StatusBadGateway, 1000, "")
+	r := newTestRenderer(srv.URL, 1500*time.Millisecond)
+
+	start := time.Now()
+	_, err := r.Render(context.Background(), "<h1>hi</h1>")
+	if !errors.Is(err, ErrRenderFailed) {
+		t.Fatalf("expected ErrRenderFailed, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("retry loop overran its deadline: %v", elapsed)
+	}
+	if n := atomic.LoadInt32(calls); n < 2 {
+		t.Fatalf("expected multiple attempts before giving up, got %d", n)
+	}
+}
+
+func TestRenderPerAttemptTimeoutLeavesBudgetForRetry(t *testing.T) {
+	// The first attempt hangs. With a client timeout equal to the overall
+	// deadline it would swallow the entire budget; a per-attempt bound must cut
+	// it loose in time for the retry that succeeds.
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			select {
+			case <-time.After(2 * time.Second):
+			case <-r.Context().Done():
+			}
+			return
+		}
+		_, _ = w.Write([]byte("PNGDATA"))
+	}))
+	t.Cleanup(srv.Close)
+
+	r := NewHTMLToImageRenderer(srv.URL, 8*time.Second)
+	r.AttemptTimeout = 300 * time.Millisecond
+
+	got, err := r.Render(context.Background(), "<h1>hi</h1>")
+	if err != nil {
+		t.Fatalf("expected the retry to succeed, got %v", err)
+	}
+	if string(got) != "PNGDATA" {
+		t.Fatalf("got body %q", got)
+	}
+}
+
+func TestRenderStopsOnContextCancel(t *testing.T) {
+	srv, _ := wakeServer(t, http.StatusBadGateway, 1000, "")
+	r := newTestRenderer(srv.URL, 30*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := r.Render(ctx, "<h1>hi</h1>")
+	if !errors.Is(err, ErrRenderFailed) {
+		t.Fatalf("expected ErrRenderFailed, got %v", err)
+	}
+	// Must abandon the loop on cancellation rather than sleeping out the 30s.
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("cancellation ignored, took %v", elapsed)
+	}
+}
+
+func TestRenderRejectsEmptySuccessBody(t *testing.T) {
+	srv, _ := wakeServer(t, http.StatusOK, 0, "")
+	r := newTestRenderer(srv.URL, 2*time.Second)
+
+	_, err := r.Render(context.Background(), "<h1>hi</h1>")
+	if !errors.Is(err, ErrRenderFailed) {
+		t.Fatalf("expected ErrRenderFailed for an empty 200, got %v", err)
+	}
+}
+
+func TestNewHTMLToImageRendererDefaults(t *testing.T) {
+	r := NewHTMLToImageRenderer("", 0)
+	if r.URL != "http://localhost:3033/" {
+		t.Fatalf("unexpected default URL %q", r.URL)
+	}
+	if r.Timeout != 30*time.Second {
+		t.Fatalf("unexpected default timeout %v", r.Timeout)
+	}
+	// A client-level timeout would bound the whole retry loop instead of one
+	// attempt, which is the bug the per-attempt deadline replaces.
+	if r.Client.Timeout != 0 {
+		t.Fatalf("client timeout must stay unset, got %v", r.Client.Timeout)
+	}
+	if r.AttemptTimeout <= 0 || r.AttemptTimeout > r.Timeout {
+		t.Fatalf("attempt timeout %v must be positive and within the overall budget", r.AttemptTimeout)
+	}
+
+	// A short overall budget must clamp the per-attempt bound, not exceed it.
+	short := NewHTMLToImageRenderer("http://x/", 2*time.Second)
+	if short.AttemptTimeout != 2*time.Second {
+		t.Fatalf("expected attempt timeout clamped to 2s, got %v", short.AttemptTimeout)
+	}
+}

--- a/server/src/lib/image-generator.ts
+++ b/server/src/lib/image-generator.ts
@@ -36,10 +36,19 @@ const BASE_CSS = `
 // deadline has to cover both, not just a warm render.
 const IMAGE_SERVICE_DEADLINE_MS = 30_000;
 
-// Retries a fetch on network errors (ECONNREFUSED, ETIMEDOUT, etc.) for up to
-// timeoutMs. Does not retry HTTP error responses — those mean the service is up.
-// Each individual request is bounded by an AbortController so a hanging
-// connection cannot block the loop past the overall deadline.
+// A sleeping service answers before it is ready, and those answers are HTTP
+// responses rather than network errors: Railway's edge returns 502 while the
+// container is still waking, and the image service itself returns 503 while
+// Chromium is still launching. Treating any response as final would turn every
+// wake into a user-visible failure. 4xx is excluded on purpose — a rejected
+// payload fails identically on every attempt — as is 429, where retrying only
+// adds load to a limiter that is already shedding.
+const WAKE_RETRYABLE_STATUSES = new Set([408, 502, 503, 504]);
+
+// Retries on network errors (ECONNREFUSED, ETIMEDOUT, etc.) and on the
+// not-awake-yet statuses above, for up to timeoutMs. Each individual request is
+// bounded by an AbortController so a hanging connection cannot block the loop
+// past the overall deadline.
 export async function fetchWithRetry(
   url: string,
   init: RequestInit,
@@ -48,6 +57,7 @@ export async function fetchWithRetry(
   const deadline = Date.now() + timeoutMs;
   let delay = 500;
   let lastError: unknown;
+  let lastRetryableResponse: { status: number; statusText: string; body: string } | undefined;
   while (true) {
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
@@ -55,8 +65,20 @@ export async function fetchWithRetry(
     const abortTimer = setTimeout(() => controller.abort(), remaining);
     try {
       const response = await fetch(url, { ...init, signal: controller.signal });
+      if (!WAKE_RETRYABLE_STATUSES.has(response.status)) {
+        clearTimeout(abortTimer);
+        return response;
+      }
+      // Drain the body before discarding the response, so the connection is
+      // released back to the pool instead of being held open by the next retry.
+      // The abort timer stays armed across the drain — a body that never
+      // finishes must not outlive the deadline.
+      lastRetryableResponse = {
+        status: response.status,
+        statusText: response.statusText,
+        body: await response.text(),
+      };
       clearTimeout(abortTimer);
-      return response;
     } catch (err) {
       clearTimeout(abortTimer);
       lastError = err;
@@ -65,6 +87,12 @@ export async function fetchWithRetry(
     if (remainingAfter <= 0) break;
     await new Promise((r) => setTimeout(r, Math.min(delay, remainingAfter)));
     delay = Math.min(Math.ceil(delay * 1.5), 2000);
+  }
+  // Exhausted while the service was still waking: hand back the last real
+  // response so the caller logs the actual status instead of a generic throw.
+  if (lastRetryableResponse) {
+    const { status, statusText, body } = lastRetryableResponse;
+    return new Response(body, { status, statusText });
   }
   throw lastError;
 }

--- a/server/src/tests/image-generator.test.ts
+++ b/server/src/tests/image-generator.test.ts
@@ -47,7 +47,7 @@ describe("fetchWithRetry", () => {
     await assert.rejects(() => fetchWithRetry("http://test/", {}, 50), networkError);
   });
 
-  test("does not retry on HTTP error responses", async () => {
+  test("does not retry a 500 — the service answered, the render itself failed", async () => {
     let callCount = 0;
     mock.method(globalThis, "fetch", async () => {
       callCount++;
@@ -58,6 +58,86 @@ describe("fetchWithRetry", () => {
 
     assert.strictEqual(result.status, 500);
     assert.strictEqual(callCount, 1);
+  });
+
+  test("retries a 502 from Railway's edge while the service is waking", async () => {
+    // A slept Railway service answers the first request from the edge with a
+    // 502 before the container is back. Treating that as final would make every
+    // wake a user-visible image-generation failure.
+    const mockResponse = new Response("ok", { status: 200 });
+    let callCount = 0;
+    mock.method(globalThis, "fetch", async () => {
+      callCount++;
+      if (callCount < 3) return new Response("Application failed to respond", { status: 502 });
+      return mockResponse;
+    });
+
+    const result = await fetchWithRetry("http://test/", {}, 5000);
+
+    assert.strictEqual(result, mockResponse);
+    assert.strictEqual(callCount, 3);
+  });
+
+  test("retries a 503 emitted while Chromium is still launching", async () => {
+    const mockResponse = new Response("ok", { status: 200 });
+    let callCount = 0;
+    mock.method(globalThis, "fetch", async () => {
+      callCount++;
+      if (callCount < 2) {
+        return new Response(JSON.stringify({ error: "Browser unavailable" }), { status: 503 });
+      }
+      return mockResponse;
+    });
+
+    const result = await fetchWithRetry("http://test/", {}, 5000);
+
+    assert.strictEqual(result, mockResponse);
+    assert.strictEqual(callCount, 2);
+  });
+
+  test("retries 408 and 504 but never a 4xx the payload caused", async () => {
+    for (const status of [408, 504]) {
+      let callCount = 0;
+      mock.method(globalThis, "fetch", async () => {
+        callCount++;
+        if (callCount < 2) return new Response("", { status });
+        return new Response("ok", { status: 200 });
+      });
+      const result = await fetchWithRetry("http://test/", {}, 5000);
+      assert.strictEqual(result.status, 200, `status ${status} should have been retried`);
+      assert.strictEqual(callCount, 2);
+      mock.restoreAll();
+    }
+
+    // 400 is a rejected payload and 429 is a limiter already shedding load —
+    // both fail identically on retry, so neither is worth another attempt.
+    for (const status of [400, 429]) {
+      let callCount = 0;
+      mock.method(globalThis, "fetch", async () => {
+        callCount++;
+        return new Response("nope", { status });
+      });
+      const result = await fetchWithRetry("http://test/", {}, 5000);
+      assert.strictEqual(result.status, status);
+      assert.strictEqual(callCount, 1, `status ${status} must not be retried`);
+      mock.restoreAll();
+    }
+  });
+
+  test("returns the last wake response, not a throw, when the deadline expires", async () => {
+    // The caller logs response.status/body on failure. Throwing here would
+    // replace a diagnosable "502 from the edge" with a generic error.
+    let callCount = 0;
+    mock.method(globalThis, "fetch", async () => {
+      callCount++;
+      return new Response("Application failed to respond", { status: 502 });
+    });
+
+    const result = await fetchWithRetry("http://test/", {}, 50);
+
+    assert.strictEqual(result.status, 502);
+    assert.strictEqual(await result.text(), "Application failed to respond");
+    assert.ok(callCount >= 1);
   });
 
   test("breaks without sleeping when deadline expires during a failed fetch attempt", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #281, which let `html-to-image` sleep. Both callers were written for a service that is either up or unreachable — and a sleeping service is neither. This hardens the wake path, and fixes a PID leak that #281 turned from harmless into slow-motion exhaustion.

## Related issue

Closes #

## Scope

- [ ] client
- [x] server
- [x] opengraph-service
- [x] docker / infra (caddy, anubis)
- [x] docs

## Changes

**Retry the wake-shaped statuses.** Railway's edge answers `502` while the container boots; the image service itself answers `503` while Chromium launches. Both are HTTP *responses*, and both callers treated any response as final — on the explicit reasoning that "a response means the service is up". So the first render after an idle stretch failed outright. `408/502/503/504` are now retried in both `server/src/lib/image-generator.ts` and `opengraph-service/internal/shim/renderer.go`. `4xx` stays terminal (a rejected payload fails identically every attempt), as does `429` (retrying a limiter that's already shedding just adds load).

**Bound retries per attempt, not per loop.** The Go renderer set `http.Client.Timeout` to the entire 30s budget, so a single hung connection consumed every retry it was meant to fund. Each attempt now carries its own context deadline. Backoff is capped at 2s, clamped to the remaining budget, and abandons the loop on context cancellation instead of sleeping through it.

**Reap Chromium's orphans.** Node ran as PID 1, and Chromium's children are reparented to PID 1 when the browser exits. Every launch/close cycle left four permanent zombie entries. That was harmless when the browser lived for the container's lifetime — #281 made it a per-idle-cycle leak. `tini` as `ENTRYPOINT` reaps them.

**Pin the builder.** Railway builds this service from `html-to-image/Dockerfile`; it wins by auto-detection (*"Railway will always build with a Dockerfile if it finds one"*) while the dashboard and API still report the `RAILPACK` default. `html-to-image/railway.json` now states it explicitly. See the correction on #281 — my note there had this backwards.

## Testing

- [x] Unit/integration tests pass locally — 321 server, full opengraph suite, `go vet ./...` clean
- [ ] E2E (Playwright) passes for affected flows
- [x] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account

8 new Go tests cover each wake status, the 4xx/429 non-retry, per-attempt timeout leaving budget for a successful retry, and cancellation. 5 new server tests cover the same matrix plus returning the last 502 rather than throwing, so the caller still logs a diagnosable status.

Zombie fix verified in the real container. Before:

```
PID   PPID  STAT COMMAND
    1     0 S    MainThread
   32     1 Z    chrome_crashpad
   34     1 Z    chrome_crashpad
   55     1 Z    chromium
   65     1 Z    chromium
```

After, following a render and a full idle close:

```
PID   PPID  STAT COMMAND
    1     0 S    tini
    7     1 S    MainThread
```

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens
- [x] Docs updated if user-facing behavior or setup changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6gnLVJZKEFoQDptbTMgom
