### PR TITLE
fix(server): fail with the real cause when @atproto-labs/fetch-node is unpatched

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "exclude": [
       "src/lexicon/**",
       "src/index.ts",
+      "src/lib/assert-fetch-node-patch.ts",
       "src/auth/client.ts",
       "src/auth/e2e-agent-store.ts",
       "src/auth/storage.ts",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,8 @@
+// Must stay the first import: it front-runs the @atproto/oauth-client-node
+// import graph so an unpatched @atproto-labs/fetch-node fails with the actual
+// cause rather than an undici stack trace. See the module for why.
+import "#/lib/assert-fetch-node-patch";
+
 import dns from "node:dns";
 import events from "node:events";
 

--- a/server/src/lib/assert-fetch-node-patch.ts
+++ b/server/src/lib/assert-fetch-node-patch.ts
@@ -1,0 +1,38 @@
+// Side-effect module. Import it FIRST in src/index.ts, before anything that
+// reaches @atproto/oauth-client-node.
+//
+// Under Bun, @atproto-labs/fetch-node crashes at module load unless
+// patches/@atproto-labs%2Ffetch-node@0.3.5.patch is applied: undici 8's
+// CacheStorage constructor calls webidl.util.markAsUncloneable, which Bun does
+// not implement (nodejs/undici#5024). The failure therefore happens while the
+// import graph is still evaluating, which is why this front-runs that import
+// rather than checking anything from the module body — by the time a statement
+// in index.ts could run, the process is already dead.
+//
+// Left alone, it surfaces as an undici stack trace with no hint that the real
+// cause is an installer that ignored `patchedDependencies`. That cost a
+// production deploy once; see #293.
+
+// Marks the file as a module so the top-level await below is legal (TS1375);
+// there is nothing to export.
+export {};
+
+try {
+  await import("@atproto/oauth-client-node");
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  if (!message.includes("markAsUncloneable")) throw err;
+
+  throw new Error(
+    "@atproto-labs/fetch-node is not patched, so the server cannot boot under Bun.\n" +
+      "\n" +
+      "This almost always means dependencies were installed by npm or yarn rather\n" +
+      "than bun: `patchedDependencies` in the root package.json is a Bun-only field\n" +
+      "and other installers ignore it silently.\n" +
+      "\n" +
+      "Fix: install with `bun install`, which docker/Dockerfile.server already does.\n" +
+      "On Railway, confirm the service builds from that Dockerfile rather than a\n" +
+      "native/RAILPACK build — see issue #293.",
+    { cause: err }
+  );
+}


### PR DESCRIPTION
## Summary

Deploying #283 to Railway crashed on boot with an undici stack trace that gave no indication of the actual cause:

```
> navyfragen-server@1.0.0 start
> bun src/index.ts
TypeError: webidl.util.markAsUncloneable is not a function
      at new CacheStorage (/app/node_modules/undici_v8/lib/web/cache/cachestorage.js:20:17)
```

The real cause was that the service builds natively on Railway and installed with **npm**. `patchedDependencies` is a Bun-only `package.json` field, so npm ignored it silently, `@atproto-labs/fetch-node` was installed unpatched, and its top-level `undici_v8` import threw.

Diagnosing that needed two indirect tells — npm's `> name@version` script echo (Bun prints `$ …`), and the flat `node_modules/undici_v8` path (Bun uses an isolated `.bun` store) — rather than anything in the error itself. This makes the error say it.

Fixing the deployment is #293; this is the guardrail so the next occurrence is a one-line diagnosis.

## Related issue

Guardrail for #293. Follows #283 / #268.

## Scope

- [x] server

## Changes

**The check has to be an import, not a statement.** The crash happens while `index.ts`'s own import graph is still evaluating — by the time any code in the module body could run, the process is already dead. So `src/lib/assert-fetch-node-patch.ts` is a side-effect module imported *first*, front-running the `@atproto/oauth-client-node` chain, catching the `markAsUncloneable` signature and re-throwing with the cause and the fix. Any other error propagates untouched.

Excluded from coverage alongside the other boot wiring (`src/index.ts`, `src/auth/client.ts`) — the catch branch only fires on an install this repo never produces.

## Testing

Verified against a deliberately unpatched install: `patchedDependencies` removed from `package.json` and reinstalled, reproducing exactly what npm does.

**Before:**

```
TypeError: webidl.util.markAsUncloneable is not a function.
      at new CacheStorage (.../undici/lib/web/cache/cachestorage.js:20:17)
```

**After:**

```
error: @atproto-labs/fetch-node is not patched, so the server cannot boot under Bun.

This almost always means dependencies were installed by npm or yarn rather
than bun: `patchedDependencies` in the root package.json is a Bun-only field
and other installers ignore it silently.

Fix: install with `bun install`, which docker/Dockerfile.server already does.
On Railway, confirm the service builds from that Dockerfile rather than a
native/RAILPACK build — see issue #293.
```

The repo was restored to a patched install afterwards and verified (`bun.lock` and `package.json` byte-identical to committed state, patch marker present in the store).

- [x] Unit/integration tests pass locally — **321/321 under both Node 24 and Bun 1.3.14**; typecheck and lint clean
- [x] Coverage unchanged (99.98% / 99.39%)
- [x] Docker smoke test — image built from `docker/Dockerfile.server` still boots against Postgres and serves
- [x] E2E (Playwright) — passed in CI
- [ ] Manually verified against a real Bluesky/AT Protocol account — not possible in this environment

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes reviewed with that lens — no behaviour change on a correctly patched install; the assertion only adds a clearer failure path
- [x] Docs updated — the rationale lives in the module's header comment

## Note

`typecheck` caught that the file needed `export {}` to be a module before top-level `await` was legal (TS1375) — worth knowing if the file is ever refactored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUJbq9HkJHgmP4MT1o8AM5)_