### PR TITLE
test(client): close remaining branch-coverage gaps to 100%

### DIFF
--- a/client/src/pages/Customise.tsx
+++ b/client/src/pages/Customise.tsx
@@ -130,7 +130,12 @@ export default function Customise() {
                         ? userSettings!.touchpointLocale!
                         : "en"
                     }
-                    onChange={(value) => updateSettings.mutate({ touchpointLocale: value || null })}
+                    onChange={(value) =>
+                      updateSettings.mutate({
+                        /* v8 ignore next */
+                        touchpointLocale: value || null,
+                      })
+                    }
                     disabled={busy}
                     allowDeselect={false}
                     aria-label="Message language"

--- a/client/src/tests/Navigation.test.tsx
+++ b/client/src/tests/Navigation.test.tsx
@@ -281,6 +281,32 @@ describe("Navigation", () => {
       expect(screen.getByTestId("location")).toHaveTextContent("/messages");
     });
 
+    it("Alt+C navigates to customise when logged in", () => {
+      mockSession({ isLoggedIn: true });
+      renderWithProviders(
+        <>
+          <Navigation />
+          <LocationDisplay />
+        </>,
+        { route: "/" }
+      );
+      fireEvent.keyDown(document, { key: "C", altKey: true });
+      expect(screen.getByTestId("location")).toHaveTextContent("/customise");
+    });
+
+    it("Alt+C does not navigate when logged out", () => {
+      mockSession({ isLoggedIn: false });
+      renderWithProviders(
+        <>
+          <Navigation />
+          <LocationDisplay />
+        </>,
+        { route: "/" }
+      );
+      fireEvent.keyDown(document, { key: "C", altKey: true });
+      expect(screen.getByTestId("location")).toHaveTextContent("/");
+    });
+
     it("Alt+S navigates to settings when logged in", () => {
       mockSession({ isLoggedIn: true });
       renderWithProviders(

--- a/client/src/tests/pages/Customise.test.tsx
+++ b/client/src/tests/pages/Customise.test.tsx
@@ -132,6 +132,14 @@ describe("Customise page", () => {
     expect(mutate).toHaveBeenCalledWith({ touchpointLocale: "es" });
   });
 
+  it("shows the matching label when touchpointLocale is already set to a known locale", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings({ touchpointLocale: "es" }));
+    mockMutation();
+    renderWithProviders(<Customise />);
+
+    expect(screen.getByRole("combobox", { name: /message language/i })).toHaveValue("Español");
+  });
+
   it("picking a profile card theme swatch fires updateSettings with profileCardTheme", () => {
     mockUseUserSettings.mockReturnValue(mockSettings());
     const mutate = mockMutation();
@@ -174,6 +182,31 @@ describe("Customise page", () => {
     fireEvent.blur(input);
 
     expect(mutate).toHaveBeenCalledWith({ customPrompt: null });
+  });
+
+  it("shows skeletons in every card while settings are loading", () => {
+    mockUseUserSettings.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as any);
+    mockMutation();
+    renderWithProviders(<Customise />);
+
+    expect(screen.getByText(/customise/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/profile prompt/i)).toBeNull();
+    expect(screen.queryByLabelText(/message language/i)).toBeNull();
+    expect(screen.queryByLabelText(/accepting messages/i)).toBeNull();
+  });
+
+  it("disables the profile theme swatches while a mutation is pending", () => {
+    mockUseUserSettings.mockReturnValue(mockSettings());
+    mockUseUpdateUserSettings.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+    } as any);
+    renderWithProviders(<Customise />);
+
+    expect(screen.getByLabelText(/ember theme/i)).toBeDisabled();
   });
 
   it("renders correctly in dark mode", () => {

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -40,6 +40,14 @@ This document explains coverage exclusions and hard-to-test code.
 
 **What it would take to test:** Not worth pursuing — would require mocking `document.body.style` property assignment to throw, which doesn't reflect any real browser behavior.
 
+### `client/src/pages/Customise.tsx` — unreachable `null` fallback in the locale `Select`'s `onChange`
+
+**Line:** `touchpointLocale: value || null` inside the "Message language" `Select`'s `onChange` handler.
+
+**Why ignored:** Mantine's `Select` `onChange` signature is typed to allow `value: string | null`, but `null` is only ever passed when the currently-selected option is deselected, which requires `allowDeselect` (or `clearable`) to be enabled. This `Select` is rendered with `allowDeselect={false}` and no clear affordance, so every `onChange` reachable through the rendered UI carries one of the non-empty locale codes from `touchpointLocales` — `value` is always truthy in practice. The `|| null` exists to satisfy the handler's declared parameter type, not to handle a reachable UI state.
+
+**What it would take to test:** Call the `Select`'s `onChange` prop directly (bypassing rendering) with `null`, e.g. by extracting the handler to a named, exported function, or by asserting on the prop passed to a mocked `Select`.
+
 ### `client/src/pages/Settings.tsx` — unreachable `!installPrompt` early-return guard
 
 **Line:** `if (!installPrompt) return;` inside `handleInstallClick`.


### PR DESCRIPTION
## Summary

Client test coverage was at 99.75% statements / 98.82% branches (from `bun run test -- --coverage`, run under Node 24 per CI). This PR adds targeted tests for the last untested branches, bringing the client suite to **100%** across statements/branches/functions/lines. Companion PR to #295 (server-side); doesn't touch any of the same files, so the two can land independently.

## Related issue

None — scheduled coverage-improvement task.

## Scope

- [x] client
- [x] docs

## Changes

- `src/Navigation.tsx` — added the missing `Alt+C` keyboard-shortcut test (navigate to `/customise`), both logged-in and logged-out, mirroring the existing `Alt+M`/`Alt+S` coverage.
- `src/pages/Customise.tsx` / its test file — all five settings cards share an identical `settingsLoading ? <Skeleton /> : settingsError ? ... : (...)` ternary, and no test ever set `isLoading: true`, so the skeleton branch was untested for every card. Added one test covering all five. Also added a test for the profile-theme-swatch buttons' `disabled` state while a mutation is pending, and a test asserting the language `Select` shows the matching label when `touchpointLocale` is already set to a known locale (the `.some()` match branch was previously only ever false).
- `src/pages/Customise.tsx` — the one remaining branch, the language `Select`'s `onChange={(value) => ... value || null}`, is unreachable through the UI: the `Select` is rendered with `allowDeselect={false}` and no clear affordance, so `onChange` only ever fires with a truthy locale code. Excluded with `/* v8 ignore next */` and documented in `docs/testing-notes.md` (new entry), following the same pattern already used for the `AppHeader`/`Settings` unreachable-guard exclusions in that file.

## Coverage

**Before** (`bun run test -- --coverage`, Node 24):
```
All files | 99.75 stmts | 98.82 branch | 100 funcs | 99.82 lines
```

**After:**
```
All files | 100 stmts | 100 branch | 100 funcs | 100 lines
```

4 files touched, 5 new test cases added. 1 branch intentionally excluded via `/* v8 ignore next */` (documented above and in `docs/testing-notes.md`); every other gap was reachable code missing a test case.

## Testing

- [x] Unit/integration tests pass locally — 528/528 (`bun run test -- --coverage`)
- [x] `bun run build` succeeds (tsc + vite build)
- [x] `bun run lint` — no new warnings introduced
- [ ] E2E (Playwright) passes for affected flows — not run (test-only change plus one inline comment, no behavior change)
- [ ] Manually verified against a real Bluesky/AT Protocol account — not applicable (test-only change)

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes reviewed with that lens — no behavior change, tests and one coverage-exclusion comment only
- [x] Docs updated if user-facing behavior or setup changed — `docs/testing-notes.md` updated with the new exclusion rationale

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2ZAxKfxGpiDdtqRoX1E1Q)_