### PR TITLE
docker: publish caddy and server by default to cut local-dev friction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ e2e/.auth/
 docs/superpowers/
 /.zcode
 /.playwright-mcp
+
+# Local-only compose overrides (e.g. exposing a service's port for debugging)
+docker/docker-compose.override.yml

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,8 +12,18 @@ COOKIE_SECRET=
 # ── Optional ──────────────────────────────────────────────────────────────────
 
 # Public-facing URL of the app (used for Bluesky OAuth client metadata).
-# Bluesky OAuth works on localhost — no tunnel needed for local testing.
-# PUBLIC_URL=http://localhost:8080
+# Leave this unset for local dev — the server falls back to the loopback
+# OAuth client format (valid per RFC 8252) and OAuth login works with no
+# tunnel, as long as the server's port 3000 reaches your browser (the
+# default compose setup already publishes it).
+#
+# Only set this if you need a real public HTTPS URL (e.g. testing OG image
+# previews from an external crawler). It must be an actual https:// URL from
+# a tunnel (ngrok, etc.) — http://localhost:8080 or similar will fail client
+# metadata validation (RFC 8252 requires the literal IP "127.0.0.1", not the
+# "localhost" hostname, for redirect_uris; and a non-loopback client_id must
+# be https).
+# PUBLIC_URL=https://your-tunnel-subdomain.ngrok-free.app
 
 # PostgreSQL credentials (defaults work out of the box)
 # POSTGRES_USER=navyfragen

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,20 +1,20 @@
 # Docker Compose Stack
 
-This stack is used for **local integration testing and smoke tests** (and optionally self-hosting). It is not how the production deployment works.
-
-**Production** runs on Railway using native Railpack/Nixpacks builds — the `client/railway.json` and `server/railway.json` files govern that path.
+This stack is used for **local integration testing and smoke tests** (and optionally self-hosting). It mirrors production closely: Railway builds every service from these same Dockerfiles (pinned via `railway.server.json` / `railway.client.json` at the repo root and `railway.json` in each self-contained service directory — see `CLAUDE.md` → "Deployment (Railway)").
 
 ## Services
 
 | Service | Description | Port |
 |---------|-------------|------|
-| `anubis` | Bot-protection WAF — main entry point | 8080 |
-| `caddy` | Reverse proxy: `/*` → client, `/api/*` → server | internal |
+| `caddy` | Reverse proxy: `/*` → client, `/api/*` → server. **Default local entry point.** | 8082 |
+| `anubis` | Bot-protection WAF, production topology (Anubis → Caddy) | 8080 |
+| `server` | Express API | 3000 |
 | `client` | React SPA served by `serve` | internal |
-| `server` | Express API | internal |
 | `html-to-image` | Puppeteer image renderer | internal |
 | `redirector` | Short-URL redirector (fragen.navy equivalent) | 8081 |
 | `postgres` | PostgreSQL 16 | internal |
+
+`caddy` and `server` are published directly so the stack works out of the box for local dev with no extra setup — see "Caveats" for why `anubis` isn't the default entry point locally even though it is in production.
 
 ## Quick start
 
@@ -25,7 +25,7 @@ cp docker/.env.example docker/.env
 docker compose -f docker/docker-compose.yml up --build
 ```
 
-The app is available at `http://localhost:8080`. The short-URL redirector is at `http://localhost:8081`.
+The app is available at `http://localhost:8082` (via Caddy directly). The short-URL redirector is at `http://localhost:8081`. The production-topology entry point through Anubis is at `http://localhost:8080` — see the Anubis caveat below before using it directly in a browser.
 
 ## Environment
 
@@ -45,11 +45,11 @@ All Docker-related files live here to keep Railway from auto-detecting them in t
 | `Dockerfile.server` | Express API image (build context: repo root) |
 | `.env.example` | Secret template — copy to `.env` before running |
 
-`client/Dockerfile` and `server/Dockerfile` are intentionally absent. If they existed there, Railway would detect them and attempt a Docker build instead of the Railpack npm build used in production.
+`client/Dockerfile` and `server/Dockerfile` are intentionally absent — all Docker-related files live under `docker/` to keep the service directories clean. Railway is explicitly pinned to `docker/Dockerfile.client` / `docker/Dockerfile.server` via config-as-code (`railway.client.json` / `railway.server.json` at the repo root — see `CLAUDE.md` → "Deployment (Railway)"), so it doesn't rely on auto-detection either way.
 
 ## Caveats
 
-- **Bluesky OAuth requires a public URL.** `localhost` works for local dev but the OAuth callback must be reachable by Bluesky's servers. For a fully functional local stack you need a tunnel (e.g. ngrok) and `PUBLIC_URL` set accordingly.
-- **Anubis PoW challenge.** Anubis serves a proof-of-work challenge page to unknown clients. In CI the smoke test hits `/robots.txt` with `X-Real-Ip` set, which bypasses the challenge. Direct browser access on a fresh IP will trigger it.
+- **OAuth login works out of the box — leave `PUBLIC_URL` unset.** With `PUBLIC_URL` unset, the server uses the RFC 8252 loopback OAuth client format, and Bluesky redirects your browser straight back to `http://127.0.0.1:3000/oauth/callback` — no tunnel needed, as long as you're testing through a URL where port 3000 is reachable (true by default; see the `server` service's `ports` in `docker-compose.yml`). A tunnel (e.g. ngrok) and a real `https://` `PUBLIC_URL` are only needed if you specifically want a non-loopback public URL, e.g. to test OG image previews against an external crawler. `PUBLIC_URL` set to any plain `http://` value (including `http://localhost:8080`) will crash the server at boot — see the comment in `.env.example`.
+- **Anubis PoW challenge, and why it's not the local default.** Anubis serves a proof-of-work challenge to unknown clients and additionally requires an upstream proxy to set `X-Real-Ip` (production: Railway's edge; CI: `DockerSmoke.yml` sets it explicitly on the `/robots.txt` check). A plain browser hitting `http://localhost:8080` directly gets a `[misconfiguration] X-Real-Ip header is not set` error rather than even reaching the challenge page. Use `http://localhost:8082` (Caddy directly) for everyday local dev; use port 8080 only when you're deliberately testing Anubis itself.
 - **html-to-image requires `shm_size: 256m`.** Chromium inside Docker needs more `/dev/shm` than the default 64 MB. This is set in the compose file but may require Docker Desktop to have sufficient memory allocated.
 - **Not tested on ARM (Apple Silicon).** The `anubis` and `html-to-image` images may need `platform: linux/amd64` on M-series Macs.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,13 @@ services:
 
   # ── Entry points ────────────────────────────────────────────────────────────
 
-  # Bot-protection WAF.  Main app entry point — http://localhost:8080
+  # Bot-protection WAF, matching the production topology — http://localhost:8080
+  # Anubis's PoW check requires an upstream proxy to set X-Real-Ip (production:
+  # Railway's edge; CI: DockerSmoke sets it explicitly). A plain browser hitting
+  # this port directly gets a "[misconfiguration] X-Real-Ip header is not set"
+  # error instead of the challenge page. For everyday local dev, use caddy
+  # directly (below) — this is here for testing Anubis itself or the full
+  # production-like chain.
   anubis:
     build: ../anubis
     ports:
@@ -31,8 +37,14 @@ services:
   # synthesize per-profile OG responses for the Bluesky Cardyb crawler while
   # passing all other /* traffic through unchanged. /api/* is split by Caddy
   # upstream and never reaches the shim.
+  #
+  # Published directly on 8082 (distinct from Anubis's 8080) as the default
+  # local dev entry point — skips Anubis's PoW/X-Real-Ip check entirely, so a
+  # plain browser just works.
   caddy:
     build: ../caddy
+    ports:
+      - "8082:80"
     environment:
       PORT: 80
       FRONTEND_DOMAIN: opengraph-service
@@ -64,10 +76,16 @@ services:
     restart: unless-stopped
 
   # Express API
+  #
+  # Published directly on 3000: the loopback OAuth client format below
+  # redirects the browser to http://127.0.0.1:3000/oauth/callback, which only
+  # resolves if this port reaches the host — not just the compose network.
   server:
     build:
       context: ..
       dockerfile: docker/Dockerfile.server
+    ports:
+      - "3000:3000"
     environment:
       NODE_ENV: production
       PORT: 3000


### PR DESCRIPTION
## Summary

- Publishes `caddy` on `8082` (distinct from Anubis's `8080`) and `server` on `3000` directly in `docker/docker-compose.yml`, so a plain `docker compose up` works out of the box for local dev — no manual override needed.
- Fixes two blockers hit while locally verifying the Railway Dockerfile migration (#293):
  - Anubis requires an upstream proxy to set `X-Real-Ip`, which a plain browser never sets — hitting `:8080` directly gets a `[misconfiguration]` error instead of even the PoW challenge page. `caddy` on `:8082` bypasses this for everyday dev (Anubis stays on `:8080`, untouched, for testing it specifically or the full production-like chain — `DockerSmoke.yml`'s Anubis check is unaffected).
  - The server's loopback OAuth client format redirects the browser to `http://127.0.0.1:3000/oauth/callback`, which only resolves if the server's port reaches the host. It didn't before this change, so local OAuth login had no path to succeed without manual compose surgery.
- This mirrors a precedent already set for E2E testing — `docker-compose.e2e.yml` already publishes Caddy on `8090` for the same Anubis-bypass reason.
- Fixes `docker/README.md` and `docker/.env.example`, which had drifted from reality: the README described production as a Railpack/Nixpacks build (it's Dockerfile-based since #293) and named nonexistent `client/railway.json` / `server/railway.json` files; `.env.example` suggested `PUBLIC_URL=http://localhost:8080` as a working local value, but that combination actually fails RFC 8252 client-metadata validation and crashes the server at boot.

## Test plan

- [x] `podman-compose up -d --build` from a clean `down` state, no manual override file
- [x] `curl http://localhost:8082/` and `http://localhost:8082/api/client-metadata.json` → 200
- [x] `curl http://localhost:3000/client-metadata.json` → 200 (server reachable directly)
- [x] Confirmed `docker-compose.e2e.yml`'s `caddy: ports: ["8090:80"]` merges cleanly alongside the new `8082:80` base mapping (compose concatenates list-type keys across `-f` files) — no port conflict
- [ ] CI: `DockerSmoke.yml`'s Anubis-specific check (`:8080` with `X-Real-Ip` header) is untouched by this change; should be unaffected but worth confirming green

🤖 Generated with [Claude Code](https://claude.com/claude-code)