### PR TITLE
fix(caddy): stop replaying pass-challenge GETs at the WAF upstream

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -12,10 +12,26 @@
 	}
 }
 
+# For the API backends: /api/* is stateless JSON, so replaying a request that
+# may never have reached the upstream costs nothing but latency.
 (lb_settings) {
 	lb_policy round_robin
 	lb_retries 100
 	lb_try_duration 10s
+	lb_try_interval 250ms
+}
+
+# The WAF upstream cannot use the settings above. Anubis owns challenge state,
+# and /.within.website/.../pass-challenge is a GET — which Caddy treats as safe
+# to replay when a connection fails. If Anubis has already marked the challenge
+# spent and the connection then drops, Caddy cannot tell that from an unsent
+# request, so it re-sends it and Anubis answers `double_spend`: a 500 the user
+# sees as "administrator has misconfigured Anubis" (issue #306). Retries here
+# only need to cover a replica swap, not ride out a sustained outage.
+(waf_lb_settings) {
+	lb_policy round_robin
+	lb_retries 2
+	lb_try_duration 3s
 	lb_try_interval 250ms
 }
 
@@ -115,8 +131,8 @@
 			versions ipv4 ipv6
 		}
 
-		# configure load balancing settings
-		import lb_settings
+		# conservative retries — this upstream is Anubis, which owns challenge state
+		import waf_lb_settings
 
 		# configure passive health checks
 		import passive_health_checks


### PR DESCRIPTION
## Summary

The frontend `reverse_proxy` — which is Anubis — imported the same `lb_settings` as the API backends: **`lb_retries 100`** over `lb_try_duration 10s`.

That policy is correct for `/api/*`, where replaying a request that may never have arrived costs only latency. It is wrong in front of a service that owns state.

`/.within.website/x/cmd/anubis/api/pass-challenge` is a **GET**, and Caddy treats GETs as safe to replay when a connection fails. If Anubis has already marked the challenge spent and the connection then drops, Caddy cannot distinguish that from a request that never arrived — so it re-sends it, and Anubis answers `double_spend`. The user sees *"Internal Server Error: administrator has misconfigured Anubis… double_spend"*.

## Related issue

Refs #306

## Scope

- [ ] client
- [ ] server
- [ ] opengraph-service
- [x] docker / infra (caddy, anubis)
- [ ] docs

## Changes

- New `(waf_lb_settings)` snippet — `lb_retries 2`, `lb_try_duration 3s`. Enough to cover a replica swap, not enough to ride out a sustained outage.
- The frontend proxy imports it instead of `lb_settings`.
- `lb_settings` is unchanged and now reaches only the API backends via `backend_proxy`.

Verified the wiring:

```
17:(lb_settings) {          19:  lb_retries 100
31:(waf_lb_settings) {      33:  lb_retries 2
46:  import lb_settings          ← inside (backend_proxy)
102/118: import backend_proxy    ← /api/* NA + EU only
135: import waf_lb_settings      ← Anubis upstream
```

## This is plausible, not proven

I could not correlate a Caddy retry with a specific `double_spend` — Railway returns no HTTP logs for the Caddy service. The mechanism is sound and fits the observed clustering (four double-spends in 90 seconds on 07-25), but I am not claiming it as the confirmed cause.

It stands on its own regardless: **100 retries against an endpoint that mutates server-side state is wrong even if it never fired.**

## What this does *not* fix

The other contributor to `double_spend` is upstream and unfixable from here. `MakeChallenge` stores the challenge ID in a **single** test cookie:

```go
s.SetCookie(w, CookieOpts{Host: r.Host, Name: anubis.TestCookieName, Value: chall.ID})
```

Two concurrent tabs overwrite each other. I checked v1.26.0 — the newest release, and what we now run — and this is still present at `lib/anubis.go:476`. [TecharoHQ/anubis#659](https://github.com/TecharoHQ/anubis/issues/659) and [#1150](https://github.com/TecharoHQ/anubis/issues/1150) are both open. There is no version to upgrade to.

So expect this PR to *reduce* double-spends, not eliminate them.

## Testing

- [x] Snippet definitions and imports verified to route as intended (above)
- [ ] DockerSmoke — this is the real check. I could not validate locally: no `caddy` binary on this machine and the Docker daemon is down, so `caddy validate` was unavailable.
- [ ] Post-merge: watch Anubis logs for `double spend prevented` frequency against the ~8-per-30h baseline

Not applicable: no client/server code changed.

## Merge timing

Worth holding until the #308 verification is done — redeploy Anubis, confirm an existing session survives without being re-challenged. Merging this first means two variables moving at once and no clean read on which one mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMSJNgK2Gz9FA2TRDSn5mm
