### PR TITLE
fix(client): bind serve.ts dual-stack — prod outage from PR #321

### DIFF
--- a/client/serve.ts
+++ b/client/serve.ts
@@ -44,48 +44,60 @@ function resolveStaticFile(urlPath: string): string | null {
   }
 }
 
-const server = Bun.serve({
-  port: PORT,
-  hostname: "0.0.0.0",
-  async fetch(req) {
-    // Only GET serves content; everything else (HEAD is fine via the file
-    // path too) — keep it simple, mirror `serve`'s behaviour for the routes
-    // that actually reach this container (Caddy proxies GETs).
-    if (req.method !== "GET") {
-      return new Response("Method Not Allowed", {
-        status: 405,
-        headers: { "cache-control": "no-store" },
-      });
-    }
+// Caddy reaches this service over Railway's private network the same way it
+// reaches the backend (FRONTEND_DOMAIN = ${{Frontend.RAILWAY_PRIVATE_DOMAIN}}
+// in caddy/README.md), and that network is IPv6-only. Binding only 0.0.0.0
+// makes the container unreachable from Caddy — the same class of bug as the
+// server's HOST incident (#298), just hardcoded here instead of configurable.
+// Prefer the IPv6 wildcard so a single listener serves both families, falling
+// back to 0.0.0.0 for environments without IPv6 (local Docker bridge networks).
+function listen(fetch: (req: Request) => Response | Promise<Response>) {
+  try {
+    return Bun.serve({ port: PORT, hostname: "::", fetch });
+  } catch (err) {
+    console.warn("IPv6 wildcard bind failed, falling back to 0.0.0.0:", err);
+    return Bun.serve({ port: PORT, hostname: "0.0.0.0", fetch });
+  }
+}
 
-    const url = new URL(req.url);
-    const filePath = resolveStaticFile(url.pathname);
+const server = listen(async (req) => {
+  // Only GET serves content; everything else (HEAD is fine via the file
+  // path too) — keep it simple, mirror `serve`'s behaviour for the routes
+  // that actually reach this container (Caddy proxies GETs).
+  if (req.method !== "GET") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { "cache-control": "no-store" },
+    });
+  }
 
-    // A real static asset: serve it. Bun.file infers the MIME from the
-    // extension (.js → application/javascript, .css → text/css, .svg →
-    // image/svg+xml, .webmanifest → application/manifest+json, etc.), so the
-    // service worker, manifest, icons, and hashed bundles all get the right
-    // content-type. Hashed assets under /assets/* are immutable; everything
-    // else is served fresh (matches what `serve` did).
-    if (filePath) {
-      const isImmutable = url.pathname.startsWith("/assets/");
-      return new Response(Bun.file(filePath), {
-        headers: {
-          "cache-control": isImmutable ? "public, max-age=31536000, immutable" : "no-cache",
-        },
-      });
-    }
+  const url = new URL(req.url);
+  const filePath = resolveStaticFile(url.pathname);
 
-    // SPA fallback: react-router-dom owns client-side routing from here.
-    // index.html is served with no-cache so deploys are picked up without a
-    // hard refresh (the HTML references fresh hashed asset names anyway).
-    return new Response(Bun.file(INDEX_HTML), {
+  // A real static asset: serve it. Bun.file infers the MIME from the
+  // extension (.js → application/javascript, .css → text/css, .svg →
+  // image/svg+xml, .webmanifest → application/manifest+json, etc.), so the
+  // service worker, manifest, icons, and hashed bundles all get the right
+  // content-type. Hashed assets under /assets/* are immutable; everything
+  // else is served fresh (matches what `serve` did).
+  if (filePath) {
+    const isImmutable = url.pathname.startsWith("/assets/");
+    return new Response(Bun.file(filePath), {
       headers: {
-        "content-type": "text/html; charset=utf-8",
-        "cache-control": "no-cache",
+        "cache-control": isImmutable ? "public, max-age=31536000, immutable" : "no-cache",
       },
     });
-  },
+  }
+
+  // SPA fallback: react-router-dom owns client-side routing from here.
+  // index.html is served with no-cache so deploys are picked up without a
+  // hard refresh (the HTML references fresh hashed asset names anyway).
+  return new Response(Bun.file(INDEX_HTML), {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-cache",
+    },
+  });
 });
 
 console.log(`client (bun static) listening on http://localhost:${server.port}`);


### PR DESCRIPTION
## Summary

PR #321 replaced the client's `serve` npm package with a hand-rolled `Bun.serve` static handler (`client/serve.ts`) hardcoded to `hostname: "0.0.0.0"`. Caddy reaches the client over Railway's **private network**, the same way it reaches the backend (`FRONTEND_DOMAIN = ${{Frontend.RAILWAY_PRIVATE_DOMAIN}}`, see `caddy/README.md`), and that network is **IPv6-only**. An IPv4-only bind makes the container unreachable from Caddy — full prod outage, including the login/OAuth-callback page never loading. This is the exact same bug class already documented in `CLAUDE.md` as the server `HOST` incident (#298), just reintroduced in the client's new static server instead of the backend.

This PR fixes the outage by making `serve.ts` bind dual-stack, mirroring the server's existing `listenPreferringDualStack` pattern: try the IPv6 wildcard (`::`) first so a single listener serves both families, falling back to `0.0.0.0` only if the IPv6 bind itself fails (e.g. networks with no IPv6 at all, like CI or local Docker bridges).

**Note on rollback:** the team could not roll back the previous deploy because PR #321 also shipped `migration 010` (index on `message.recipient`), which has already run against the prod DB — the previous code's migration list doesn't include `010`, so Kysely's migrator refuses to boot against a DB with an unrecognized already-applied migration. Rolling forward with this fix avoids that blocker entirely rather than fighting the migration system.

## Related issue

N/A — production incident, no tracking issue yet.

## Scope

- [x] client
- [ ] server
- [ ] opengraph-service
- [ ] docker / infra (caddy, anubis)
- [ ] docs

## Changes

- `client/serve.ts`: `Bun.serve` now tries `hostname: "::"` first, falling back to `"0.0.0.0"` only if the IPv6 bind fails — same dual-stack negotiation the server already does in `src/index.ts`.

## Testing

- [x] Manually ran `bun serve.ts` in this sandbox (no IPv6 available, matching the documented CI/local-bridge limitation): confirmed it logs the documented spurious `EADDRINUSE (errno: 0)` on the `::` attempt, falls back to `0.0.0.0`, and serves `200 OK` correctly.
- [x] `bun build client/serve.ts --target bun` — bundles cleanly, no syntax errors.
- [ ] Unit/integration tests pass locally (no server-side changes; client has no test coverage on `serve.ts` per its exclusion from `tsc`'s `include`)
- [ ] E2E (Playwright) passes for affected flows
- [ ] Docker smoke test passes if server/infra changed — recommend running before merging given this is a prod-outage fix
- [ ] Manually verified against a real Bluesky/AT Protocol account

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens — no auth logic touched, this is purely a network-bind fix
- [ ] Docs updated if user-facing behavior or setup changed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRc14zodWpRQsgXucMfVGV)_