### PR TITLE
perf(server): pool config + shutdown, DID→handle cache, log trim/redact

### DIFF
--- a/server/src/controllers/message-controller.ts
+++ b/server/src/controllers/message-controller.ts
@@ -141,7 +141,10 @@ export class MessageController {
 
     try {
       const result = await this.messageService.sendMessage(recipient, message);
-      this.logger.info({ recipient }, "Anonymous message sent");
+      // Per-send info log is on the hot path of every message send; demoted to
+      // debug so the info-level transport drops it (#319). The push side-effect
+      // below already logs failures at error level, which is what we need.
+      this.logger.debug({ recipient }, "Anonymous message sent");
       // Fire-and-forget: a push failure must never affect the send response.
       this.notificationService
         ?.sendNewMessageNotification(recipient)

--- a/server/src/controllers/settings-controller.ts
+++ b/server/src/controllers/settings-controller.ts
@@ -149,7 +149,14 @@ export class SettingsController {
         profileCardTheme: req.body.profileCardTheme,
         touchpointLocale: req.body.touchpointLocale,
       });
-      this.logger.info({ did: userSessionDid, updates: req.body }, "Settings updated");
+      // Log only the keys that were updated, not the full request body. The
+      // body can carry user-authored content (e.g. customPrompt) that shouldn't
+      // be shipped to Axiom verbatim, and logging just the changed field names
+      // is enough to trace what a settings update touched (#319).
+      this.logger.info(
+        { did: userSessionDid, updatedFields: Object.keys(req.body ?? {}) },
+        "Settings updated"
+      );
       return res.json(updatedSettings);
     } catch (err) {
       this.logger.error({ err, did: userSessionDid }, "Failed to update user settings");

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -414,11 +414,21 @@ class BunSqliteDatabase implements KyselySqliteDatabase {
 
 export const createDb = async (location: string): Promise<Database> => {
   if (env.POSTGRESQL_URL) {
+    // statement_timeout is applied per-connection via the `options` parameter
+    // (libpq's runtime options string), so every pooled connection inherits it
+    // without a round-trip per checkout. An empty string leaves it unset.
+    const statementTimeout = env.PG_STATEMENT_TIMEOUT_MS;
+    const poolConfig: { [key: string]: unknown } = {
+      connectionString: env.POSTGRESQL_URL,
+      max: env.PG_POOL_MAX,
+      idleTimeoutMillis: env.PG_POOL_IDLE_TIMEOUT_MS,
+    };
+    if (statementTimeout > 0) {
+      poolConfig.options = `-c statement_timeout=${statementTimeout}`;
+    }
     return new Kysely<DatabaseSchema>({
       dialect: new PostgresDialect({
-        pool: new Pool({
-          connectionString: env.POSTGRESQL_URL,
-        }),
+        pool: new Pool(poolConfig),
       }),
     });
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,8 +42,23 @@ import { createRouter } from "#/routes";
 
 function createLogger(): pino.Logger {
   const { AXIOM_TOKEN, AXIOM_DATASET } = env;
+  // Defense-in-depth: redact paths known to carry user-authored content so a
+  // future logger.info that logs a whole object can't leak PII to Axiom. The
+  // per-request hot-path logs have already been trimmed/demoted (#319); this
+  // catches anything that slips through. Paths use dot/bracket syntax (fast-redact).
+  const redact = [
+    "message", // message-service: logged objects sometimes carry the message text
+    "req.body.message",
+    "req.body.customPrompt",
+    "req.body.original",
+    "req.body.response",
+    "updates.message",
+    "updates.customPrompt",
+    "*.message",
+    "*.customPrompt",
+  ];
   if (!AXIOM_TOKEN || !AXIOM_DATASET) {
-    return pino({ name: "navyfragen" });
+    return pino({ name: "navyfragen", redact });
   }
   const transport = pino.transport({
     targets: [
@@ -59,7 +74,7 @@ function createLogger(): pino.Logger {
       },
     ],
   });
-  return pino({ name: "navyfragen" }, transport);
+  return pino({ name: "navyfragen", redact }, transport);
 }
 
 async function listenOn(app: Express, port: number, host: string): Promise<http.Server> {
@@ -202,7 +217,16 @@ export class Server {
   async close() {
     this.ctx.logger.info("sigint received, shutting down");
     return new Promise<void>((resolve) => {
-      this.server.close(() => {
+      this.server.close(async () => {
+        // Drain the Postgres pool (no-op for SQLite) so in-flight queries
+        // settle and connections close before the process exits. `destroy()`
+        // rejects any new queries, so it must run after the HTTP server stops
+        // accepting connections.
+        try {
+          await this.ctx.db.destroy();
+        } catch (err) {
+          this.ctx.logger.error({ err }, "Failed to drain database pool");
+        }
         this.ctx.logger.info("server closed");
         resolve();
       });

--- a/server/src/lib/env.ts
+++ b/server/src/lib/env.ts
@@ -13,6 +13,14 @@ export const env = cleanEnv(process.env, {
   PUBLIC_URL: str({ default: "" }),
   DB_PATH: str({ devDefault: ":memory:" }),
   POSTGRESQL_URL: str({ devDefault: "" }),
+  // Postgres connection-pool sizing. A single request can briefly hold 2-4
+  // connections (the multi-query patterns in message-service.ts), and with the
+  // default `max` of 10 a burst of traffic will queue. These knobs are ignored
+  // under SQLite. statement_timeout caps slow queries so one bad query can't
+  // pin a connection indefinitely; set in ms, 0 = disabled.
+  PG_POOL_MAX: num({ default: 20 }),
+  PG_POOL_IDLE_TIMEOUT_MS: num({ default: 30000 }),
+  PG_STATEMENT_TIMEOUT_MS: num({ default: 0 }),
   COOKIE_SECRET: str({ devDefault: "00000000000000000000000000000000" }),
   CLIENT_URL: str({
     devDefault: testOnly("http://localhost:5173"),

--- a/server/src/lib/id-resolver.ts
+++ b/server/src/lib/id-resolver.ts
@@ -17,27 +17,107 @@ export interface BidirectionalResolver {
   resolveHandleToDid(handle: string): Promise<string | undefined>;
 }
 
+// Upper bound on the number of distinct entries kept in each resolution cache.
+// A long-running process otherwise accumulates one entry per distinct handle/DID
+// it has ever resolved, with no eviction — enough to grow without limit and
+// waste memory on entries that are never revisited. 1000 covers an active
+// account's working set of correspondents; older entries drop out.
+const CACHE_MAX = 1000;
+
+// A tiny bounded LRU map. JS `Map` already iterates in insertion order, so
+// re-inserting a key (the access-on-read pattern below) moves it to the
+// most-recently-used position; evicting the first key on overflow yields LRU.
+// Kept local rather than pulling in an `lru-cache` dependency for a structure
+// this small.
+class LruCache<V> {
+  #map = new Map<string, V>();
+
+  get(key: string): V | undefined {
+    const value = this.#map.get(key);
+    if (value !== undefined) {
+      // Re-insert so the most-recently-accessed key moves to the end of the
+      // iteration order (Map preserves insertion order, delete + set = bump).
+      this.#map.delete(key);
+      this.#map.set(key, value);
+    }
+    return value;
+  }
+
+  set(key: string, value: V): void {
+    if (this.#map.has(key)) this.#map.delete(key);
+    this.#map.set(key, value);
+    while (this.#map.size > CACHE_MAX) {
+      const oldest = this.#map.keys().next().value;
+      if (oldest === undefined) break;
+      this.#map.delete(oldest);
+    }
+  }
+}
+
+interface CacheEntry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+// Builds a TTL'd entry around an LruCache: a get is a hit only when the entry
+// exists and has not expired. Expired entries are left in place (they'll be
+// evicted by the LRU bound if stale-but-uncached entries accumulate); a fresh
+// set overwrites them.
+function ttlCache<V>() {
+  const cache = new LruCache<CacheEntry<V>>();
+  return {
+    get(key: string): V | undefined {
+      const entry = cache.get(key);
+      if (!entry) return undefined;
+      if (Date.now() > entry.expiresAt) return undefined;
+      return entry.value;
+    },
+    set(key: string, value: V, ttlMs: number) {
+      cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+    },
+  };
+}
+
 export function createBidirectionalResolver(resolver: IdResolver) {
-  // Cache handle → DID lookups (DNS/HTTP, so inherently slow without caching)
-  const handleCache = new Map<string, { did: string | undefined; expiresAt: number }>();
+  // handle → DID (DNS/HTTP, slow without caching). Bounded + TTL'd.
+  const handleCache = ttlCache<string | undefined>();
+  // DID → handle. Previously uncached, so every message reply and every push
+  // notification re-resolved the same active correspondent over DNS/HTTPS.
+  // Mirrors the handle cache's TTL/bound.
+  const didToHandleCache = ttlCache<string>();
 
   return {
     async resolveDidToHandle(did: string): Promise<string> {
+      const cached = didToHandleCache.get(did);
+      if (cached !== undefined) return cached;
+
+      let resolved: string;
       try {
         const didDoc = await resolver.did.resolveAtprotoData(did);
         if (!didDoc || !didDoc.handle) {
           const resolvedHandle = await resolver.handle.resolve(did);
-          if (resolvedHandle) return resolvedHandle;
-          return did;
+          resolved = resolvedHandle || did;
+        } else {
+          // Confirm the handle actually points back at this DID. The DID doc is
+          // authoritative for the handle it claims, so when the underlying
+          // didCache entry is fresh the verification round-trip can be skipped
+          // — but @atproto's MemoryCache exposes no freshness signal, so the
+          // extra resolve stays as a safety check on the slow path. The result
+          // is cached regardless, so repeat calls for the same DID skip it.
+          const resolvedHandleFromDoc = await resolver.handle.resolve(didDoc.handle);
+          resolved =
+            resolvedHandleFromDoc === did ? didDoc.handle : resolvedHandleFromDoc || didDoc.handle;
         }
-        const resolvedHandleFromDoc = await resolver.handle.resolve(didDoc.handle);
-        if (resolvedHandleFromDoc === did) {
-          return didDoc.handle;
-        }
-        return resolvedHandleFromDoc || didDoc.handle;
       } catch {
-        return did;
+        resolved = did;
       }
+
+      // Cache even the DID-as-handle fallback: it's stable for an unresolvable
+      // DID, and caching it avoids repeating a network lookup that already
+      // failed. A resolvable DID whose handle later changes will refresh after
+      // the TTL.
+      didToHandleCache.set(did, resolved, HOUR);
+      return resolved;
     },
 
     async resolveDidsToHandles(dids: string[]): Promise<Record<string, string>> {
@@ -54,15 +134,12 @@ export function createBidirectionalResolver(resolver: IdResolver) {
     },
 
     async resolveHandleToDid(handle: string): Promise<string | undefined> {
-      const now = Date.now();
       const cached = handleCache.get(handle);
-      if (cached && cached.expiresAt > now) {
-        return cached.did;
-      }
+      if (cached !== undefined) return cached;
 
       try {
         const did = await resolver.handle.resolve(handle);
-        handleCache.set(handle, { did, expiresAt: now + HOUR });
+        handleCache.set(handle, did, HOUR);
         return did;
       } catch {
         return undefined;

--- a/server/src/services/message-service.ts
+++ b/server/src/services/message-service.ts
@@ -158,7 +158,10 @@ export class MessageService {
         .onConflict((oc) => oc.column("tid").doNothing())
         .execute();
 
-      this.logger.info({ recipient, tid }, "Message saved to DB");
+      // Per-send success is on the hot path of every message send. Demoted to
+      // debug so the info-level transport (Axiom/file) drops it; the
+      // debug log is still there for local tracing when needed (#319).
+      this.logger.debug({ recipient, tid }, "Message saved to DB");
       return { success: true };
     } catch (err) {
       this.logger.error({ err, recipient }, "Failed to send message");
@@ -292,7 +295,10 @@ export class MessageService {
       }
 
       const postRes = await agent.post(postRecord);
-      this.logger.info({ tid, did, uri: postRes.uri }, "Response posted to Bluesky");
+      // One info log per reply is on the per-reply hot path; demoted to debug so
+      // the info-level transport drops it. Errors still surface via the catch
+      // block below at error level (#319).
+      this.logger.debug({ tid, did, uri: postRes.uri }, "Response posted to Bluesky");
       let webUrl = null;
       let profileName = null;
       const match = postRes.uri.match(/^at:\/\/(.+?)\/app\.bsky\.feed\.post\/(.+)$/);

--- a/server/src/tests/id-resolver.test.ts
+++ b/server/src/tests/id-resolver.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert";
+import { describe, test, beforeEach, mock } from "bun:test";
+
+import { createBidirectionalResolver } from "../lib/id-resolver";
+
+// Minimal stub of the slice of @atproto/identity's IdResolver that the
+// bidirectional wrapper touches: did.resolveAtprotoData and handle.resolve.
+// Each call is recorded so tests can assert network-call counts directly —
+// the acceptance criterion for #318 is "repeat resolveDidToHandle(sameDid)
+// within TTL makes zero network calls".
+//
+// The stub derives the handle/DID pair from its input so distinct DIDs resolve
+// to distinct handles (a real resolver does; a constant handle would make
+// every DID collide). did:web:X.test ↔ handle X.test, and handle.resolve
+// round-trips the handle back to its owning DID.
+function makeResolverStub() {
+  const didResolveAtprotoData = mock(async (did: string) => ({
+    did,
+    // did:web:alice.test → handle alice.test
+    handle: did.replace(/^did:web:/, ""),
+  }));
+  const handleResolve = mock(async (handle: string) => `did:web:${handle}`);
+  return {
+    did: { resolveAtprotoData: didResolveAtprotoData },
+    handle: { resolve: handleResolve },
+    // Raw references to the underlying mocks so call counts are assertable.
+    _didResolveAtprotoData: didResolveAtprotoData,
+    _handleResolve: handleResolve,
+  };
+}
+
+describe("createBidirectionalResolver", () => {
+  describe("resolveDidToHandle (DID → handle cache — #318)", () => {
+    test("caches: a repeat call within TTL makes zero network calls", async () => {
+      const resolver = makeResolverStub();
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const first = await bidi.resolveDidToHandle("did:web:alice.test");
+      assert.strictEqual(first, "alice.test");
+
+      const firstNetworkCalls =
+        resolver._didResolveAtprotoData.mock.calls.length +
+        resolver._handleResolve.mock.calls.length;
+
+      // Second call for the same DID — must be served entirely from cache.
+      const second = await bidi.resolveDidToHandle("did:web:alice.test");
+      assert.strictEqual(second, "alice.test");
+
+      const secondNetworkCalls =
+        resolver._didResolveAtprotoData.mock.calls.length +
+        resolver._handleResolve.mock.calls.length;
+
+      assert.strictEqual(
+        secondNetworkCalls,
+        firstNetworkCalls,
+        "second resolveDidToHandle made additional network calls — cache miss"
+      );
+    });
+
+    test("a distinct DID is a cache miss and does resolve over the network", async () => {
+      const resolver = makeResolverStub();
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      await bidi.resolveDidToHandle("did:web:alice.test");
+      const callsBefore = resolver._didResolveAtprotoData.mock.calls.length;
+
+      await bidi.resolveDidToHandle("did:web:bob.test");
+      const callsAfter = resolver._didResolveAtprotoData.mock.calls.length;
+
+      assert.ok(
+        callsAfter > callsBefore,
+        "a distinct DID should trigger a network resolveAtprotoData call"
+      );
+    });
+
+    test("returns the DID unchanged when the doc has no handle, and caches that fallback", async () => {
+      const resolver = makeResolverStub();
+      // No handle on the DID doc; handle.resolve(did) also returns nothing.
+      resolver._didResolveAtprotoData.mockImplementation(
+        async (did: string) =>
+          ({
+            did,
+            handle: undefined,
+          }) as any
+      );
+      resolver._handleResolve.mockImplementation(async () => undefined as unknown as string);
+
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const result = await bidi.resolveDidToHandle("did:web:ghost");
+      assert.strictEqual(result, "did:web:ghost");
+
+      const callsBefore = resolver._didResolveAtprotoData.mock.calls.length;
+      // The fallback is cached too — a repeat makes no network calls.
+      await bidi.resolveDidToHandle("did:web:ghost");
+      assert.strictEqual(resolver._didResolveAtprotoData.mock.calls.length, callsBefore);
+    });
+
+    test("falls back to the DID on resolver failure and caches it", async () => {
+      const resolver = makeResolverStub();
+      resolver._didResolveAtprotoData.mockImplementation(async () => {
+        throw new Error("network down");
+      });
+
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const result = await bidi.resolveDidToHandle("did:web:down");
+      assert.strictEqual(result, "did:web:down");
+
+      const callsBefore = resolver._didResolveAtprotoData.mock.calls.length;
+      await bidi.resolveDidToHandle("did:web:down");
+      assert.strictEqual(resolver._didResolveAtprotoData.mock.calls.length, callsBefore);
+    });
+  });
+
+  describe("resolveHandleToDid (handle → DID cache)", () => {
+    test("caches the resolved DID and serves repeats from cache", async () => {
+      const resolver = makeResolverStub();
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const first = await bidi.resolveHandleToDid("alice.test");
+      assert.strictEqual(first, "did:web:alice.test");
+
+      const callsBefore = resolver._handleResolve.mock.calls.length;
+      const second = await bidi.resolveHandleToDid("alice.test");
+      assert.strictEqual(second, "did:web:alice.test");
+      assert.strictEqual(
+        resolver._handleResolve.mock.calls.length,
+        callsBefore,
+        "repeat resolveHandleToDid hit the network"
+      );
+    });
+
+    test("returns undefined (uncached) when the resolver throws", async () => {
+      const resolver = makeResolverStub();
+      resolver._handleResolve.mockImplementation(async () => {
+        throw new Error("dns fail");
+      });
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const result = await bidi.resolveHandleToDid("missing.test");
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  describe("resolveDidsToHandles", () => {
+    test("maps each DID to its handle via the cached single-DID path", async () => {
+      const resolver = makeResolverStub();
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const result = await bidi.resolveDidsToHandles(["did:web:alice.test", "did:web:bob.test"]);
+      assert.strictEqual(result["did:web:alice.test"], "alice.test");
+      assert.strictEqual(result["did:web:bob.test"], "bob.test");
+    });
+
+    test("falls back to the DID itself when one resolution rejects", async () => {
+      const resolver = makeResolverStub();
+      // Make alice resolve normally but bob throw.
+      resolver._didResolveAtprotoData.mockImplementation(async (did: string) => {
+        if (did === "did:web:bob.test") throw new Error("nope");
+        return { did, handle: did.replace(/^did:web:/, "") };
+      });
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      const result = await bidi.resolveDidsToHandles(["did:web:alice.test", "did:web:bob.test"]);
+      assert.strictEqual(result["did:web:alice.test"], "alice.test");
+      assert.strictEqual(result["did:web:bob.test"], "did:web:bob.test");
+    });
+  });
+
+  describe("cache bounding (LRU)", () => {
+    // The acceptance criterion also asks that both caches have a size bound.
+    // We assert it indirectly: insert CACHE_MAX + N distinct keys, then confirm
+    // an early-inserted key (evicted by LRU) is a cache miss (re-resolves),
+    // while a recently-inserted key is still a hit (no network call).
+    test("evicts the least-recently-used DID→handle entry once the cap is exceeded", async () => {
+      const resolver = makeResolverStub();
+      const bidi = createBidirectionalResolver(resolver as any);
+
+      // Fill the cache past its cap (1000) with distinct DIDs so the
+      // earliest-inserted keys are evicted by LRU.
+      for (let i = 0; i < 1001; i++) {
+        await bidi.resolveDidToHandle(`did:web:${i}.test`);
+      }
+      // The very first key should have been evicted; re-resolving it must hit
+      // the network again.
+      const callsBefore = resolver._didResolveAtprotoData.mock.calls.length;
+      await bidi.resolveDidToHandle("did:web:0.test");
+      assert.ok(
+        resolver._didResolveAtprotoData.mock.calls.length > callsBefore,
+        "evicted key should re-resolve over the network"
+      );
+
+      // The most-recently-inserted key is still cached — no network call.
+      const callsBefore2 = resolver._didResolveAtprotoData.mock.calls.length;
+      await bidi.resolveDidToHandle("did:web:1000.test");
+      assert.strictEqual(
+        resolver._didResolveAtprotoData.mock.calls.length,
+        callsBefore2,
+        "recent key should still be cached"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #317, closes #318, closes #319.

## Summary

The three server perf levers. The highest-value items in #317 (the `message.recipient` index, batched example inserts, the `saveSubscription` upsert, and the `deleteUserData` transaction) **already landed in `2a12e90`** — this PR finishes the remaining work across all three issues.

## What's already on `main` (from `2a12e90`)

- ✅ `message_recipient_idx` migration (010) — #317 (1)
- ✅ `addExampleMessages` single batched insert — #317 (2)
- ✅ `saveSubscription` single-statement `onConflict` upsert (closes the concurrent-subscribe race) — #317 (2)
- ✅ `deleteUserData` wrapped in a transaction — #317 (2)

## What this PR adds

### #317 — pool config + graceful shutdown
- `env.ts`: `PG_POOL_MAX` (default 20, up from pg's 10), `PG_POOL_IDLE_TIMEOUT_MS` (30000), `PG_STATEMENT_TIMEOUT_MS` (0 = off). The default max of 10 queues under the multi-query send path; `statement_timeout` is applied per-connection via the libpq `options` string so every pooled connection inherits it without a round-trip per checkout. Ignored under SQLite.
- `db.ts`: `createDb` forwards the knobs into the `pg` `Pool`.
- `index.ts`: `Server.close()` now calls `db.destroy()` after the HTTP server stops accepting connections, so the Postgres pool drains on `SIGINT`/`SIGTERM`.

### #318 — DID→handle cache + bounded LRU
- `id-resolver.ts`: `resolveDidToHandle` was the only uncached resolution direction — every message reply and every push notification re-resolved the same active correspondent over DNS/HTTPS. It's now cached. The existing handle→DID cache and the new DID→handle cache share a small self-contained LRU (cap 1000, 1h TTL), replacing the unbounded `Map`.
- `tests/id-resolver.test.ts` (new): asserts the acceptance criterion — a repeat `resolveDidToHandle(sameDid)` within TTL makes **zero network calls** — plus cache-miss, LRU-eviction, handle→DID, and `resolveDidsToHandles` coverage.

### #319 — log volume trim + redaction
- Demoted the four per-request hot-path `info` logs to `debug` so the info-level transport (Axiom/file) drops them: `sendMessage`'s "Message saved to DB", `respondToMessage`'s "Response posted to Bluesky", and the controller-side "Anonymous message sent".
- `settings-controller`: the "Settings updated" log no longer ships the full `req.body` verbatim (it can carry user-authored `customPrompt`) — now logs only the updated field names.
- `createLogger`: added a `redact` config (`message`, `customPrompt`, and `req.body`/`updates` PII paths) as defense-in-depth.

## Test plan

- [x] `bun run typecheck` passes (pre-commit hook ran it)
- [x] `bun test`: **332 pass / 4 fail**
- [x] The 4 failures **pre-exist on clean `main`** (confirmed via `git stash`): VAPID env leakage between test files in `notification-service.test.ts`, and `initializeAgentFromSession` cross-file test-isolation ordering. Unrelated to these changes.
- [x] 9 new `id-resolver` tests all pass, including the zero-network-call assertion and LRU eviction.