### PR TITLE
docs: fix stale npm/node references after Bun migration

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -31,8 +31,8 @@ E2E_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
 First time only:
 
 ```bash
-npm install
-npx playwright install --with-deps chromium
+bun install
+bunx playwright install --with-deps chromium
 ```
 
 ### 4. Start the e2e stack
@@ -49,13 +49,13 @@ Wait ~30 s for services to stabilise.
 ### 5. Run the tests
 
 ```bash
-npm run test:e2e
+bun run test:e2e
 ```
 
 Interactive UI (useful for debugging):
 
 ```bash
-npm run test:e2e:ui
+bun run test:e2e:ui
 ```
 
 ### 6. Tear down
@@ -113,8 +113,8 @@ mobile project runs the same auth setup, so specs there reuse the saved session 
 Run a single project locally:
 
 ```bash
-npx playwright test --project=chromium
-npx playwright test --project=mobile-chromium
+bunx playwright test --project=chromium
+bunx playwright test --project=mobile-chromium
 ```
 
 ### Side-effect hygiene

--- a/html-to-image/probe-bun-puppeteer.mjs
+++ b/html-to-image/probe-bun-puppeteer.mjs
@@ -1,7 +1,7 @@
-// Bun-runtime canary for issue #314 — gates the html-to-image-tests CI job.
-// This service still runs on Node in production; this probe is the evidence
-// that decides whether the migration to Bun can proceed. It exercises the two
-// surfaces in the render path that are genuinely under-verified under Bun:
+// Bun-runtime regression canary for issue #314 — gates the html-to-image-tests
+// CI job. The service runs on Bun in production; this probe protects against
+// regressions of the two surfaces in the render path that were the load-bearing
+// risk of the Node→Bun migration:
 //   1. the child_process.spawn of Chromium (Puppeteer launches the browser via
 //      child_process), and
 //   2. the CDP WebSocket transport between puppeteer and Chromium.

--- a/server/README.md
+++ b/server/README.md
@@ -25,7 +25,7 @@ Session management is kept intentionally thin on the server side for speed and s
 
 ## AT Protocol / Lexicons
 
-A custom lexicon `app.navyfragen.message` defines the record type for messages stored on the user's PDS. Generated TypeScript types live in `src/lexicon/` — do **not** edit these manually; regenerate with `npm run lexgen`. Avoid running `lexgen` on Windows as it can delete generated files; use WSL2.
+A custom lexicon `app.navyfragen.message` defines the record type for messages stored on the user's PDS. Generated TypeScript types live in `src/lexicon/` — do **not** edit these manually; regenerate with `bun run lexgen`. Avoid running `lexgen` on Windows as it can delete generated files; use WSL2.
 
 The `#/` path alias maps to `src/` (configured in `tsconfig.json`).
 


### PR DESCRIPTION
Follow-up to the Bun migrations (#268 server, #314 html-to-image). A handful of doc/comment commands still pointed at `npm`/`npx` even though those services now run under Bun.

## Changes

- **`server/README.md`** — `npm run lexgen` → `bun run lexgen`
- **`docs/e2e-testing.md`** — five commands: `npm install` → `bun install`, `npx playwright install` → `bunx`, `npm run test:e2e(:ui)` → `bun run`, `npx playwright test` → `bunx` (two project runs)
- **`html-to-image/probe-bun-puppeteer.mjs`** — stale comment said *"this service still runs on Node"* (leftover from the probe-gates-the-decision phase); rewritten as a regression canary now that the service runs on Bun in production

`npm` would still work (it reads workspaces too), but these were inconsistent with the rest of the repo's Bun story. **No code or runtime changes** — docs and one comment only.

## Note on remaining Node references

These are legitimate and left as-is:
- `setup-node@v4` in the `client-tests` and `E2E` CI jobs — Playwright and Vite/Vitest run on Node (the FE toolchain)
- `import ... from 'node:test'` in `html-to-image/app.test.js` — Bun runs Node's `node:test` API natively, which is why the suite works unchanged under `bun test`
- Historical comments documenting what changed ("formerly Node", "former Node driver removed in #288") — accurate context, not live commands
- `nodejsscan` — a SAST scanner name, unrelated to the Node runtime