### PR TITLE
fix(client): replace auto-reloading SW update with an Update button

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -25,6 +25,7 @@ import { useHasBounceGap } from "../lib/useHasBounceGap";
 import { surfaceBg } from "../styles/tokens";
 
 import { useBounceLogos } from "./BounceLogosContext";
+import { UpdateAvailableButton } from "./UpdateAvailableButton";
 import { WinkMark } from "./WinkMark";
 import { Wordmark } from "./Wordmark";
 
@@ -75,6 +76,8 @@ export function AppHeader({ opened, onBurgerToggle, burgerRef, onNavClose }: App
       >
         <Wordmark size={18} />
       </Box>
+
+      <UpdateAvailableButton />
 
       <Flex gap="sm" justify="flex-end" align="center" style={{ flexGrow: 1 }}>
         {hasBounceGap && (

--- a/client/src/components/UpdateAvailableButton.tsx
+++ b/client/src/components/UpdateAvailableButton.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@mantine/core";
+import { IconRefresh } from "@tabler/icons-react";
+import { useSyncExternalStore } from "react";
+import { useHaptic } from "use-haptic";
+
+import { applyUpdate, isUpdateReady, subscribeToUpdate } from "../lib/swUpdate";
+
+export function UpdateAvailableButton() {
+  const updateReady = useSyncExternalStore(subscribeToUpdate, isUpdateReady, isUpdateReady);
+  const { triggerHaptic } = useHaptic(1);
+
+  if (!updateReady) return null;
+
+  return (
+    <Button
+      onClick={() => {
+        triggerHaptic();
+        applyUpdate();
+      }}
+      size="xs"
+      radius="xl"
+      variant="light"
+      color="royal"
+      leftSection={<IconRefresh size={14} />}
+      aria-label="Update available — reload to apply"
+    >
+      Update
+    </Button>
+  );
+}

--- a/client/src/lib/swUpdate.ts
+++ b/client/src/lib/swUpdate.ts
@@ -1,0 +1,31 @@
+type UpdateApplier = () => void;
+type Listener = () => void;
+
+let updateReady = false;
+let applier: UpdateApplier | null = null;
+const listeners = new Set<Listener>();
+
+export function subscribeToUpdate(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function isUpdateReady(): boolean {
+  return updateReady;
+}
+
+export function markUpdateReady(): void {
+  if (updateReady) return;
+  updateReady = true;
+  for (const listener of listeners) listener();
+}
+
+export function setUpdateApplier(fn: UpdateApplier | null): void {
+  applier = fn;
+}
+
+export function applyUpdate(): void {
+  applier?.();
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -11,6 +11,7 @@ import { queryClient } from "./api/queryClient";
 import { AppLayout } from "./AppLayout";
 import { BounceLogosProvider } from "./components/BounceLogosContext";
 import { InstallPromptProvider } from "./components/InstallPromptContext";
+import { markUpdateReady, setUpdateApplier } from "./lib/swUpdate";
 import navyfragenTheme from "./Theme";
 
 import "@mantine/core/styles.css";
@@ -42,4 +43,17 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 // closing the race where a leftover production SW could intercept TanStack
 // Query's first fetches on a fresh reload. In production it registers the
 // generated /sw.js (push notifications, offline app shell).
-registerSW({ immediate: true });
+//
+// Registration runs in "prompt" mode, so a new deploy never reloads the page on
+// its own: it reports the waiting worker here, and the header's "Update" button
+// is what applies it.
+const updateSW = registerSW({
+  immediate: true,
+  onNeedRefresh() {
+    markUpdateReady();
+  },
+});
+
+setUpdateApplier(() => {
+  void updateSW();
+});

--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -12,15 +12,24 @@ declare const self: ServiceWorkerGlobalScope;
 // by vite-plugin-pwa's `injectManifest` strategy).
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Activate a newly installed worker without waiting for every tab to close,
-// but deliberately skip clientsClaim(): claiming already-open tabs fires a
-// `controllerchange` event that vite-plugin-pwa's autoUpdate registration
-// (main.tsx) responds to with an immediate, unprompted `location.reload()` —
-// so any tab open when a new deploy ships gets silently reloaded seconds into
-// the session. Without clientsClaim(), the new worker only takes control of
-// tabs opened/reloaded after activation, so the update applies on the next
-// natural navigation instead of interrupting an in-progress session.
-self.skipWaiting();
+// Stay in the `waiting` state until the user explicitly asks for the update.
+//
+// Calling skipWaiting() at parse time activated every new deploy the instant it
+// finished installing, and vite-plugin-pwa's registration answers an update
+// activation with `window.location.reload()` — so a tab that happened to be
+// open when a deploy shipped was reloaded mid-session, discarding whatever the
+// user was typing. Dropping clientsClaim() alone did not stop that, because
+// skipWaiting() on its own already transfers control of existing clients.
+//
+// `registerType: "prompt"` surfaces the waiting worker as the header's "Update"
+// button instead. workbox-window's messageSkipWaiting() posts this message when
+// that button is pressed, and it only posts to a worker that is genuinely
+// waiting — so skipping the wait here would break the button as well.
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
 
 // --- Production-only runtime caching ---------------------------------------
 // In dev, vite-plugin-pwa serves the SW with devOptions that intentionally keep

--- a/client/src/tests/components/UpdateAvailableButton.test.tsx
+++ b/client/src/tests/components/UpdateAvailableButton.test.tsx
@@ -1,0 +1,80 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { renderWithProviders } from "../testUtils";
+
+const triggerHaptic = vi.fn();
+vi.mock("use-haptic", () => ({
+  useHaptic: () => ({ triggerHaptic }),
+}));
+
+type SwUpdateModule = typeof import("../../lib/swUpdate");
+
+let swUpdate: SwUpdateModule;
+let UpdateAvailableButton: typeof import("../../components/UpdateAvailableButton").UpdateAvailableButton;
+
+// swUpdate is module-level singleton state and the component reads it via
+// useSyncExternalStore, so both are re-imported together for each test.
+beforeEach(async () => {
+  vi.resetModules();
+  triggerHaptic.mockClear();
+  swUpdate = await import("../../lib/swUpdate");
+  ({ UpdateAvailableButton } = await import("../../components/UpdateAvailableButton"));
+});
+
+describe("UpdateAvailableButton", () => {
+  it("renders nothing while no update is waiting", () => {
+    renderWithProviders(<UpdateAvailableButton />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("appears once an update becomes ready", async () => {
+    renderWithProviders(<UpdateAvailableButton />);
+
+    swUpdate.markUpdateReady();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /update available/i })).toBeInTheDocument();
+    });
+  });
+
+  it("renders immediately when an update was already ready before mount", () => {
+    swUpdate.markUpdateReady();
+
+    renderWithProviders(<UpdateAvailableButton />);
+
+    expect(screen.getByRole("button", { name: /update available/i })).toBeInTheDocument();
+  });
+
+  it("applies the waiting update when pressed", async () => {
+    const applier = vi.fn();
+    swUpdate.setUpdateApplier(applier);
+    swUpdate.markUpdateReady();
+    renderWithProviders(<UpdateAvailableButton />);
+
+    await userEvent.click(screen.getByRole("button", { name: /update available/i }));
+
+    expect(applier).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires haptic feedback when pressed", async () => {
+    swUpdate.setUpdateApplier(vi.fn());
+    swUpdate.markUpdateReady();
+    renderWithProviders(<UpdateAvailableButton />);
+
+    await userEvent.click(screen.getByRole("button", { name: /update available/i }));
+
+    expect(triggerHaptic).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes from the store on unmount", () => {
+    const { unmount } = renderWithProviders(<UpdateAvailableButton />);
+
+    unmount();
+
+    // A post-unmount notification must not attempt to update a torn-down tree.
+    expect(() => swUpdate.markUpdateReady()).not.toThrow();
+  });
+});

--- a/client/src/tests/lib/swUpdate.test.ts
+++ b/client/src/tests/lib/swUpdate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type SwUpdateModule = typeof import("../../lib/swUpdate");
+
+// The store is module-level singleton state, so every test gets a fresh copy.
+let swUpdate: SwUpdateModule;
+
+beforeEach(async () => {
+  vi.resetModules();
+  swUpdate = await import("../../lib/swUpdate");
+});
+
+describe("swUpdate", () => {
+  it("starts with no update ready", () => {
+    expect(swUpdate.isUpdateReady()).toBe(false);
+  });
+
+  it("notifies subscribers when an update becomes ready", () => {
+    const listener = vi.fn();
+    swUpdate.subscribeToUpdate(listener);
+
+    swUpdate.markUpdateReady();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(swUpdate.isUpdateReady()).toBe(true);
+  });
+
+  it("ignores repeat notifications once an update is already ready", () => {
+    const listener = vi.fn();
+    swUpdate.subscribeToUpdate(listener);
+
+    swUpdate.markUpdateReady();
+    swUpdate.markUpdateReady();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = swUpdate.subscribeToUpdate(listener);
+
+    unsubscribe();
+    swUpdate.markUpdateReady();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("notifies every active subscriber", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    swUpdate.subscribeToUpdate(first);
+    swUpdate.subscribeToUpdate(second);
+
+    swUpdate.markUpdateReady();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the registered applier when the update is applied", () => {
+    const applier = vi.fn();
+    swUpdate.setUpdateApplier(applier);
+
+    swUpdate.applyUpdate();
+
+    expect(applier).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when no applier has been registered", () => {
+    expect(() => swUpdate.applyUpdate()).not.toThrow();
+  });
+
+  it("clears a previously registered applier when set to null", () => {
+    const applier = vi.fn();
+    swUpdate.setUpdateApplier(applier);
+    swUpdate.setUpdateApplier(null);
+
+    swUpdate.applyUpdate();
+
+    expect(applier).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/tests/sw.test.ts
+++ b/client/src/tests/sw.test.ts
@@ -72,9 +72,31 @@ describe("sw.ts", () => {
     vi.unstubAllGlobals();
   });
 
-  it("precaches the injected build manifest and skips waiting", () => {
+  it("precaches the injected build manifest", () => {
     expect(precacheAndRouteMock).toHaveBeenCalledWith(selfMock.__WB_MANIFEST);
-    expect(selfMock.skipWaiting).toHaveBeenCalledOnce();
+  });
+
+  describe("update activation", () => {
+    it("stays waiting instead of skipping on its own", () => {
+      // The regression this guards: an unconditional skipWaiting() at parse time
+      // activates every deploy immediately, and the registration answers that
+      // activation by reloading the page mid-session.
+      expect(selfMock.skipWaiting).not.toHaveBeenCalled();
+    });
+
+    it("skips waiting once the page asks it to", () => {
+      listeners.message({ data: { type: "SKIP_WAITING" } });
+
+      expect(selfMock.skipWaiting).toHaveBeenCalledOnce();
+    });
+
+    it("ignores unrelated messages", () => {
+      listeners.message({ data: { type: "SOMETHING_ELSE" } });
+      listeners.message({ data: undefined });
+      listeners.message({});
+
+      expect(selfMock.skipWaiting).not.toHaveBeenCalled();
+    });
   });
 
   it("registers the network-only, navigation, and static-asset routes", () => {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
       strategies: "injectManifest",
       srcDir: "src",
       filename: "sw.ts",
-      registerType: "autoUpdate",
+      // "prompt", not "autoUpdate": autoUpdate reloads the page as soon as a new
+      // worker activates, which interrupts whatever the user is doing. In prompt
+      // mode the registration reports the waiting worker to main.tsx, which
+      // surfaces it as the header's "Update" button (see src/sw.ts).
+      registerType: "prompt",
       // We register the SW ourselves via virtual:pwa-register in main.tsx so we
       // can keep the push-notification registration flow (and its error
       // handling) in one place.


### PR DESCRIPTION
## Summary

An open tab was reloaded whenever a new client build shipped, discarding whatever the user was in the middle of typing. This replaces the automatic reload with an explicit **Update** button beside the wordmark in the header.

**Root cause — two things combined.** `sw.ts` called `self.skipWaiting()` at parse time, so a newly installed worker activated immediately rather than waiting. And vite-plugin-pwa's `autoUpdate` registration answers an update activation with a reload (`dist/client/build/register.js`):

```js
wb.addEventListener("activated", (event) => {
  if (event.isUpdate || event.isExternal) window.location.reload()
})
```

The mitigation already in the tree — deliberately omitting `clientsClaim()` — could not have fixed this, because `skipWaiting()` on its own already transfers control of existing clients. That's why the comment explaining it was there while the symptom persisted.

**Why `registerType: "prompt"` is required, not just preferred.** In `autoUpdate` mode `updateServiceWorker()` is a no-op — `if (!auto) sendSkipWaitingMessage?.()` — so a button could never apply the update. And workbox's `messageSkipWaiting()` only posts to a worker that is genuinely *waiting*, which an unconditional `skipWaiting()` guarantees never exists. Both halves of the old setup had to change together.

## Related issue

<!-- none -->

## Scope

- [x] client
- [ ] server
- [ ] opengraph-service
- [ ] docker / infra (caddy, anubis)
- [ ] docs

## Changes

- `vite.config.ts` — `registerType: "autoUpdate"` → `"prompt"`.
- `src/sw.ts` — replaced the unconditional `self.skipWaiting()` with a `SKIP_WAITING` message listener, so the worker stays in `waiting` until asked.
- `src/lib/swUpdate.ts` *(new)* — a small observable store (subscribe / snapshot / apply). Plain module, no framework coupling, fully unit-tested.
- `src/main.tsx` — registers in prompt mode, pipes `onNeedRefresh` into the store and hands back the applier. Kept here because `main.tsx` is the one place that imports the `virtual:pwa-register` module, which cannot be imported in tests.
- `src/components/UpdateAvailableButton.tsx` *(new)* — reads the store via `useSyncExternalStore`; renders nothing until an update is waiting.
- `src/components/AppHeader.tsx` — renders it immediately after the wordmark, top-left.

### Hard refresh still works

Unaffected by this change — a hard refresh bypasses the service worker for the navigation request and lets the waiting worker take over regardless of the prompt flow. Nothing here intercepts or suppresses it.

### A note on the button label

The visible label is just **Update** with a refresh icon; the accessible name is the fuller "Update available — reload to apply". On mobile the burger and wordmark already compete for the top-left, and a full "Update available" label pushed the header out of shape. Happy to change the wording if you'd rather it read literally.

## Testing

- [x] Unit/integration tests pass locally
- [ ] E2E (Playwright) passes for affected flows
- [ ] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account

- **545 client tests pass**, and coverage holds at **100% across all four metrics** (statements 1228/1228, branches 937/937, functions 380/380, lines 1146/1146).
- `sw.test.ts` gains a regression guard asserting `skipWaiting` is *not* called on its own, plus coverage of the message listener.
- **Zero new lint warnings** — 440 on `main`, 440 on this branch.
- Verified against the real production bundle rather than trusting the config: the injected auto-update flag resolves to `"false"`, so the reload-on-activate branch is unreachable, and the generated `sw.js` carries the `SKIP_WAITING` listener with exactly one `skipWaiting` call inside it.

E2E was not run — it needs the Docker Compose stack, and no Docker daemon is available in this environment. The update flow also can't be exercised without two successive deploys, so it's worth a manual check on a preview deploy before this merges.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens — none present
- [x] Docs updated if user-facing behavior or setup changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg3gFFBQE7RGqhgBr7U2Ci)_