### PR TITLE
fix: drain the flaky generate goroutine, and close a hole in the doc-links checker

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -388,6 +388,11 @@ jobs:
         with:
           bun-version: latest
 
+      # The checker silently missed a wrapped @see once, so it is pinned by its
+      # own boundary pairs before it is trusted to gate anything.
+      - name: Test the checker
+        run: bun run test:doc-links
+
       - name: Check doc links resolve
         run: bun run check:doc-links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,9 @@ When rung 3 or 4 is what replaced a comment, leave a link to the test so the rul
 
 Say which rule the test pins, not just that one exists. A bare `@see` is noise.
 
-`bun run check:doc-links` (run in CI by the `Doc Links` job in `Tests.yml`) fails on a `@see [name](path)` whose file is missing and on a Go `[TestName]` doc link with no matching `func TestName`. Without it a renamed test rots the link silently, which is the same staleness problem the comment had.
+`bun run check:doc-links` (run in CI by the `Doc Links` job in `Tests.yml`) fails on a relative markdown link in any TS/JS comment whose file is missing, and on a Go `[TestName]` doc link with no matching `func TestName`. Without it a renamed test rots the link silently, which is the same staleness problem the comment had.
+
+The markdown side deliberately does not require the `@see` tag to be adjacent: JSDoc wraps, so the tag and the link often sit on different lines, and an earlier tag-anchored version of the checker passed a wrapped link that pointed at nothing. `bun run test:doc-links` pins that case and the rest of the checker's boundaries.
 
 ### What this does not license
 

--- a/opengraph-service/internal/shim/handler_test.go
+++ b/opengraph-service/internal/shim/handler_test.go
@@ -489,10 +489,19 @@ func TestHandler_GenerateCap_ProxyUnaffected(t *testing.T) {
 	h.MaxConcurrentGenerate = 1
 	h.initSem()
 
-	// Saturate the generate slot.
-	go func() { _ = do(t, h, "Bluesky Cardyb", "/profile/busy.test") }()
+	// Saturate the generate slot. The generate must be drained before the test
+	// returns: releasing it leaves it running into Cache.Store, which writes into
+	// the t.TempDir() that cleanup is about to walk.
+	saturated := make(chan struct{})
+	go func() {
+		defer close(saturated)
+		_ = do(t, h, "Bluesky Cardyb", "/profile/busy.test")
+	}()
 	<-started
-	defer close(release)
+	defer func() {
+		close(release)
+		<-saturated
+	}()
 
 	// Ordinary proxy traffic (browser UA) must succeed — the cap is generate-only.
 	rec := do(t, h, "Mozilla/5.0", "/some/path")

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepare": "bunx --bun husky || true",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "check:doc-links": "bun scripts/check-doc-links.mjs"
+    "check:doc-links": "bun scripts/check-doc-links.mjs",
+    "test:doc-links": "bun test scripts/check-doc-links.test.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -3,9 +3,14 @@
 // comment policy in CLAUDE.md lets a test carry a business rule in place of
 // prose, which only holds while the link resolves.
 //
-// Checks two forms: the TypeScript JSDoc "see" tag followed by a markdown link
-// to a relative path, and Go doc links naming a test, which must match a
-// `func TestName(` in the same package.
+// Checks two forms: a markdown link to a relative path anywhere in a
+// TypeScript/JavaScript comment, and Go doc links naming a test, which must
+// match a `func TestName(` in the same package.
+//
+// The markdown form is matched across the whole comment rather than only
+// where it trails a "see" tag: JSDoc wraps, so the tag and the link routinely
+// land on different lines, and a link the checker cannot see is a link that
+// rots silently.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
@@ -25,7 +30,7 @@ const SKIP_DIRS = new Set([
 
 const TS_EXTENSIONS = [".ts", ".tsx", ".mjs", ".js"];
 
-function walk(dir) {
+export function walk(dir) {
   const found = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.name.startsWith(".") && entry.name !== ".github") continue;
@@ -49,29 +54,79 @@ function fileExists(path) {
   }
 }
 
-// A markdown link after the tag, plus the bare relative-path form.
-const TS_MARKDOWN_LINK = /@see\s+\[[^\]]+\]\(([^)]+)\)/g;
+const TS_MARKDOWN_LINK = /\[[^\]]+\]\(([^)]+)\)/g;
 const TS_BARE_LINK = /@see\s+((?:\.{1,2}\/)[^\s)]+)/g;
 const GO_DOC_LINK = /\[(Test[A-Za-z0-9_]+)\]/g;
 
-function checkTypeScript(files) {
+const LINE_COMMENT = /^\s*\/\/(.*)$/;
+const BLOCK_COMMENT_OPEN = /\/\*(.*)$/;
+const BLOCK_COMMENT_CLOSE = /^(.*?)\*\//;
+
+/**
+ * Matching the whole file would read `arr[i](x)` as a markdown link, so only
+ * comment text is offered to the link patterns.
+ */
+function commentText(source) {
+  const lines = [];
+  let inBlock = false;
+
+  for (const line of source.split("\n")) {
+    if (inBlock) {
+      const close = line.match(BLOCK_COMMENT_CLOSE);
+      if (close) {
+        lines.push(close[1]);
+        inBlock = false;
+      } else {
+        lines.push(line);
+      }
+      continue;
+    }
+
+    const lineComment = line.match(LINE_COMMENT);
+    if (lineComment) {
+      lines.push(lineComment[1]);
+      continue;
+    }
+
+    const open = line.match(BLOCK_COMMENT_OPEN);
+    if (open) {
+      const close = open[1].match(BLOCK_COMMENT_CLOSE);
+      if (close) {
+        lines.push(close[1]);
+      } else {
+        lines.push(open[1]);
+        inBlock = true;
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// A markdown link in prose ("[the docs](https://...)", "[1](#footnote)") is not
+// a file reference, so only repo-relative paths are resolved.
+function isRelativePath(target) {
+  return target.startsWith("./") || target.startsWith("../");
+}
+
+export function checkTypeScript(files, root = REPO_ROOT) {
   const failures = [];
 
   for (const file of files) {
     if (!TS_EXTENSIONS.some((ext) => file.endsWith(ext))) continue;
 
-    const source = readFileSync(file, "utf8");
+    const comments = commentText(readFileSync(file, "utf8"));
     const targets = new Set();
 
-    for (const [, target] of source.matchAll(TS_MARKDOWN_LINK)) targets.add(target);
-    for (const [, target] of source.matchAll(TS_BARE_LINK)) targets.add(target);
+    for (const [, target] of comments.matchAll(TS_MARKDOWN_LINK)) targets.add(target);
+    for (const [, target] of comments.matchAll(TS_BARE_LINK)) targets.add(target);
 
     for (const target of targets) {
-      if (/^[a-z]+:\/\//.test(target) || target.startsWith("#")) continue;
+      if (!isRelativePath(target)) continue;
 
       const resolved = resolve(dirname(file), target.split("#")[0]);
       if (!fileExists(resolved)) {
-        failures.push(`${relative(REPO_ROOT, file)} -> ${target} (no such file)`);
+        failures.push(`${relative(root, file)} -> ${target} (no such file)`);
       }
     }
   }
@@ -79,7 +134,7 @@ function checkTypeScript(files) {
   return failures;
 }
 
-function checkGo(files) {
+export function checkGo(files, root = REPO_ROOT) {
   const goFiles = files.filter((file) => file.endsWith(".go"));
   const failures = [];
 
@@ -103,7 +158,7 @@ function checkGo(files) {
 
       for (const [, name] of line.matchAll(GO_DOC_LINK)) {
         if (!known.has(name)) {
-          failures.push(`${relative(REPO_ROOT, file)} -> [${name}] (no such test in package)`);
+          failures.push(`${relative(root, file)} -> [${name}] (no such test in package)`);
         }
       }
     }
@@ -112,14 +167,16 @@ function checkGo(files) {
   return failures;
 }
 
-const files = walk(REPO_ROOT);
-const failures = [...checkTypeScript(files), ...checkGo(files)];
+if (import.meta.main) {
+  const files = walk(REPO_ROOT);
+  const failures = [...checkTypeScript(files), ...checkGo(files)];
 
-if (failures.length > 0) {
-  console.error(`Broken doc links (${failures.length}):\n`);
-  for (const failure of failures) console.error(`  ${failure}`);
-  console.error("\nEvery @see must resolve, or the rule it points at is undocumented again.");
-  process.exit(1);
+  if (failures.length > 0) {
+    console.error(`Broken doc links (${failures.length}):\n`);
+    for (const failure of failures) console.error(`  ${failure}`);
+    console.error("\nEvery link must resolve, or the rule it points at is undocumented again.");
+    process.exit(1);
+  }
+
+  console.log("All doc links resolve.");
 }
-
-console.log("All doc links resolve.");

--- a/scripts/check-doc-links.test.ts
+++ b/scripts/check-doc-links.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "bun:test";
+
+import { checkGo, checkTypeScript, walk } from "./check-doc-links.mjs";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "doc-links-"));
+  mkdirSync(join(root, "tests"));
+  writeFileSync(join(root, "tests", "real.test.ts"), "");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function write(name: string, source: string) {
+  writeFileSync(join(root, name), source);
+}
+
+// Assembled rather than written literally: this file is itself scanned by the
+// checker, and a literal block-comment fixture would read as a real comment.
+const SLASH = "/";
+const STAR = "*";
+
+function jsdoc(...lines: string[]) {
+  return [`${SLASH}${STAR}${STAR}`, ...lines.map((line) => ` ${STAR} ${line}`), ` ${STAR}${SLASH}`]
+    .join("\n")
+    .concat("\n");
+}
+
+function tsFailures() {
+  return checkTypeScript(walk(root), root);
+}
+
+function goFailures() {
+  return checkGo(walk(root), root);
+}
+
+describe("markdown links in TypeScript comments", () => {
+  test("accepts a link whose target exists", () => {
+    write("src.ts", jsdoc("@see [real.test.ts](./tests/real.test.ts) pins the rule."));
+    assert.deepStrictEqual(tsFailures(), []);
+  });
+
+  test("rejects a link whose target was renamed away", () => {
+    write("src.ts", jsdoc("@see [gone.test.ts](./tests/gone.test.ts) pins the rule."));
+    assert.match(tsFailures().join("\n"), /src\.ts -> \.\/tests\/gone\.test\.ts/);
+  });
+
+  test("rejects a broken link when JSDoc wraps the tag onto its own line", () => {
+    write("src.ts", jsdoc("@see", "[gone.test.ts](./tests/gone.test.ts) pins the rule."));
+    assert.strictEqual(tsFailures().length, 1);
+  });
+
+  test("rejects a broken link written as prose, with no tag at all", () => {
+    write("src.ts", `// See [gone.test.ts](./tests/gone.test.ts) for the boundary pair.\n`);
+    assert.strictEqual(tsFailures().length, 1);
+  });
+
+  test("ignores a link-shaped string literal outside a comment", () => {
+    write("src.ts", `const template = "[gone.test.ts](./tests/gone.test.ts)";\n`);
+    assert.deepStrictEqual(tsFailures(), []);
+  });
+
+  test("ignores targets that are not repo-relative paths", () => {
+    write(
+      "src.ts",
+      ["// [the docs](https://example.test/docs)", "// [1](#footnote)"].join("\n") + "\n"
+    );
+    assert.deepStrictEqual(tsFailures(), []);
+  });
+});
+
+describe("Go doc links naming a test", () => {
+  const goSource = (link: string) => `package shim\n\n// ${link} pins the rule.\nfunc Run() {}\n`;
+  const goTest = `package shim\n\nfunc TestRunPinsTheRule(t *testing.T) {}\n`;
+
+  test("accepts a doc link matching a test in the same package", () => {
+    write("run.go", goSource("[TestRunPinsTheRule]"));
+    write("run_test.go", goTest);
+    assert.deepStrictEqual(goFailures(), []);
+  });
+
+  test("rejects a doc link naming a test that no longer exists", () => {
+    write("run.go", goSource("[TestRunUnderTheOldName]"));
+    write("run_test.go", goTest);
+    assert.match(goFailures().join("\n"), /run\.go -> \[TestRunUnderTheOldName\]/);
+  });
+
+  test("rejects a doc link whose test lives in another package", () => {
+    write("run.go", goSource("[TestRunPinsTheRule]"));
+    mkdirSync(join(root, "other"));
+    write(join("other", "run_test.go"), goTest);
+    assert.strictEqual(goFailures().length, 1);
+  });
+});


### PR DESCRIPTION
Two follow-ups to #355: the Go flake it uncovered, and a hole in the doc-links checker it shipped.

## The flake (closes #356)

`TestHandler_GenerateCap_ProxyUnaffected` failed roughly 1 run in 5 on `TempDir RemoveAll cleanup: directory not empty`.

The test parks a generate in a goroutine to hold the single generate slot, and never waits for it. `close(release)` unblocks the fetcher exactly as the test returns, so the goroutine runs on into `Cache.Store` and writes a `.png` and a `.meta` into the `t.TempDir()` that cleanup is already walking. Land a file after the directory has been walked and the unlink fails.

The `0.00s` duration in the failure output was the tell: the body passed, only cleanup failed.

Fix is to close `release` from a defer that then waits on the goroutine. Deferred calls run before `t.Cleanup` functions, so the writes finish before `RemoveAll` starts.

Verified at 60 runs under `-race`, having previously failed within 20. Full Go suite green at `-count=3 -race`.

`TestHandler_GenerateCap_FailsFast` was the other candidate and is already correct: it waits on `leaderDone`. `Cache.Store` is synchronous inside `generateOnce`, so awaiting a `Generate` result is sufficient everywhere else.

## The doc-links checker

The `Doc Links` job merged in #355 had a silent false negative. It only matched a markdown link sitting immediately after an `@see` tag:

```js
const TS_MARKDOWN_LINK = /@see\s+\[[^\]]+\]\(([^)]+)\)/g;
```

JSDoc wraps, so the tag and the link routinely land on different lines with a `* ` between them, and the regex cannot span that. Confirmed by probe: a file containing

```ts
/**
 * @see
 * [gone.test.ts](./tests/gone.test.ts)
 */
```

passes the job with the target deleted. So does a link written as prose without the tag. That is precisely the rot the job exists to catch.

Now it matches any relative markdown link, scoped to comment text so a link-shaped string literal is not read as a file reference. Non-relative targets (URLs, `#anchors`) stay ignored. No new failures across the tree.

| Case | Before | After |
|---|---|---|
| `@see [x](path)` inline, target missing | caught | caught |
| `@see` wrapped, link on next line | **missed** | caught |
| `// See [x](path)`, no tag | **missed** | caught |
| Link-shaped string literal in code | n/a | ignored |
| URL / anchor target | ignored | ignored |
| Go `[TestName]` with no matching func | caught | caught |

## Why the hole existed

Nothing tested the checker. It was written, probed by hand once, and shipped.

So the checker now gets the same treatment #355 prescribes for everything else: `scripts/check-doc-links.test.ts`, nine tests, boundary pairs on each rule. Link resolves vs renamed away. Wrapped vs inline. Comment vs string literal. Go doc link in package vs in another package. The `Doc Links` job runs those before it trusts the checker to gate anything.

Required a small refactor to make it testable: export the two passes, take the report root as a parameter, and guard the entrypoint with `import.meta.main` so importing it does not scan the repo.

One wrinkle worth knowing about: the test file is itself scanned by the checker, so a literal block-comment fixture reads as a real comment and its fake paths get resolved. Fixtures are assembled from `SLASH`/`STAR` constants to avoid that. Noted in the file.

## Checks

- [x] `go test ./... -race -count=3` green, target test 60 runs clean
- [x] `bun run test:doc-links` 9 pass
- [x] `bun run check:doc-links` clean on the tree
- [x] `go vet`, `gofmt`, prettier clean (Tests.yml already fails prettier on main, left alone)
