### PR TITLE
Refactor frontend: split components, extract styling, fix contrast

### DIFF
--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -13,6 +13,7 @@ The explicit `--bun` flag is load-bearing: `bun run <script>` hands a node-sheba
 ## Data Layer
 
 React Query is the data layer. Each domain (auth, messages, profile, settings) has a service file in `src/api/` that exports plain functions and React Query hooks:
+
 - `src/api/apiClient.ts` — thin fetch wrapper; reads `VITE_API_URL` env var (defaults to `""`, so same-origin)
 - `src/api/authService.ts` — exports `useSession`, `useLogin`, `useLogout`
 - `src/api/messageService.ts`, `profileService.ts`, `settingsService.ts` — similar pattern
@@ -22,6 +23,7 @@ All API calls use `credentials: "include"` for cookie forwarding.
 ### Form Validation
 
 The client uses **Zod v4** (`^4.4.3`). Zod v4 has breaking syntax changes from v3:
+
 - Import it as `import * as z from "zod"`, never `import { z }` (see below)
 - Custom messages on `.min()` / `.max()` use `{ error: "..." }` instead of a plain string
 - Validation errors are accessed via `.issues` not `.errors`
@@ -32,19 +34,75 @@ The client uses **Zod v4** (`^4.4.3`). Zod v4 has breaking syntax changes from v
 
 Transient feedback (success, error) uses Mantine's `showNotification()` from `@mantine/notifications` rather than inline alert state. The `<Notifications>` component is mounted in `src/main.tsx` with `position="bottom-right"` and `autoClose={5000}`. Use `showNotification()` for any new transient messages — don't add stateful alert components to pages.
 
+## Styling
+
+### Rendering and styling are separate files
+
+A `.tsx` describes structure and behaviour; the CSS objects it needs live in a
+sibling `*.styles.ts`, imported as `import * as styles from "./Thing.styles"`.
+Anything computed from props is a small named function there
+(`card({ gradient, pinned, focused })`), not a ternary inline in JSX. Style
+modules are excluded from coverage — they are constants and the pure functions
+that pick between them, with no behaviour an assertion could pin. Do not let
+logic drift into one: if a "style" function needs to know a business rule, the
+rule belongs in the component or a hook.
+
 ### Design Tokens
 
-Brand CSS custom properties live in `client/src/index.css` under the `--nf-*` namespace and are the single source of truth for colors and gradients. Key gradient tokens:
+`client/src/index.css` is the single source of truth for colour, and it is
+layered — components may only read from the last two layers:
 
-- `--nf-grad-mark` — the primary brand gradient (`#3349E0 → #6B3FD4 → #4F1FA6`); use this for all interactive card backgrounds (login, ask, inbox hero, question cards with gradient enabled)
-- `--nf-grad-dark` — reserved exclusively for the "default" image-export theme preview in the `ThemeCard` selector; do not use it for new UI elements
-- `--nf-grad-hero` — defined but no longer applied to any UI element; do not reintroduce it for text or nav items
+1. **Brand primitives** (`--nf-royal`, `--nf-grad-mark`, …) — scheme-independent
+   raw palette. Referenced only by the semantic layer in the same file.
+2. **Semantic tokens** (`--nf-surface`, `--nf-link`, `--nf-nav-active-bg`, …) —
+   named for the job. Light values on `:root`, dark overrides under
+   `:root[data-mantine-color-scheme="dark"]`. **This is why no component calls
+   `useComputedColorScheme` to choose a colour** — the browser picks. If you find
+   yourself adding an `isDark` prop, add a token instead.
+3. **On-gradient tokens** (`--nf-on-grad`, `--nf-on-grad-muted`,
+   `--nf-on-grad-accent`) — deliberately _not_ scheme-aware, because the brand
+   gradients are dark in both schemes. `--nf-on-grad-faint` is for rules and
+   progress tracks; it is not strong enough for text and a test pins that.
 
-Nav active state uses a solid tint (`--nf-nav-active-bg`) — no gradients on nav items. Gradient text (`background-clip: text`) is not used in the app; brand color (`--nf-royal`) is used for highlighted text instead.
+`src/styles/tokens.ts` gives these TypeScript handles so a renamed token is a
+compile error rather than a colour that silently resolves to nothing.
+
+Gradient usage:
+
+- `--nf-grad-mark` — the primary brand gradient; use it for every interactive
+  card background (login, ask, inbox hero, gradient question cards)
+- `--nf-grad-dark` — reserved for the "default" image-export theme preview; not a
+  UI surface
+- ask-card presets (`aurora`/`ember`/`verdant`) are curated so white text clears
+  AA across the whole ramp — check `contrast.test.ts` before changing a stop
+
+Nav active state uses a solid tint (`--nf-nav-active-bg`) — no gradients on nav
+items. Gradient text (`background-clip: text`) is used only in the `Wordmark`.
+
+### Overriding a Mantine variable
+
+Mantine declares its scheme variables at `:root[data-mantine-color-scheme="…"]`
+(specificity 0,2,0). A bare `[data-mantine-color-scheme="…"]` block loses to it
+and silently does nothing — which is what had happened to the light-mode
+`--mantine-color-body` and `--mantine-color-default-border` overrides. Match the
+selector exactly, and only for variables the provider does not re-emit at
+runtime: `--mantine-color-body` comes from `theme.white` / `dark[7]`, and brand
+text colours come from `--nf-accent-text` / `--nf-link` rather than fighting the
+provider's `--mantine-color-*-text`.
+
+### Contrast is enforced, not reviewed
+
+`src/tests/theme/contrast.test.ts` parses `index.css`, resolves the tokens, and
+fails if any documented text/background pair drops below WCAG AA — including
+across the full ramp of every gradient, both colour schemes, and every `Alert`
+tone against its own tint. It also fails on a declared `--nf-*` token nothing
+references and on a referenced token nothing declares, so the palette cannot
+accumulate dead entries or typos.
 
 ## Testing & Coverage
 
 Run coverage from `client/`:
+
 ```bash
 bun run test:coverage
 ```
@@ -58,11 +116,13 @@ The client targets **100% across all four metrics** (statements, lines, branches
 Suppress unreachable code with istanbul's markers. `/* v8 ignore */` is inert under the istanbul provider and there are none left in `src/`; do not reintroduce them.
 
 Pick the narrowest form:
+
 - `/* istanbul ignore if */` — the `if` body is unreachable (a defensive early-return guard whose condition can't hold)
 - `/* istanbul ignore else */` — the implicit else is unreachable (a guard that always passes)
 - `/* istanbul ignore next */` — the whole next statement or function, for `catch` blocks wrapping non-throwing DOM operations and for callbacks tests never invoke
 
 Use them **only** for:
+
 1. `catch {}` blocks that wrap non-throwing DOM operations (e.g. the AppHeader `handleSwitch` catch that resets `body.style` — the try never throws in practice)
 2. TypeScript-narrowed union branches, and UI guards, that are structurally unreachable at runtime
 
@@ -73,9 +133,11 @@ Do **not** use them to skip real business logic. Document any usage in `docs/tes
 ### Coverage Exclusions
 
 Excluded via `coverage.exclude` in `vite.config.ts`:
+
 - `src/tests/**`, `src/main.tsx`, `src/Theme.tsx` — test infra and app entry point
 - `src/vite-env.d.ts` — ambient declarations
 - `src/styles/tokens.ts` — pure style constant exports
+- `src/**/*.styles.ts` — per-component style modules, same rationale
 - `src/pushPayload.ts` — a type-only `interface` with no runtime code to execute
 - `src/index.css` — a stylesheet; Vite's CSS import handling registers it as a coverage-tracked module with zero instrumentable statements
 

--- a/client/src/AppLayout.tsx
+++ b/client/src/AppLayout.tsx
@@ -16,6 +16,7 @@ import Messages from "./pages/Messages";
 import OAuthCallback from "./pages/OAuthCallback";
 import PublicProfile from "./pages/PublicProfile";
 import Settings from "./pages/Settings";
+import { dangerText } from "./styles/tokens";
 
 export function AppLayout() {
   const [navOpen, setNavOpen] = React.useState(false);
@@ -116,7 +117,7 @@ function NotFoundPage() {
   return (
     <Container>
       <Paper p="xl" radius="md" withBorder shadow="xs">
-        <Title order={2} c="red">
+        <Title order={2} style={{ color: dangerText }}>
           404 - Not Found
         </Title>
         <Text c="dimmed" mt="md">

--- a/client/src/Navigation.styles.ts
+++ b/client/src/Navigation.styles.ts
@@ -1,0 +1,43 @@
+import type { CSSProperties } from "react";
+
+import { border, radiusControl } from "./styles/tokens";
+
+export const root: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+};
+
+/** Nav items get a solid tint when active — deliberately never a gradient. */
+export const navItem = (active: boolean) => ({
+  root: {
+    borderRadius: radiusControl,
+    transition: "background var(--nf-dur-fast) var(--nf-ease)",
+    ...(active
+      ? {
+          background: "var(--nf-nav-active-bg)",
+          color: "var(--nf-nav-active-color)",
+        }
+      : {}),
+  },
+  label: {
+    fontFamily: "var(--nf-font-sans)",
+    fontSize: 16,
+    fontWeight: active ? 600 : 500,
+  },
+});
+
+export const friendsScroller: CSSProperties = {
+  flex: 1,
+  overflowY: "auto",
+  minHeight: 0,
+};
+
+export const viewingProfile: CSSProperties = {
+  borderRadius: radiusControl,
+  background: "var(--mantine-color-default)",
+  border,
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+};

--- a/client/src/Navigation.tsx
+++ b/client/src/Navigation.tsx
@@ -1,56 +1,36 @@
+import { Box, Group, NavLink, Skeleton, Stack, Text } from "@mantine/core";
 import {
-  NavLink,
-  Text,
-  Box,
-  Skeleton,
-  Stack,
-  Avatar,
-  Group,
-  Collapse,
-  UnstyledButton,
-} from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-import {
+  IconAdjustments,
   IconHome,
-  IconMessage,
   IconLogin,
+  IconMessage,
   IconSettings,
   IconUser,
-  IconChevronDown,
-  IconAdjustments,
 } from "@tabler/icons-react";
-import { useEffect } from "react";
-import { useLocation, Link, useNavigate } from "react-router";
+import { useLocation, Link } from "react-router";
 import { useHaptic } from "use-haptic";
 
 import { useSession } from "./api/authService";
-import { useFriends, Friend } from "./api/profileService";
+import { useFriends } from "./api/profileService";
 import { useUserStats } from "./api/settingsService";
-import { WinkMark } from "./components/WinkMark";
+import { FriendSection } from "./components/nav/FriendSection";
+import { MessageCountBadge } from "./components/nav/MessageCountBadge";
+import * as styles from "./Navigation.styles";
+import { useNavShortcuts } from "./lib/useNavShortcuts";
+
+/** The three ways a Navyfragen user can be related to you. */
+const FRIEND_GROUPS = [
+  { key: "moots", label: "Moots", emptyText: "No mutuals on Navyfragen yet." },
+  { key: "following", label: "Following", emptyText: "No one-sided follows on Navyfragen yet." },
+  { key: "oomfs", label: "Oomfs", emptyText: "None of your followers are on Navyfragen yet." },
+] as const;
 
 interface NavigationProps {
   onLinkClick?: () => void;
 }
 
-const activeNavStyle = {
-  background: "var(--nf-nav-active-bg)",
-  borderRadius: 12,
-  color: "var(--nf-nav-active-color)",
-  boxShadow: "var(--nf-nav-active-shadow)",
-};
-
-const inactiveNavStyle = {
-  borderRadius: 12,
-  transition: "background 120ms ease",
-};
-
-const friendNavLinkStyles = {
-  root: { borderRadius: 10, transition: "background 120ms ease" },
-};
-
 export function Navigation({ onLinkClick }: NavigationProps) {
   const location = useLocation();
-  const navigate = useNavigate();
   const { data: sessionData, isLoading: isSessionLoading } = useSession();
   const isLoggedIn = !!sessionData?.isLoggedIn;
   const did = sessionData?.did ?? undefined;
@@ -65,104 +45,43 @@ export function Navigation({ onLinkClick }: NavigationProps) {
     onLinkClick?.();
   };
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const targetNodeName = (event.target as HTMLElement)?.nodeName;
-      if (["INPUT", "TEXTAREA", "SELECT"].includes(targetNodeName)) return;
-
-      if (event.altKey) {
-        let targetPath: string | null = null;
-        switch (event.key.toUpperCase()) {
-          case "H":
-            targetPath = "/";
-            break;
-          case "M":
-            if (isLoggedIn) targetPath = "/messages";
-            break;
-          case "C":
-            if (isLoggedIn) targetPath = "/customise";
-            break;
-          case "S":
-            if (isLoggedIn) targetPath = "/settings";
-            break;
-          case "L":
-            if (!isLoggedIn && !isSessionLoading) targetPath = "/login";
-            break;
-        }
-        if (targetPath) {
-          event.preventDefault();
-          navigate(targetPath);
-          onLinkClick?.();
-        }
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isLoggedIn, isSessionLoading, navigate, onLinkClick]);
+  useNavShortcuts({ isLoggedIn, isSessionLoading, onNavigate: onLinkClick });
 
   const isActive = (path: string) => location.pathname === path;
-
-  const navItemStyles = (path: string) => ({
-    root: isActive(path) ? activeNavStyle : inactiveNavStyle,
-    label: {
-      fontFamily: "Inter, sans-serif",
-      fontSize: 16,
-      fontWeight: isActive(path) ? 600 : 500,
-    },
+  const linkProps = (path: string, label: string, icon: React.ReactNode) => ({
+    my: 2,
+    label,
+    component: Link,
+    to: path,
+    active: isActive(path),
+    onClick: handleClick,
+    leftSection: icon,
+    styles: styles.navItem(isActive(path)),
   });
 
-  const profileMatch = location.pathname.match(/^\/profile\/(.+)$/);
-  const viewingHandle = profileMatch ? profileMatch[1] : null;
+  const viewingHandle = location.pathname.match(/^\/profile\/(.+)$/)?.[1];
+  const unread = userStats?.messageCount ?? 0;
 
   return (
-    <Box style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <Box style={styles.root}>
       <Box style={{ flexShrink: 0 }}>
-        <NavLink
-          my={2}
-          label="Home"
-          component={Link}
-          to="/"
-          active={isActive("/")}
-          onClick={handleClick}
-          leftSection={<IconHome size={16} stroke={1.5} />}
-          styles={navItemStyles("/")}
-        />
+        <NavLink {...linkProps("/", "Home", <IconHome size={16} stroke={1.5} />)} />
+
         {isLoggedIn ? (
           <>
             <NavLink
-              my={2}
-              label="Messages"
-              component={Link}
-              to="/messages"
-              active={isActive("/messages")}
-              onClick={handleClick}
-              leftSection={<IconMessage size={16} stroke={1.5} />}
+              {...linkProps("/messages", "Messages", <IconMessage size={16} stroke={1.5} />)}
               rightSection={
-                !isActive("/messages") && (userStats?.messageCount ?? 0) > 0 ? (
-                  <MessageCountBadge count={userStats!.messageCount} />
+                !isActive("/messages") && unread > 0 ? (
+                  <MessageCountBadge count={unread} />
                 ) : undefined
               }
-              styles={navItemStyles("/messages")}
             />
             <NavLink
-              my={2}
-              label="Customise"
-              component={Link}
-              to="/customise"
-              active={isActive("/customise")}
-              onClick={handleClick}
-              leftSection={<IconAdjustments size={16} stroke={1.5} />}
-              styles={navItemStyles("/customise")}
+              {...linkProps("/customise", "Customise", <IconAdjustments size={16} stroke={1.5} />)}
             />
             <NavLink
-              my={2}
-              label="Settings"
-              component={Link}
-              to="/settings"
-              active={isActive("/settings")}
-              onClick={handleClick}
-              leftSection={<IconSettings size={16} stroke={1.5} />}
-              styles={navItemStyles("/settings")}
+              {...linkProps("/settings", "Settings", <IconSettings size={16} stroke={1.5} />)}
             />
           </>
         ) : isSessionLoading ? (
@@ -171,88 +90,27 @@ export function Navigation({ onLinkClick }: NavigationProps) {
             <Skeleton height={12} width="40%" radius="sm" />
           </Group>
         ) : (
-          <NavLink
-            my={2}
-            label="Login"
-            component={Link}
-            to="/login"
-            active={isActive("/login")}
-            onClick={handleClick}
-            leftSection={<IconLogin size={16} stroke={1.5} />}
-            styles={navItemStyles("/login")}
-          />
+          <NavLink {...linkProps("/login", "Login", <IconLogin size={16} stroke={1.5} />)} />
         )}
 
-        {viewingHandle && (
-          <Box
-            mt={4}
-            px={12}
-            py={8}
-            style={{
-              borderRadius: 12,
-              background: "var(--mantine-color-default)",
-              border: "1px solid var(--mantine-color-default-border)",
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-            }}
-          >
-            <IconUser size={13} stroke={1.5} style={{ opacity: 0.5, flexShrink: 0 }} />
-            <Box style={{ minWidth: 0 }}>
-              <Text fz={9} c="dimmed">
-                Viewing profile
-              </Text>
-              <Text fz={12} fw={600} truncate>
-                @{viewingHandle}
-              </Text>
-            </Box>
-          </Box>
-        )}
+        {viewingHandle && <ViewingProfile handle={viewingHandle} />}
       </Box>
 
       {isLoggedIn && did && (
-        <Box style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+        <Box style={styles.friendsScroller}>
           {friendsLoading ? (
-            <>
-              <Box mt="lg" mb="xs" px={2}>
-                <Skeleton height={10} width="60%" radius="sm" />
-              </Box>
-              <Stack gap={6}>
-                {[0, 1, 2].map((i) => (
-                  <Group key={i} gap="xs" px={4} py={4}>
-                    <Skeleton circle height={28} width={28} style={{ flexShrink: 0 }} />
-                    <Box style={{ flex: 1, minWidth: 0 }}>
-                      <Skeleton height={10} mb={4} radius="sm" />
-                      <Skeleton height={8} width="60%" radius="sm" />
-                    </Box>
-                  </Group>
-                ))}
-              </Stack>
-            </>
+            <FriendsSkeleton />
           ) : (
-            <>
+            FRIEND_GROUPS.map(({ key, label, emptyText }) => (
               <FriendSection
-                label="Moots"
-                friends={friendsData?.moots ?? []}
-                emptyText="No mutuals on Navyfragen yet."
+                key={key}
+                label={label}
+                friends={friendsData?.[key] ?? []}
+                emptyText={emptyText}
                 onLinkClick={handleClick}
                 did={did}
               />
-              <FriendSection
-                label="Following"
-                friends={friendsData?.following ?? []}
-                emptyText="No one-sided follows on Navyfragen yet."
-                onLinkClick={handleClick}
-                did={did}
-              />
-              <FriendSection
-                label="Oomfs"
-                friends={friendsData?.oomfs ?? []}
-                emptyText="None of your followers are on Navyfragen yet."
-                onLinkClick={handleClick}
-                did={did}
-              />
-            </>
+            ))
           )}
         </Box>
       )}
@@ -262,148 +120,40 @@ export function Navigation({ onLinkClick }: NavigationProps) {
   );
 }
 
-function sectionKey(did: string) {
-  return `navyfragen_friends_sections_open_${did}`;
-}
-
-function getSectionOpen(label: string, did: string): boolean {
-  try {
-    const raw = localStorage.getItem(sectionKey(did));
-    if (!raw) return true;
-    const parsed = JSON.parse(raw);
-    return parsed[label] !== false;
-  } catch {
-    return true;
-  }
-}
-
-function setSectionOpen(label: string, open: boolean, did: string) {
-  try {
-    const raw = localStorage.getItem(sectionKey(did));
-    const parsed = raw ? JSON.parse(raw) : {};
-    localStorage.setItem(sectionKey(did), JSON.stringify({ ...parsed, [label]: open }));
-  } catch {
-    // localStorage unavailable (private browsing quota, etc.)
-  }
-}
-
-function FriendSection({
-  label,
-  friends,
-  emptyText,
-  onLinkClick,
-  did,
-}: {
-  label: string;
-  friends: Friend[];
-  emptyText: string;
-  onLinkClick: () => void;
-  did: string;
-}) {
-  const [opened, { toggle }] = useDisclosure(getSectionOpen(label, did));
-  const { triggerHaptic } = useHaptic(1);
-
-  const handleToggle = () => {
-    triggerHaptic();
-    setSectionOpen(label, !opened, did);
-    toggle();
-  };
-
+/** Context chip shown while looking at someone else's public profile. */
+function ViewingProfile({ handle }: { handle: string }) {
   return (
-    <>
-      <UnstyledButton
-        onClick={handleToggle}
-        mb="xs"
-        px={2}
-        aria-expanded={opened}
-        aria-label={`${label} — ${opened ? "collapse" : "expand"}`}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 4,
-          width: "100%",
-          cursor: "pointer",
-          position: "sticky",
-          top: 0,
-          zIndex: 1,
-          background: "var(--mantine-color-body)",
-          paddingTop: "var(--mantine-spacing-lg)",
-        }}
-      >
-        <Text size="xs" fw={600} c="dimmed" style={{ flex: 1 }}>
-          {label}
+    <Box mt={4} px={12} py={8} style={styles.viewingProfile}>
+      <IconUser size={13} stroke={1.5} style={{ opacity: 0.5, flexShrink: 0 }} />
+      <Box style={{ minWidth: 0 }}>
+        <Text fz={9} c="dimmed">
+          Viewing profile
         </Text>
-        <IconChevronDown
-          size={12}
-          style={{
-            color: "var(--mantine-color-dimmed)",
-            transition: "transform 150ms ease",
-            transform: opened ? "rotate(0deg)" : "rotate(-90deg)",
-            flexShrink: 0,
-          }}
-        />
-      </UnstyledButton>
-      <Collapse expanded={opened}>
-        {friends.length > 0 ? (
-          <Box style={{ overflowX: "hidden" }}>
-            {friends.map((friend) => (
-              <NavLink
-                key={friend.did}
-                label={
-                  <Group gap={10} wrap="nowrap" style={{ overflow: "hidden", width: "100%" }}>
-                    <Avatar
-                      size={28}
-                      radius="xl"
-                      src={friend.avatar || undefined}
-                      alt={friend.displayName || friend.handle}
-                      style={{ flexShrink: 0 }}
-                    >
-                      <WinkMark size={22} sparkle={false} aria-hidden />
-                    </Avatar>
-                    <Box style={{ flex: 1, minWidth: 0 }}>
-                      <Text fz={13} fw={600} truncate style={{ lineHeight: 1.3 }}>
-                        {friend.displayName || friend.handle}
-                      </Text>
-                      <Text fz={10} c="dimmed" truncate style={{ lineHeight: 1.3 }}>
-                        @{friend.handle}
-                      </Text>
-                    </Box>
-                  </Group>
-                }
-                component={Link}
-                to={`/profile/${friend.handle}`}
-                onClick={onLinkClick}
-                py={4}
-                styles={friendNavLinkStyles}
-              />
-            ))}
-          </Box>
-        ) : (
-          <Text size="xs" c="dimmed" px={2} style={{ lineHeight: 1.6 }}>
-            {emptyText}
-          </Text>
-        )}
-      </Collapse>
-    </>
+        <Text fz={12} fw={600} truncate>
+          @{handle}
+        </Text>
+      </Box>
+    </Box>
   );
 }
 
-/** Sunshine badge showing unread message count in the nav sidebar. */
-function MessageCountBadge({ count }: { count: number }) {
+function FriendsSkeleton() {
   return (
-    <span
-      style={{
-        background: "var(--nf-sunshine)",
-        color: "var(--nf-midnight)",
-        padding: "1px 7px",
-        borderRadius: 999,
-        fontFamily: "var(--nf-font-mono)",
-        fontSize: 9,
-        fontWeight: 700,
-        lineHeight: 1.6,
-      }}
-    >
-      {count}
-    </span>
+    <>
+      <Box mt="lg" mb="xs" px={2}>
+        <Skeleton height={10} width="60%" radius="sm" />
+      </Box>
+      <Stack gap={6}>
+        {[0, 1, 2].map((i) => (
+          <Group key={i} gap="xs" px={4} py={4}>
+            <Skeleton circle height={28} width={28} style={{ flexShrink: 0 }} />
+            <Box style={{ flex: 1, minWidth: 0 }}>
+              <Skeleton height={10} mb={4} radius="sm" />
+              <Skeleton height={8} width="60%" radius="sm" />
+            </Box>
+          </Group>
+        ))}
+      </Stack>
+    </>
   );
 }

--- a/client/src/Theme.tsx
+++ b/client/src/Theme.tsx
@@ -52,6 +52,24 @@ const sunshine: MantineColorsTuple = [
   "#665104",
 ];
 
+/**
+ * Destructive actions. Previously spelled `color="crimson"`, which is not a
+ * Mantine palette entry — it fell through to the CSS named colour and so had no
+ * hover, light or outline variants.
+ */
+const crimson: MantineColorsTuple = [
+  "#FFF0F0",
+  "#FFD8D8",
+  "#F5A9A9",
+  "#E97C7C",
+  "#DC5A5A",
+  "#D13F3F",
+  "#C92A2A",
+  "#A82121",
+  "#8A1B1B",
+  "#6B1414",
+];
+
 // Dark mode surface colors — body=#0B0A24 (void), Paper/card=#15192B
 const dark: MantineColorsTuple = [
   "#C4C0DC", // [0] light text
@@ -66,10 +84,33 @@ const dark: MantineColorsTuple = [
   "#050412", // [9]
 ];
 
+/**
+ * Semantic tones for `Alert`. One row per colour instead of three parallel
+ * lookup tables, so a tone cannot be half-defined. The tints are alpha over
+ * whatever the page background is, which reads correctly in both schemes; the
+ * title colour cannot be, so it comes from a scheme-aware token.
+ *
+ * @see [contrast.test.ts](./tests/theme/contrast.test.ts): pins every title
+ * colour against its own tint at WCAG AA.
+ */
+export const ALERT_TONES = {
+  red: { rgb: "220,38,38", title: "var(--nf-tone-red)" },
+  crimson: { rgb: "201,42,42", title: "var(--nf-tone-red)" },
+  green: { rgb: "34,197,94", title: "var(--nf-tone-green)" },
+  yellow: { rgb: "250,204,21", title: "var(--nf-tone-yellow)" },
+  royal: { rgb: "59,91,255", title: "var(--nf-tone-royal)" },
+  blue: { rgb: "59,91,255", title: "var(--nf-tone-royal)" },
+  purple: { rgb: "139,92,246", title: "var(--nf-tone-purple)" },
+} as const;
+
+const DEFAULT_ALERT_TONE = ALERT_TONES.royal;
+
 const navyfragenTheme = createTheme({
   primaryColor: "royal",
-  primaryShade: { light: 6, dark: 4 },
-  colors: { royal, purple, midnight, sunshine, dark },
+  // Flat rather than {light: 6, dark: 4}: shade 4 as a filled background puts
+  // white button labels at 3.6:1. Text keeps its own per-scheme token below.
+  primaryShade: 6,
+  colors: { royal, purple, midnight, sunshine, crimson, dark },
   white: "#FDF8FF",
   black: "#1E1B4B",
 
@@ -101,34 +142,17 @@ const navyfragenTheme = createTheme({
   components: {
     Alert: Alert.extend({
       styles: (_theme, props) => {
-        // Map semantic colors to brand-consistent translucent backgrounds.
-        // Keeps the semantic signal without clashing with the purple-dominant palette.
-        const bg: Record<string, string> = {
-          red: "rgba(220,38,38,0.09)",
-          green: "rgba(34,197,94,0.09)",
-          yellow: "rgba(250,204,21,0.09)",
-          royal: "rgba(59,91,255,0.09)",
-          blue: "rgba(59,91,255,0.09)",
-          purple: "rgba(139,92,246,0.09)",
-        };
-        const bd: Record<string, string> = {
-          red: "1px solid rgba(220,38,38,0.22)",
-          green: "1px solid rgba(34,197,94,0.22)",
-          yellow: "1px solid rgba(250,204,21,0.22)",
-          royal: "1px solid rgba(59,91,255,0.22)",
-          blue: "1px solid rgba(59,91,255,0.22)",
-          purple: "1px solid rgba(139,92,246,0.22)",
-        };
-        const c = (props.color as string | undefined) ?? "royal";
+        const tone = ALERT_TONES[props.color as keyof typeof ALERT_TONES] ?? DEFAULT_ALERT_TONE;
         return {
           root: {
-            borderRadius: 12,
-            background: bg[c] ?? bg.royal,
-            border: bd[c] ?? bd.royal,
+            borderRadius: "var(--nf-radius-control)",
+            background: `rgba(${tone.rgb},0.09)`,
+            border: `1px solid rgba(${tone.rgb},0.22)`,
           },
           title: {
-            fontFamily: "Inter, sans-serif",
+            fontFamily: "var(--nf-font-sans)",
             fontWeight: 700,
+            color: tone.title,
           },
         };
       },
@@ -136,22 +160,10 @@ const navyfragenTheme = createTheme({
 
     Notification: Notification.extend({
       styles: {
-        root: { borderRadius: 12 },
-        title: { fontFamily: "Inter, sans-serif", fontWeight: 700 },
+        root: { borderRadius: "var(--nf-radius-control)" },
+        title: { fontFamily: "var(--nf-font-sans)", fontWeight: 700 },
       },
     }),
-  },
-
-  other: {
-    gradHero: "linear-gradient(135deg, #3B5BFF 0%, #8B5CF6 55%, #C4B5FD 100%)",
-    gradMark: "linear-gradient(135deg, #3349E0 0%, #6B3FD4 55%, #4F1FA6 100%)",
-    gradDark: "linear-gradient(135deg, #1E1B4B 0%, #3B2E78 50%, #6B3FD4 100%)",
-    paper2: "#F2EBFF",
-    lavender: "#C4B5FD",
-    ease: "cubic-bezier(.2,.7,.2,1)",
-    durFast: "120ms",
-    durBase: "200ms",
-    durSlow: "360ms",
   },
 });
 

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -1,32 +1,26 @@
 import {
   ActionIcon,
-  Avatar,
   Box,
   Burger,
   Button,
   Flex,
   Group,
   Loader,
-  Menu,
-  Text,
   useComputedColorScheme,
   useMantineColorScheme,
 } from "@mantine/core";
-import { showNotification } from "@mantine/notifications";
-import { IconCheck, IconLogout, IconMoon, IconPlus, IconSun, IconUser } from "@tabler/icons-react";
+import { IconMoon, IconSun } from "@tabler/icons-react";
 import React from "react";
 import { Link } from "react-router";
 import { useHaptic } from "use-haptic";
 
-import { ApiError } from "../api/apiClient";
-import { type AccountEntry, useLogout, useSession, useSwitchAccount } from "../api/authService";
-import { buildAccountSwitchUrl } from "../lib/accountSwitchToast";
+import { useLogout, useSession } from "../api/authService";
 import { useHasBounceGap } from "../lib/useHasBounceGap";
-import { surfaceBg } from "../styles/tokens";
+import { BRAND_GRADIENT, surface, textDefault } from "../styles/tokens";
 
 import { useBounceLogos } from "./BounceLogosContext";
+import { UserMenu } from "./header/UserMenu";
 import { UpdateAvailableButton } from "./UpdateAvailableButton";
-import { WinkMark } from "./WinkMark";
 import { Wordmark } from "./Wordmark";
 
 interface AppHeaderProps {
@@ -36,22 +30,29 @@ interface AppHeaderProps {
   onNavClose: () => void;
 }
 
+const chipStyle = { background: surface, color: textDefault, border: "none" };
+
 export function AppHeader({ opened, onBurgerToggle, burgerRef, onNavClose }: AppHeaderProps) {
   const { data: sessionData, isLoading } = useSession();
   const { mutate: logout } = useLogout();
-  const { toggleColorScheme } = useMantineColorScheme();
   const { enabled: bounceLogosEnabled, setEnabled: setBounceLogosEnabled } = useBounceLogos();
   const hasBounceGap = useHasBounceGap();
   const { triggerHaptic } = useHaptic(1);
-  const computedColorScheme = useComputedColorScheme("light", {
-    getInitialValueInEffect: true,
-  });
 
-  const isDark = computedColorScheme === "dark";
   const isLoggedIn = !!sessionData?.isLoggedIn;
   const userProfile = sessionData?.profile;
-  const accounts = sessionData?.accounts ?? [];
-  const activeDid = sessionData?.did ?? undefined;
+
+  const handleLogout = () => {
+    try {
+      document.body.style.pointerEvents = "none";
+      document.body.style.opacity = "0.5";
+      logout();
+    } catch {
+      document.body.style.pointerEvents = "";
+      document.body.style.opacity = "";
+    }
+    onNavClose();
+  };
 
   return (
     <Group h="100%" px="md">
@@ -68,11 +69,7 @@ export function AppHeader({ opened, onBurgerToggle, burgerRef, onNavClose }: App
       <Box
         component={Link}
         to="/"
-        style={{
-          textDecoration: "none",
-          display: "flex",
-          alignItems: "center",
-        }}
+        style={{ textDecoration: "none", display: "flex", alignItems: "center" }}
       >
         <Wordmark size={18} />
       </Box>
@@ -89,52 +86,22 @@ export function AppHeader({ opened, onBurgerToggle, burgerRef, onNavClose }: App
             variant="default"
             size="xs"
             radius="xl"
-            style={{
-              background: surfaceBg(isDark),
-              color: "var(--mantine-color-text)",
-              border: "none",
-            }}
+            style={chipStyle}
           >
             {bounceLogosEnabled ? "Disable animations" : "Enable animations"}
           </Button>
         )}
 
-        <ActionIcon
-          onClick={() => {
-            triggerHaptic();
-            toggleColorScheme();
-          }}
-          aria-label="Toggle color scheme"
-          size={36}
-          radius="xl"
-          variant="transparent"
-          style={{
-            background: surfaceBg(isDark),
-            color: "var(--mantine-color-text)",
-          }}
-        >
-          {isDark ? <IconSun size={18} /> : <IconMoon size={18} />}
-        </ActionIcon>
+        <ColorSchemeToggle />
 
         {isLoading ? (
           <Loader size="sm" />
         ) : isLoggedIn && userProfile ? (
           <UserMenu
             userProfile={userProfile}
-            accounts={accounts}
-            activeDid={activeDid}
-            isDark={isDark}
-            onLogout={() => {
-              try {
-                document.body.style.pointerEvents = "none";
-                document.body.style.opacity = "0.5";
-                logout();
-              } catch {
-                document.body.style.pointerEvents = "";
-                document.body.style.opacity = "";
-              }
-              onNavClose();
-            }}
+            accounts={sessionData?.accounts ?? []}
+            activeDid={sessionData?.did ?? undefined}
+            onLogout={handleLogout}
             onNavigate={onNavClose}
           />
         ) : (
@@ -142,7 +109,7 @@ export function AppHeader({ opened, onBurgerToggle, burgerRef, onNavClose }: App
             component={Link}
             to="/login"
             variant="gradient"
-            gradient={{ from: "royal", to: "purple", deg: 135 }}
+            gradient={BRAND_GRADIENT}
             size="xs"
             onClick={() => {
               triggerHaptic();
@@ -157,179 +124,24 @@ export function AppHeader({ opened, onBurgerToggle, burgerRef, onNavClose }: App
   );
 }
 
-interface UserMenuProps {
-  userProfile: {
-    avatar?: string | null;
-    displayName?: string | null;
-    handle?: string;
-  };
-  accounts: AccountEntry[];
-  activeDid?: string;
-  isDark: boolean;
-  onLogout: () => void;
-  onNavigate: () => void;
-}
-
-function UserMenu({
-  userProfile,
-  accounts,
-  activeDid,
-  isDark,
-  onLogout,
-  onNavigate,
-}: UserMenuProps) {
+function ColorSchemeToggle() {
+  const { toggleColorScheme } = useMantineColorScheme();
   const { triggerHaptic } = useHaptic(1);
-  const { mutate: switchAccount, isPending: isSwitching } = useSwitchAccount();
-  const hasMultiple = accounts.length > 1; // gates the "Accounts" label only
-
-  const handleSwitch = (did: string, handle: string) => {
-    /* istanbul ignore if */
-    if (did === activeDid || isSwitching) return;
-    triggerHaptic();
-
-    /* istanbul ignore next */
-    try {
-      document.body.style.pointerEvents = "none";
-      document.body.style.opacity = "0.5";
-    } catch {
-      document.body.style.pointerEvents = "";
-      document.body.style.opacity = "";
-    }
-
-    switchAccount(
-      { did },
-      {
-        onSuccess: () => {
-          window.location.href = buildAccountSwitchUrl(handle);
-        },
-        onError: (err: ApiError) => {
-          showNotification({
-            title: "Couldn't switch account",
-            message: err.error || "Please try again.",
-            color: "red",
-          });
-        },
-      }
-    );
-  };
+  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
 
   return (
-    <Menu
-      shadow="md"
-      width={260}
-      position="bottom-end"
-      middlewares={{ shift: true, flip: true }}
-      styles={{
-        item: { padding: "10px 14px", fontSize: "var(--mantine-font-size-sm)" },
-        itemLabel: { overflow: "hidden" },
+    <ActionIcon
+      onClick={() => {
+        triggerHaptic();
+        toggleColorScheme();
       }}
+      aria-label="Toggle color scheme"
+      size={36}
+      radius="xl"
+      variant="transparent"
+      style={chipStyle}
     >
-      <Menu.Target>
-        <Button
-          onClick={triggerHaptic}
-          variant="transparent"
-          px={8}
-          radius="xl"
-          style={{
-            background: surfaceBg(isDark),
-            height: 36,
-            color: "var(--mantine-color-text)",
-          }}
-        >
-          <Group gap="xs">
-            <Avatar
-              size={28}
-              src={userProfile.avatar || undefined}
-              alt={userProfile.displayName || "User Avatar"}
-              radius="xl"
-            >
-              <WinkMark size={22} sparkle={false} aria-hidden />
-            </Avatar>
-            <Box visibleFrom="sm">
-              <Text size="sm" fw={600} truncate maw={120}>
-                {userProfile.displayName}
-              </Text>
-            </Box>
-          </Group>
-        </Button>
-      </Menu.Target>
-
-      <Menu.Dropdown>
-        {/* Account switcher — the active profile row always renders above
-            "Add account", even when only one account is signed in. The
-            "Accounts" label is shown only when there are other switchable
-            accounts to list beneath the current one. */}
-        {accounts.length > 0 && (
-          <>
-            {hasMultiple && <Menu.Label>Accounts</Menu.Label>}
-            {accounts.map((acct) => {
-              const isActive = acct.did === activeDid;
-              const label = acct.displayName || acct.handle || acct.did;
-              return (
-                <Menu.Item
-                  key={acct.did}
-                  disabled={isActive || isSwitching}
-                  onClick={() => handleSwitch(acct.did, acct.handle || acct.did)}
-                  leftSection={
-                    <Avatar size={20} src={acct.avatar || undefined} radius="xl">
-                      {(acct.handle || "?").charAt(0).toUpperCase()}
-                    </Avatar>
-                  }
-                  rightSection={isActive ? <IconCheck size={14} stroke={2.5} /> : undefined}
-                >
-                  <Box style={{ minWidth: 0, flex: 1, overflow: "hidden" }}>
-                    <Text size="sm" fw={500} truncate>
-                      {label}
-                    </Text>
-                    {acct.handle && (
-                      <Text size="xs" c="dimmed" truncate>
-                        @{acct.handle}
-                      </Text>
-                    )}
-                  </Box>
-                </Menu.Item>
-              );
-            })}
-            <Menu.Divider />
-          </>
-        )}
-
-        <Menu.Item
-          component={Link}
-          to="/login?add=1"
-          onClick={() => {
-            triggerHaptic();
-            onNavigate();
-          }}
-          leftSection={<IconPlus size="1.2rem" stroke={1.5} />}
-        >
-          Add account
-        </Menu.Item>
-
-        <Menu.Divider />
-
-        <Menu.Item
-          component={Link}
-          to={`/profile/${userProfile.handle}`}
-          onClick={() => {
-            triggerHaptic();
-            onNavigate();
-          }}
-          leftSection={<IconUser size="1.2rem" stroke={1.5} />}
-        >
-          View Profile
-        </Menu.Item>
-
-        <Menu.Item
-          onClick={() => {
-            triggerHaptic();
-            onLogout();
-          }}
-          leftSection={<IconLogout size="1.2rem" stroke={1.5} />}
-        >
-          {`Log out @${userProfile.handle}`}
-        </Menu.Item>
-      </Menu.Dropdown>
-    </Menu>
+      {isDark ? <IconSun size={18} /> : <IconMoon size={18} />}
+    </ActionIcon>
   );
 }

--- a/client/src/components/AuthPanel.styles.ts
+++ b/client/src/components/AuthPanel.styles.ts
@@ -1,0 +1,26 @@
+import type { CSSProperties } from "react";
+
+import { surface, surfaceGlow } from "../styles/tokens";
+
+export const panel: CSSProperties = {
+  background: surface,
+  position: "relative",
+  overflow: "hidden",
+};
+
+export const glow: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  background: surfaceGlow,
+  pointerEvents: "none",
+};
+
+export const content: CSSProperties = {
+  position: "relative",
+};
+
+/** Drop shadow under the mark at the top of an auth panel. */
+export const mark: CSSProperties = {
+  borderRadius: 16,
+  boxShadow: "0 12px 30px -10px rgba(20,18,58,0.4)",
+};

--- a/client/src/components/AuthPanel.tsx
+++ b/client/src/components/AuthPanel.tsx
@@ -1,0 +1,18 @@
+import { Box, Paper, Stack } from "@mantine/core";
+
+import * as styles from "./AuthPanel.styles";
+
+/**
+ * The bordered card with a brand halo behind it, shared by the login form and
+ * the OAuth callback so the redirect round trip does not visibly change surface.
+ */
+export function AuthPanel({ children }: { children: React.ReactNode }) {
+  return (
+    <Paper radius="lg" p="xl" withBorder style={styles.panel}>
+      <Box style={styles.glow} />
+      <Stack gap="md" style={styles.content}>
+        {children}
+      </Stack>
+    </Paper>
+  );
+}

--- a/client/src/components/ConfirmationModal.tsx
+++ b/client/src/components/ConfirmationModal.tsx
@@ -8,6 +8,8 @@ interface ConfirmationModalProps {
   message: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  /** Colours the confirm button as a destructive action rather than a primary one. */
+  destructive?: boolean;
   loading?: boolean;
 }
 
@@ -19,6 +21,7 @@ export function ConfirmationModal({
   message,
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
+  destructive = false,
   loading = false,
 }: ConfirmationModalProps) {
   return (
@@ -28,13 +31,7 @@ export function ConfirmationModal({
         <Button variant="default" onClick={onClose} disabled={loading}>
           {cancelLabel}
         </Button>
-        <Button
-          color="blue"
-          onClick={() => {
-            onConfirm();
-          }}
-          loading={loading}
-        >
+        <Button color={destructive ? "crimson" : "royal"} onClick={onConfirm} loading={loading}>
           {confirmLabel}
         </Button>
       </Group>

--- a/client/src/components/SettingsCard.styles.ts
+++ b/client/src/components/SettingsCard.styles.ts
@@ -1,0 +1,19 @@
+import type { CSSProperties } from "react";
+
+import { surface } from "../styles/tokens";
+
+export const card: CSSProperties = {
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  borderRadius: 14,
+  padding: 20,
+  background: surface,
+};
+
+/** Grows so every card in a row ends its action at the same baseline. */
+export const description: CSSProperties = {
+  lineHeight: 1.5,
+  flexGrow: 1,
+  marginBottom: 16,
+};

--- a/client/src/components/SettingsCard.tsx
+++ b/client/src/components/SettingsCard.tsx
@@ -1,32 +1,21 @@
 import { Paper, Text } from "@mantine/core";
 
-import { surfaceBg } from "../styles/tokens";
+import * as styles from "./SettingsCard.styles";
 
 interface SettingsCardProps {
   title: string;
   description: string;
-  isDark: boolean;
   children: React.ReactNode;
 }
 
 /** Owns the card surface; pass the action (button/switch/select) as children. */
-export function SettingsCard({ title, description, isDark, children }: SettingsCardProps) {
+export function SettingsCard({ title, description, children }: SettingsCardProps) {
   return (
-    <Paper
-      withBorder
-      style={{
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        borderRadius: 14,
-        padding: 20,
-        background: surfaceBg(isDark),
-      }}
-    >
+    <Paper withBorder style={styles.card}>
       <Text fw={700} fz={18} mb={10}>
         {title}
       </Text>
-      <Text c="dimmed" fz={13} style={{ lineHeight: 1.5, flexGrow: 1, marginBottom: 16 }}>
+      <Text c="dimmed" fz={13} style={styles.description}>
         {description}
       </Text>
       {children}

--- a/client/src/components/ShareButton.tsx
+++ b/client/src/components/ShareButton.tsx
@@ -4,6 +4,19 @@ import { IconShare } from "@tabler/icons-react";
 import React from "react";
 import { useHaptic } from "use-haptic";
 
+import { onGrad, onGradBorder, onGradFill } from "../styles/tokens";
+
+/**
+ * Chrome for a button that sits directly on a brand gradient — a translucent
+ * wash of the gradient's own foreground rather than a surface colour, which
+ * would fight it. Exported because the inbox hero pairs Copy with this Share.
+ */
+export const onGradientButton = {
+  background: onGradFill,
+  border: `1px solid ${onGradBorder}`,
+  "--button-color": onGrad,
+} as React.CSSProperties;
+
 interface ShareButtonProps {
   shareData: {
     title?: string;
@@ -62,13 +75,7 @@ const ShareButton = ({ shareData, onSuccess, onError }: ShareButtonProps) => {
       radius="xl"
       variant="transparent"
       leftSection={<IconShare size={14} />}
-      style={
-        {
-          background: "rgba(255,255,255,0.15)",
-          border: "1px solid rgba(255,255,255,0.2)",
-          "--button-color": "var(--mantine-white)",
-        } as React.CSSProperties
-      }
+      style={onGradientButton}
     >
       Share
     </Button>

--- a/client/src/components/ShortcutList.styles.ts
+++ b/client/src/components/ShortcutList.styles.ts
@@ -1,0 +1,17 @@
+import type { CSSProperties } from "react";
+
+import { textDimmed } from "../styles/tokens";
+
+/** Small-caps section label rather than a display heading. */
+export const heading: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: textDimmed,
+  marginBottom: "var(--mantine-spacing-sm)",
+};
+
+export const row: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: 12,
+};

--- a/client/src/components/ShortcutList.tsx
+++ b/client/src/components/ShortcutList.tsx
@@ -1,0 +1,39 @@
+import { Box, Stack, Text, Title } from "@mantine/core";
+
+import * as styles from "./ShortcutList.styles";
+
+export interface Shortcut {
+  label: string;
+  /** Written with the literal "Alt"; the ⌘ alternative is rendered in. */
+  hint: string;
+}
+
+interface ShortcutListProps {
+  title: string;
+  shortcuts: Shortcut[];
+}
+
+/**
+ * Keyboard-shortcut reference. Shared by the home page and the Messages image
+ * theme panel, which previously kept two copies that disagreed on type sizes and
+ * on whether the modifier read "Alt/Cmd" or "Alt/⌘".
+ */
+export function ShortcutList({ title, shortcuts }: ShortcutListProps) {
+  return (
+    <>
+      <Title order={2} style={styles.heading}>
+        {title}
+      </Title>
+      <Stack gap={4}>
+        {shortcuts.map(({ label, hint }) => (
+          <Box key={label} style={styles.row}>
+            <Text fz={13}>{label}</Text>
+            <Text fz={12} c="dimmed">
+              {hint.replace("Alt", "Alt/⌘")}
+            </Text>
+          </Box>
+        ))}
+      </Stack>
+    </>
+  );
+}

--- a/client/src/components/SwatchButton.styles.ts
+++ b/client/src/components/SwatchButton.styles.ts
@@ -1,0 +1,27 @@
+import type { CSSProperties } from "react";
+
+import { borderColor, selectedBg, selectedBorder, textDefault } from "../styles/tokens";
+
+export const button = (selected: boolean, disabled?: boolean): CSSProperties => ({
+  background: selected ? selectedBg : "transparent",
+  border: `1.5px solid ${selected ? selectedBorder : borderColor}`,
+  borderRadius: 10,
+  padding: 8,
+  cursor: disabled ? "default" : "pointer",
+  display: "flex",
+  flexDirection: "column",
+  gap: 6,
+  flex: 1,
+  minWidth: 0,
+  transition: "border-color var(--nf-dur-fast) var(--nf-ease)",
+});
+
+export const preview: CSSProperties = {
+  aspectRatio: "4/3",
+  borderRadius: 5,
+  overflow: "hidden",
+};
+
+export const label: CSSProperties = {
+  color: textDefault,
+};

--- a/client/src/components/SwatchButton.tsx
+++ b/client/src/components/SwatchButton.tsx
@@ -1,0 +1,35 @@
+import { Text } from "@mantine/core";
+
+import * as styles from "./SwatchButton.styles";
+
+interface SwatchButtonProps {
+  /** Visible caption, and the button's accessible name. */
+  label: string;
+  selected: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  /** The preview tile: a card mockup, a gradient fill, whatever the picker shows. */
+  children: React.ReactNode;
+}
+
+/**
+ * One option in a visual picker. Shared by the image-export theme picker and the
+ * profile-card colour picker so the two agree on selection chrome, focus
+ * behaviour and how they announce themselves.
+ */
+export function SwatchButton({ label, selected, disabled, onClick, children }: SwatchButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={selected}
+      style={styles.button(selected, disabled)}
+    >
+      <div style={styles.preview}>{children}</div>
+      <Text component="span" size="xs" fw={600} ta="center" style={styles.label}>
+        {label}
+      </Text>
+    </button>
+  );
+}

--- a/client/src/components/Wordmark.tsx
+++ b/client/src/components/Wordmark.tsx
@@ -20,7 +20,7 @@ export function Wordmark({ size = 22, showMark = true }: WordmarkProps) {
       {showMark && <WinkMark size={size + 10} sparkle={false} aria-hidden />}
       <span
         style={{
-          fontFamily: "Inter, sans-serif",
+          fontFamily: "var(--nf-font-sans)",
           fontWeight: 800,
           fontSize: size,
           letterSpacing: "-0.04em",

--- a/client/src/components/customise/ProfileThemeSwatches.styles.ts
+++ b/client/src/components/customise/ProfileThemeSwatches.styles.ts
@@ -1,0 +1,12 @@
+import type { CSSProperties } from "react";
+
+export const grid: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+  gap: 10,
+};
+
+export const fill = (gradient: string): CSSProperties => ({
+  height: "100%",
+  background: gradient,
+});

--- a/client/src/components/customise/ProfileThemeSwatches.tsx
+++ b/client/src/components/customise/ProfileThemeSwatches.tsx
@@ -1,0 +1,35 @@
+import { profileCardThemes } from "../../lib/themes";
+import { SwatchButton } from "../SwatchButton";
+
+import * as styles from "./ProfileThemeSwatches.styles";
+
+const DEFAULT_THEME = "royal";
+
+interface ProfileThemeSwatchesProps {
+  value: string | null;
+  disabled: boolean;
+  onPick: (value: string) => void;
+}
+
+/**
+ * Ask-card colour picker. Same swatch chrome as the image-theme picker; the
+ * preview is a gradient fill rather than a card mockup, because the choice only
+ * affects the card's background.
+ */
+export function ProfileThemeSwatches({ value, disabled, onPick }: ProfileThemeSwatchesProps) {
+  return (
+    <div style={styles.grid}>
+      {Object.entries(profileCardThemes).map(([themeValue, theme]) => (
+        <SwatchButton
+          key={themeValue}
+          label={theme.label}
+          selected={(value ?? DEFAULT_THEME) === themeValue}
+          disabled={disabled}
+          onClick={() => onPick(themeValue)}
+        >
+          <div style={styles.fill(theme.gradient)} />
+        </SwatchButton>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/customise/SettingsSection.styles.ts
+++ b/client/src/components/customise/SettingsSection.styles.ts
@@ -1,0 +1,11 @@
+import type { CSSProperties } from "react";
+
+const SECTION_GAP = 34;
+
+export const section = (last?: boolean): CSSProperties => ({
+  marginBottom: last ? 0 : SECTION_GAP,
+});
+
+export const eyebrow: CSSProperties = {
+  letterSpacing: "0.05em",
+};

--- a/client/src/components/customise/SettingsSection.tsx
+++ b/client/src/components/customise/SettingsSection.tsx
@@ -1,0 +1,25 @@
+import { Grid, Text } from "@mantine/core";
+
+import * as styles from "./SettingsSection.styles";
+
+interface SettingsSectionProps {
+  eyebrow: string;
+  help: string;
+  last?: boolean;
+  children: React.ReactNode;
+}
+
+/** A titled band of setting cards. */
+export function SettingsSection({ eyebrow, help, last, children }: SettingsSectionProps) {
+  return (
+    <div style={styles.section(last)}>
+      <Text tt="uppercase" fw={700} fz={12} c="dimmed" style={styles.eyebrow}>
+        {eyebrow}
+      </Text>
+      <Text c="dimmed" fz={13} mb="md">
+        {help}
+      </Text>
+      <Grid style={{ gap: "var(--mantine-spacing-md)" }}>{children}</Grid>
+    </div>
+  );
+}

--- a/client/src/components/header/UserMenu.styles.ts
+++ b/client/src/components/header/UserMenu.styles.ts
@@ -1,0 +1,14 @@
+import type { CSSProperties } from "react";
+
+import { surface, textDefault } from "../../styles/tokens";
+
+export const menu = {
+  item: { padding: "10px 14px", fontSize: "var(--mantine-font-size-sm)" },
+  itemLabel: { overflow: "hidden" },
+} as const;
+
+export const trigger: CSSProperties = {
+  background: surface,
+  height: 36,
+  color: textDefault,
+};

--- a/client/src/components/header/UserMenu.tsx
+++ b/client/src/components/header/UserMenu.tsx
@@ -1,0 +1,178 @@
+import { Avatar, Box, Button, Group, Menu, Text } from "@mantine/core";
+import { showNotification } from "@mantine/notifications";
+import { IconCheck, IconLogout, IconPlus, IconUser } from "@tabler/icons-react";
+import { Link } from "react-router";
+import { useHaptic } from "use-haptic";
+
+import { ApiError } from "../../api/apiClient";
+import { type AccountEntry, useSwitchAccount } from "../../api/authService";
+import { buildAccountSwitchUrl } from "../../lib/accountSwitchToast";
+import { WinkMark } from "../WinkMark";
+
+import * as styles from "./UserMenu.styles";
+
+interface UserMenuProps {
+  userProfile: {
+    avatar?: string | null;
+    displayName?: string | null;
+    handle?: string;
+  };
+  accounts: AccountEntry[];
+  activeDid?: string;
+  onLogout: () => void;
+  onNavigate: () => void;
+}
+
+export function UserMenu({
+  userProfile,
+  accounts,
+  activeDid,
+  onLogout,
+  onNavigate,
+}: UserMenuProps) {
+  const { triggerHaptic } = useHaptic(1);
+  const { mutate: switchAccount, isPending: isSwitching } = useSwitchAccount();
+  const hasMultiple = accounts.length > 1; // gates the "Accounts" label only
+
+  const handleSwitch = (did: string, handle: string) => {
+    /* istanbul ignore if */
+    if (did === activeDid || isSwitching) return;
+    triggerHaptic();
+
+    /* istanbul ignore next */
+    try {
+      document.body.style.pointerEvents = "none";
+      document.body.style.opacity = "0.5";
+    } catch {
+      document.body.style.pointerEvents = "";
+      document.body.style.opacity = "";
+    }
+
+    switchAccount(
+      { did },
+      {
+        onSuccess: () => {
+          window.location.href = buildAccountSwitchUrl(handle);
+        },
+        onError: (err: ApiError) => {
+          showNotification({
+            title: "Couldn't switch account",
+            message: err.error || "Please try again.",
+            color: "red",
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <Menu
+      shadow="md"
+      width={260}
+      position="bottom-end"
+      middlewares={{ shift: true, flip: true }}
+      styles={styles.menu}
+    >
+      <Menu.Target>
+        <Button
+          onClick={triggerHaptic}
+          variant="transparent"
+          px={8}
+          radius="xl"
+          style={styles.trigger}
+        >
+          <Group gap="xs">
+            <Avatar
+              size={28}
+              src={userProfile.avatar || undefined}
+              alt={userProfile.displayName || "User Avatar"}
+              radius="xl"
+            >
+              <WinkMark size={22} sparkle={false} aria-hidden />
+            </Avatar>
+            <Box visibleFrom="sm">
+              <Text size="sm" fw={600} truncate maw={120}>
+                {userProfile.displayName}
+              </Text>
+            </Box>
+          </Group>
+        </Button>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        {/* The active profile row always renders above "Add account", even with
+            one account signed in. The "Accounts" label appears only when there
+            are other switchable accounts listed beneath it. */}
+        {accounts.length > 0 && (
+          <>
+            {hasMultiple && <Menu.Label>Accounts</Menu.Label>}
+            {accounts.map((acct) => {
+              const isActive = acct.did === activeDid;
+              return (
+                <Menu.Item
+                  key={acct.did}
+                  disabled={isActive || isSwitching}
+                  onClick={() => handleSwitch(acct.did, acct.handle || acct.did)}
+                  leftSection={
+                    <Avatar size={20} src={acct.avatar || undefined} radius="xl">
+                      {(acct.handle || "?").charAt(0).toUpperCase()}
+                    </Avatar>
+                  }
+                  rightSection={isActive ? <IconCheck size={14} stroke={2.5} /> : undefined}
+                >
+                  <Box style={{ minWidth: 0, flex: 1, overflow: "hidden" }}>
+                    <Text size="sm" fw={500} truncate>
+                      {acct.displayName || acct.handle || acct.did}
+                    </Text>
+                    {acct.handle && (
+                      <Text size="xs" c="dimmed" truncate>
+                        @{acct.handle}
+                      </Text>
+                    )}
+                  </Box>
+                </Menu.Item>
+              );
+            })}
+            <Menu.Divider />
+          </>
+        )}
+
+        <Menu.Item
+          component={Link}
+          to="/login?add=1"
+          onClick={() => {
+            triggerHaptic();
+            onNavigate();
+          }}
+          leftSection={<IconPlus size="1.2rem" stroke={1.5} />}
+        >
+          Add account
+        </Menu.Item>
+
+        <Menu.Divider />
+
+        <Menu.Item
+          component={Link}
+          to={`/profile/${userProfile.handle}`}
+          onClick={() => {
+            triggerHaptic();
+            onNavigate();
+          }}
+          leftSection={<IconUser size="1.2rem" stroke={1.5} />}
+        >
+          View Profile
+        </Menu.Item>
+
+        <Menu.Item
+          onClick={() => {
+            triggerHaptic();
+            onLogout();
+          }}
+          leftSection={<IconLogout size="1.2rem" stroke={1.5} />}
+        >
+          {`Log out @${userProfile.handle}`}
+        </Menu.Item>
+      </Menu.Dropdown>
+    </Menu>
+  );
+}

--- a/client/src/components/login/E2ELoginPanel.tsx
+++ b/client/src/components/login/E2ELoginPanel.tsx
@@ -1,0 +1,91 @@
+import { Alert, Box, Button, Paper, PasswordInput, Stack, Text, TextInput } from "@mantine/core";
+import { useState } from "react";
+import { useNavigate } from "react-router";
+
+import { authKeys, useE2ELogin } from "../../api/authService";
+import { queryClient } from "../../api/queryClient";
+
+/**
+ * Bypasses the OAuth redirect with an app password so Playwright can drive a
+ * real account on a private PDS. Only built when VITE_E2E_TESTING=true.
+ */
+export function E2ELoginPanel() {
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { mutate: e2eLogin, isPending } = useE2ELogin();
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    e2eLogin(
+      { identifier, password },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: authKeys.session });
+          navigate("/messages");
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onError: (err: any) => {
+          setError(err.error || "E2E login failed");
+        },
+      }
+    );
+  };
+
+  return (
+    <Box maw={480} mx="auto" mt="xl">
+      <Paper
+        radius="lg"
+        p="xl"
+        withBorder
+        style={{ borderColor: "var(--mantine-color-orange-5)", borderWidth: 2 }}
+      >
+        <Stack gap="md">
+          <Text fw={700} c="orange" size="sm">
+            E2E Test Mode - not for production use
+          </Text>
+          {error && (
+            <Alert color="red" withCloseButton onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+          <form onSubmit={onSubmit}>
+            <Stack gap="sm">
+              <TextInput
+                label="Identifier"
+                placeholder="handle.pds.example"
+                value={identifier}
+                onChange={(e) => setIdentifier(e.target.value)}
+                required
+                autoCorrect="off"
+                autoCapitalize="none"
+                spellCheck={false}
+                data-testid="e2e-identifier"
+              />
+              <PasswordInput
+                label="App Password"
+                placeholder="xxxx-xxxx-xxxx-xxxx"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                data-testid="e2e-password"
+              />
+              <Button
+                type="submit"
+                loading={isPending}
+                fullWidth
+                color="orange"
+                mt="xs"
+                data-testid="e2e-submit"
+              >
+                Sign In (E2E)
+              </Button>
+            </Stack>
+          </form>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}

--- a/client/src/components/login/HandleSuggestions.styles.ts
+++ b/client/src/components/login/HandleSuggestions.styles.ts
@@ -1,0 +1,24 @@
+import type { CSSProperties } from "react";
+
+import { surfaceHighlight } from "../../styles/tokens";
+
+/** One row's height, held constant so the form below never shifts. */
+const ROW_HEIGHT = 64;
+
+export const box: CSSProperties = {
+  background: "var(--nf-surface-ghost)",
+  overflow: "hidden",
+};
+
+export const staticRow: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  height: ROW_HEIGHT,
+};
+
+export const row = (focused: boolean): CSSProperties => ({
+  ...staticRow,
+  outline: focused ? "2px solid var(--nf-purple)" : "none",
+  outlineOffset: "-2px",
+  background: focused ? surfaceHighlight : undefined,
+});

--- a/client/src/components/login/HandleSuggestions.tsx
+++ b/client/src/components/login/HandleSuggestions.tsx
@@ -1,0 +1,136 @@
+import { Avatar, Box, Center, Group, Paper, Skeleton, Text, UnstyledButton } from "@mantine/core";
+import { useState, type RefObject } from "react";
+
+import type { BlueskyActor, HandleSearch } from "../../lib/useHandleSearch";
+
+import * as styles from "./HandleSuggestions.styles";
+
+function ActorIdentity({ actor, bold }: { actor: BlueskyActor; bold: boolean }) {
+  return (
+    <Group gap="sm" wrap="nowrap" px="sm" w="100%">
+      <Avatar src={actor.avatar ?? null} size={40} radius="xl" />
+      <Box style={{ minWidth: 0 }}>
+        <Text size="sm" fw={bold ? 600 : 500} truncate>
+          {actor.displayName || actor.handle}
+        </Text>
+        <Text size="xs" c="dimmed" truncate>
+          @{actor.handle}
+        </Text>
+      </Box>
+    </Group>
+  );
+}
+
+function SuggestionRow({
+  actor,
+  onClick,
+  buttonRef,
+  onEscape,
+}: {
+  actor: BlueskyActor;
+  onClick: () => void;
+  buttonRef: RefObject<HTMLButtonElement | null>;
+  onEscape: () => void;
+}) {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <UnstyledButton
+      ref={buttonRef}
+      onClick={onClick}
+      onFocus={(e) => setIsFocused(e.currentTarget.matches(":focus-visible"))}
+      onBlur={() => setIsFocused(false)}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === "Escape" || e.key === "ArrowUp") {
+          e.preventDefault();
+          onEscape();
+        }
+      }}
+      w="100%"
+      role="option"
+      aria-selected={false}
+      style={styles.row(isFocused)}
+    >
+      <ActorIdentity actor={actor} bold={false} />
+    </UnstyledButton>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <Box style={styles.staticRow} px="sm">
+      <Group gap="sm" wrap="nowrap" w="100%">
+        <Skeleton circle height={40} width={40} />
+        <Box style={{ flex: 1 }}>
+          <Skeleton height={12} width="55%" mb={6} />
+          <Skeleton height={10} width="38%" />
+        </Box>
+      </Group>
+    </Box>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return (
+    <Center style={styles.staticRow} aria-live="polite">
+      <Text size="xs" c="dimmed">
+        {children}
+      </Text>
+    </Center>
+  );
+}
+
+interface HandleSuggestionsProps {
+  search: HandleSearch;
+  suggestionRef: RefObject<HTMLButtonElement | null>;
+  onEscape: () => void;
+}
+
+/**
+ * The single-row typeahead under the handle input. It always occupies one row's
+ * worth of space — suggestion, skeleton or hint — so the Continue button never
+ * jumps while the user types.
+ */
+export function HandleSuggestions({ search, suggestionRef, onEscape }: HandleSuggestionsProps) {
+  const { selectedActor, isSearching, suggestions, noResults, isHandleReady, cleanHandle } = search;
+  const isListbox = !selectedActor && (suggestions.length > 0 || (noResults && isHandleReady));
+
+  return (
+    <Paper
+      radius="md"
+      withBorder
+      mt="xs"
+      role={isListbox ? "listbox" : undefined}
+      aria-label={isListbox ? "Handle suggestions" : undefined}
+      style={styles.box}
+    >
+      {selectedActor ? (
+        <Box style={styles.staticRow} px="sm">
+          <ActorIdentity actor={selectedActor} bold />
+        </Box>
+      ) : isSearching ? (
+        <SkeletonRow />
+      ) : suggestions.length > 0 ? (
+        <SuggestionRow
+          actor={suggestions[0]}
+          onClick={() => search.select(suggestions[0])}
+          buttonRef={suggestionRef}
+          onEscape={onEscape}
+        />
+      ) : noResults && isHandleReady ? (
+        // Nothing in the Bluesky index, but the handle looks complete — offer it
+        // directly so users on unindexed third-party PDSes can still proceed.
+        <SuggestionRow
+          actor={{ did: "", handle: cleanHandle }}
+          onClick={() => search.select({ did: "", handle: cleanHandle })}
+          buttonRef={suggestionRef}
+          onEscape={onEscape}
+        />
+      ) : noResults ? (
+        <Hint>No handles found</Hint>
+      ) : (
+        <Hint>Start typing to get handle suggestions</Hint>
+      )}
+    </Paper>
+  );
+}

--- a/client/src/components/messages/CharRing.tsx
+++ b/client/src/components/messages/CharRing.tsx
@@ -1,0 +1,46 @@
+const RADIUS = 9;
+const SIZE = 22;
+const CENTRE = SIZE / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+/** Fraction of the budget at which the ring switches to the warning colour. */
+const DANGER_AT = 0.9;
+
+/**
+ * Circular character-budget meter for the reply composer.
+ *
+ * Both stroke colours are the composer's own, not the brand ones: the ring is
+ * drawn on the composer's paper surface, where `--nf-sunshine` sits at 1.7:1 and
+ * the track was invisible entirely.
+ *
+ * @see [Messages.test.tsx](../../tests/pages/Messages.test.tsx): pins the switch
+ * to the warning colour past 90% of the limit.
+ */
+export function CharRing({ count, limit }: { count: number; limit: number }) {
+  const filled = Math.min(count / limit, 1);
+  const stroke = count > limit * DANGER_AT ? "var(--nf-compose-warn)" : "var(--nf-compose-accent)";
+
+  return (
+    <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} style={{ flexShrink: 0 }}>
+      <circle
+        cx={CENTRE}
+        cy={CENTRE}
+        r={RADIUS}
+        fill="none"
+        stroke="var(--nf-compose-track)"
+        strokeWidth={2.5}
+      />
+      <circle
+        cx={CENTRE}
+        cy={CENTRE}
+        r={RADIUS}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={2.5}
+        strokeDasharray={CIRCUMFERENCE}
+        strokeDashoffset={CIRCUMFERENCE - filled * CIRCUMFERENCE}
+        transform={`rotate(-90 ${CENTRE} ${CENTRE})`}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/client/src/components/messages/CollapsibleCard.styles.ts
+++ b/client/src/components/messages/CollapsibleCard.styles.ts
@@ -1,0 +1,34 @@
+import type { CSSProperties } from "react";
+
+import { border, radiusPanel, surface } from "../../styles/tokens";
+
+export const card: CSSProperties = {
+  borderRadius: radiusPanel,
+  overflow: "hidden",
+  background: surface,
+};
+
+export const header: CSSProperties = {
+  width: "100%",
+  padding: "14px 20px",
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  userSelect: "none",
+};
+
+export const summary: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+};
+
+export const chevron = (open: boolean): CSSProperties => ({
+  transition: "transform var(--nf-dur-base) var(--nf-ease)",
+  transform: open ? "rotate(180deg)" : "rotate(0deg)",
+  color: "var(--mantine-color-dimmed)",
+});
+
+export const body: CSSProperties = {
+  borderTop: border,
+};

--- a/client/src/components/messages/CollapsibleCard.tsx
+++ b/client/src/components/messages/CollapsibleCard.tsx
@@ -1,0 +1,47 @@
+import { Box, Collapse, Paper, Text, UnstyledButton } from "@mantine/core";
+import { IconChevronDown } from "@tabler/icons-react";
+import { useState } from "react";
+import { useHaptic } from "use-haptic";
+
+import * as styles from "./CollapsibleCard.styles";
+
+interface CollapsibleCardProps {
+  title: string;
+  /** Right-aligned status shown in the header, e.g. "3 of 5 on". */
+  summary: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/** Panel with a click-to-toggle header, open by default. */
+export function CollapsibleCard({ title, summary, children }: CollapsibleCardProps) {
+  const [open, setOpen] = useState(true);
+  const { triggerHaptic } = useHaptic(1);
+
+  return (
+    <Paper withBorder p={0} style={styles.card}>
+      <UnstyledButton
+        aria-expanded={open}
+        style={styles.header}
+        onClick={() => {
+          triggerHaptic();
+          setOpen((o) => !o);
+        }}
+      >
+        <Text component="span" fw={700} fz={15}>
+          {title}
+        </Text>
+        <span style={styles.summary}>
+          <Text component="span" size="xs" c="dimmed">
+            {summary}
+          </Text>
+          <IconChevronDown size={16} style={styles.chevron(open)} />
+        </span>
+      </UnstyledButton>
+      <Collapse expanded={open}>
+        <Box px="md" pb="sm" style={styles.body}>
+          {children}
+        </Box>
+      </Collapse>
+    </Paper>
+  );
+}

--- a/client/src/components/messages/ImageThemePicker.tsx
+++ b/client/src/components/messages/ImageThemePicker.tsx
@@ -1,0 +1,51 @@
+import { Box, Group } from "@mantine/core";
+
+import { themes } from "../../lib/themes";
+import { ShortcutList } from "../ShortcutList";
+import { SwatchButton } from "../SwatchButton";
+
+import { CollapsibleCard } from "./CollapsibleCard";
+import { ImageThemePreview } from "./ImageThemePreview";
+
+const DEFAULT_THEME = "default";
+
+const SHORTCUTS = [
+  { label: "Focus / cycle cards", hint: "Alt+R" },
+  { label: "Navigate cards", hint: "↑ / ↓" },
+  { label: "Close expanded card", hint: "Esc" },
+];
+
+interface ImageThemePickerProps {
+  /** Null until settings load, so the default is shown rather than nothing. */
+  selected: string | null;
+  disabled: boolean;
+  onSelect: (theme: string) => void;
+}
+
+export function ImageThemePicker({ selected, disabled, onSelect }: ImageThemePickerProps) {
+  const active = selected ?? DEFAULT_THEME;
+
+  return (
+    <CollapsibleCard title="Image theme" summary={themes[active as keyof typeof themes]}>
+      <Group grow gap="sm" mt="sm">
+        {Object.entries(themes).map(([value, label]) => (
+          <SwatchButton
+            key={value}
+            label={label}
+            selected={active === value}
+            onClick={() => {
+              if (disabled) return;
+              onSelect(value);
+            }}
+          >
+            <ImageThemePreview theme={value} />
+          </SwatchButton>
+        ))}
+      </Group>
+
+      <Box mt="md" pt="md" style={{ borderTop: "1px solid var(--mantine-color-default-border)" }}>
+        <ShortcutList title="Keyboard Shortcuts" shortcuts={SHORTCUTS} />
+      </Box>
+    </CollapsibleCard>
+  );
+}

--- a/client/src/components/messages/ImageThemePreview.styles.ts
+++ b/client/src/components/messages/ImageThemePreview.styles.ts
@@ -1,0 +1,111 @@
+import type { CSSProperties } from "react";
+
+import { gradDark } from "../../styles/tokens";
+
+/**
+ * Miniature mockups of the three image-export themes.
+ *
+ * These deliberately do NOT use app tokens beyond the gradient: they depict what
+ * the rendered PNG looks like, which is a fixed artefact that does not follow the
+ * viewer's colour scheme. Treating them as themeable UI would make the preview
+ * lie about the output.
+ */
+
+const bar = (height: number, background: string, extra?: CSSProperties): CSSProperties => ({
+  height,
+  background,
+  borderRadius: 2,
+  ...extra,
+});
+
+/* ── default: white quote card on the brand dark gradient ── */
+
+export const defaultRoot: CSSProperties = {
+  background: gradDark,
+  height: "100%",
+  borderRadius: 5,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "stretch",
+  justifyContent: "center",
+  padding: "8px 10px",
+  gap: 6,
+};
+
+export const centered: CSSProperties = { display: "flex", justifyContent: "center" };
+export const defaultHeading = bar(2.5, "rgba(255,255,255,0.7)", { width: "55%" });
+export const defaultQuote: CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  padding: "6px 10px",
+  boxShadow: "0 3px 10px rgba(0,0,0,0.3)",
+};
+export const defaultQuoteLine = bar(3.5, "#ccc", { marginBottom: 4 });
+export const defaultQuoteLineShort = bar(3.5, "#ccc", { width: "65%" });
+export const defaultFooter = bar(2, "rgba(255,255,255,0.4)", { width: "40%" });
+
+/* ── compressed: accent-ruled block on a near-black field ── */
+
+export const compressedRoot: CSSProperties = {
+  background: "#1a1a2a",
+  height: "100%",
+  borderRadius: 5,
+  display: "flex",
+  alignItems: "center",
+  padding: 8,
+};
+export const compressedBlock: CSSProperties = {
+  background: "#22223a",
+  borderLeft: "3px solid #7c3aed",
+  borderRadius: 6,
+  padding: "7px 9px",
+  width: "100%",
+};
+export const compressedTitle = bar(3, "#a78bfa", {
+  borderRadius: 3,
+  marginBottom: 5,
+  width: "45%",
+});
+export const compressedLine = bar(3, "#4a4a6a", { borderRadius: 3, marginBottom: 3 });
+export const compressedLineShort = bar(3, "#4a4a6a", {
+  borderRadius: 3,
+  width: "70%",
+  marginBottom: 5,
+});
+export const compressedMeta = bar(2.5, "#3a3a5a", { width: "45%" });
+
+/* ── twitter: light post card ── */
+
+export const twitterRoot: CSSProperties = {
+  background: "#ffffff",
+  height: "100%",
+  borderRadius: 5,
+  display: "flex",
+  alignItems: "center",
+};
+export const twitterCard: CSSProperties = {
+  background: "#fff",
+  border: "1px solid #cfd9de",
+  borderRadius: 8,
+  padding: "7px 9px",
+  width: "100%",
+};
+export const twitterHeader: CSSProperties = {
+  display: "flex",
+  gap: 5,
+  marginBottom: 5,
+  alignItems: "center",
+};
+export const twitterAvatar: CSSProperties = {
+  width: 12,
+  height: 12,
+  borderRadius: "50%",
+  background: "#1d9bf0",
+  flexShrink: 0,
+};
+export const twitterName = bar(2.5, "#333", { marginBottom: 2 });
+export const twitterHandle = bar(2.5, "#aaa", { width: "55%" });
+export const twitterLine = bar(2.5, "#ccc", { marginBottom: 3 });
+export const twitterLineShort = bar(2.5, "#ccc", { width: "75%", marginBottom: 4 });
+export const twitterRule: CSSProperties = { height: 1, background: "#eff3f4", marginBottom: 3 };
+export const twitterAction = bar(2.5, "#1d9bf0", { width: "40%" });

--- a/client/src/components/messages/ImageThemePreview.tsx
+++ b/client/src/components/messages/ImageThemePreview.tsx
@@ -1,0 +1,67 @@
+import * as s from "./ImageThemePreview.styles";
+
+/**
+ * Wireframe of what each image-export theme produces. Every dimension and colour
+ * lives in the styles module; these functions only describe the arrangement.
+ */
+
+function DefaultPreview() {
+  return (
+    <div style={s.defaultRoot}>
+      <div style={s.centered}>
+        <div style={s.defaultHeading} />
+      </div>
+      <div style={s.defaultQuote}>
+        <div style={s.defaultQuoteLine} />
+        <div style={s.defaultQuoteLineShort} />
+      </div>
+      <div style={s.centered}>
+        <div style={s.defaultFooter} />
+      </div>
+    </div>
+  );
+}
+
+function CompressedPreview() {
+  return (
+    <div style={s.compressedRoot}>
+      <div style={s.compressedBlock}>
+        <div style={s.compressedTitle} />
+        <div style={s.compressedLine} />
+        <div style={s.compressedLineShort} />
+        <div style={s.compressedMeta} />
+      </div>
+    </div>
+  );
+}
+
+function TwitterPreview() {
+  return (
+    <div style={s.twitterRoot}>
+      <div style={s.twitterCard}>
+        <div style={s.twitterHeader}>
+          <div style={s.twitterAvatar} />
+          <div style={{ flex: 1 }}>
+            <div style={s.twitterName} />
+            <div style={s.twitterHandle} />
+          </div>
+        </div>
+        <div style={s.twitterLine} />
+        <div style={s.twitterLineShort} />
+        <div style={s.twitterRule} />
+        <div style={s.twitterAction} />
+      </div>
+    </div>
+  );
+}
+
+const PREVIEWS: Record<string, () => React.JSX.Element> = {
+  default: DefaultPreview,
+  compressed: CompressedPreview,
+  twitter: TwitterPreview,
+};
+
+export function ImageThemePreview({ theme }: { theme: string }) {
+  const Preview = PREVIEWS[theme];
+  return <Preview />;
+}

--- a/client/src/components/messages/InboxLinkCard.styles.ts
+++ b/client/src/components/messages/InboxLinkCard.styles.ts
@@ -1,0 +1,18 @@
+import type { CSSProperties } from "react";
+
+import { gradMark, onGradAccent, onGradMuted, radiusCard } from "../../styles/tokens";
+
+export const card: CSSProperties = {
+  borderRadius: radiusCard,
+  background: gradMark,
+  overflow: "hidden",
+};
+
+export const eyebrow: CSSProperties = {
+  color: onGradMuted,
+};
+
+export const url: CSSProperties = {
+  color: onGradAccent,
+  wordBreak: "break-all",
+};

--- a/client/src/components/messages/InboxLinkCard.tsx
+++ b/client/src/components/messages/InboxLinkCard.tsx
@@ -1,0 +1,55 @@
+import { Box, Button, CopyButton, Group, Paper, Text, Tooltip } from "@mantine/core";
+import { IconClipboard } from "@tabler/icons-react";
+import { useHaptic } from "use-haptic";
+
+import ShareButton, { onGradientButton } from "../ShareButton";
+
+import * as styles from "./InboxLinkCard.styles";
+
+interface InboxLinkCardProps {
+  /** Display form, e.g. "fragen.navy/karan.bsky.social". */
+  shortUrl: string;
+  fullUrl: string;
+  shareData: { title: string; text: string; url: string };
+}
+
+export function InboxLinkCard({ shortUrl, fullUrl, shareData }: InboxLinkCardProps) {
+  const { triggerHaptic } = useHaptic(1);
+
+  return (
+    <Paper mb="md" p="lg" style={styles.card}>
+      <Group align="center" gap="md" wrap="wrap">
+        <Box style={{ flex: 1, minWidth: 200 }}>
+          <Text size="xs" fw={500} mb={6} style={styles.eyebrow}>
+            Your inbox link · publicly accessible
+          </Text>
+          <Text fw={700} fz={17} style={styles.url}>
+            {shortUrl}
+          </Text>
+        </Box>
+        <Group gap="xs" wrap="wrap">
+          <CopyButton value={fullUrl}>
+            {({ copied, copy }) => (
+              <Tooltip label={copied ? "Copied!" : "Copy link"} withArrow>
+                <Button
+                  onClick={() => {
+                    triggerHaptic();
+                    copy();
+                  }}
+                  size="sm"
+                  radius="xl"
+                  variant="transparent"
+                  leftSection={<IconClipboard size={14} />}
+                  style={onGradientButton}
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </Button>
+              </Tooltip>
+            )}
+          </CopyButton>
+          <ShareButton shareData={shareData} />
+        </Group>
+      </Group>
+    </Paper>
+  );
+}

--- a/client/src/components/messages/PostingPreferences.styles.ts
+++ b/client/src/components/messages/PostingPreferences.styles.ts
@@ -1,0 +1,7 @@
+import type { CSSProperties } from "react";
+
+import { border } from "../../styles/tokens";
+
+export const row: CSSProperties = {
+  borderBottom: border,
+};

--- a/client/src/components/messages/PostingPreferences.tsx
+++ b/client/src/components/messages/PostingPreferences.tsx
@@ -1,0 +1,67 @@
+import { Box, Switch, Text } from "@mantine/core";
+
+import {
+  PREFERENCE_KEYS,
+  type MessagePreferencesState,
+  type PreferenceKey,
+} from "../../lib/useMessagePreferences";
+
+import { CollapsibleCard } from "./CollapsibleCard";
+import * as styles from "./PostingPreferences.styles";
+
+const COPY: Record<PreferenceKey, { label: string; description: string }> = {
+  appendProfileLink: {
+    label: "Auto-append inbox link",
+    description: "Appends your link to every post. Reduces character budget.",
+  },
+  useGradients: {
+    label: "Gradient backgrounds",
+    description: "Pretty for screenshots. Turn off for higher contrast.",
+  },
+  includeQuestionAsImage: {
+    label: "Question as image",
+    description: "Generates a shareable image with auto alt text.",
+  },
+  confirmBeforeDelete: {
+    label: "Confirm before deleting",
+    description: "Leave off if you want to bulk-delete messages.",
+  },
+  autoScrollToMessages: {
+    label: "Auto-scroll to messages",
+    description: "Scrolls new messages into view when they load.",
+  },
+};
+
+interface PostingPreferencesProps {
+  state: MessagePreferencesState;
+}
+
+export function PostingPreferences({ state }: PostingPreferencesProps) {
+  const { preferences, setPreference, enabledCount } = state;
+
+  return (
+    <CollapsibleCard
+      title="Posting preferences"
+      summary={`${enabledCount} of ${PREFERENCE_KEYS.length} on`}
+    >
+      {PREFERENCE_KEYS.map((key) => (
+        <Box key={key} py="xs" style={styles.row}>
+          <Switch
+            checked={preferences[key]}
+            onChange={(e) => setPreference(key, e.currentTarget.checked)}
+            label={
+              <Box>
+                <Text fw={600} size="sm">
+                  {COPY[key].label}
+                </Text>
+                <Text size="xs" c="dimmed" mt={2}>
+                  {COPY[key].description}
+                </Text>
+              </Box>
+            }
+          />
+        </Box>
+      ))}
+    </CollapsibleCard>
+  );
+}

--- a/client/src/components/messages/QuestionCard.styles.ts
+++ b/client/src/components/messages/QuestionCard.styles.ts
@@ -1,0 +1,115 @@
+import type { CSSProperties } from "react";
+
+import {
+  borderColor,
+  gradMark,
+  onGrad,
+  onGradAccent,
+  onGradFaint,
+  onGradMuted,
+  radiusCard,
+  surface,
+  textDefault,
+  textDimmed,
+} from "../../styles/tokens";
+
+export interface CardState {
+  gradient: boolean;
+  pinned: boolean;
+  focused: boolean;
+}
+
+/**
+ * A question card is painted either with the brand gradient or with the ordinary
+ * card surface, and everything inside it has to follow. Rather than each Text
+ * repeating the choice — which is how the message body ended up hard-coded to
+ * white and therefore invisible on the light surface — the card publishes four
+ * `--nf-card-*` custom properties and its children read those.
+ */
+function foreground(gradient: boolean): CSSProperties {
+  return {
+    "--nf-card-fg": gradient ? onGrad : textDefault,
+    "--nf-card-fg-muted": gradient ? onGradMuted : textDimmed,
+    "--nf-card-fg-faint": gradient ? onGradFaint : textDimmed,
+    "--nf-card-accent": gradient ? onGradAccent : "var(--nf-link)",
+    "--nf-card-edge": gradient ? "rgba(255,255,255,0.10)" : borderColor,
+  } as CSSProperties;
+}
+
+function borderFor({ pinned, focused }: CardState): string {
+  if (pinned) return "2px solid var(--nf-royal)";
+  if (focused) return "2px solid var(--nf-purple)";
+  return "2px solid var(--nf-card-edge)";
+}
+
+export const card = (state: CardState): CSSProperties => ({
+  ...foreground(state.gradient),
+  borderRadius: radiusCard,
+  background: state.gradient ? gradMark : surface,
+  border: borderFor(state),
+  boxShadow: state.pinned
+    ? "0 4px 22px -4px rgba(59,91,255,0.38)"
+    : "0 4px 16px -8px rgba(0,0,0,0.3)",
+  padding: "8px 20px 20px",
+  transition:
+    "border-color var(--nf-dur-fast) var(--nf-ease), box-shadow var(--nf-dur-fast) var(--nf-ease)",
+  cursor: "pointer",
+  display: "flex",
+  flexDirection: "column",
+});
+
+export const timestamp: CSSProperties = {
+  color: "var(--nf-card-fg-muted)",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+};
+
+export const iconButton = (active: boolean): CSSProperties => ({
+  color: active ? "var(--nf-royal)" : "var(--nf-card-fg-muted)",
+  transition:
+    "color var(--nf-dur-fast) var(--nf-ease), background var(--nf-dur-fast) var(--nf-ease)",
+});
+
+export const disabledIconButton: CSSProperties = {
+  color: "var(--nf-card-fg-faint)",
+  cursor: "not-allowed",
+};
+
+export const bodyWrap: CSSProperties = {
+  flex: 1,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+export const body: CSSProperties = {
+  color: "var(--nf-card-fg)",
+  fontSize: 20,
+  lineHeight: 1.35,
+  wordBreak: "break-word",
+  whiteSpace: "pre-wrap",
+  textAlign: "center",
+  textWrap: "balance",
+  width: "100%",
+};
+
+export const threadLink: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  color: "var(--nf-card-accent)",
+  textDecoration: "none",
+  fontSize: 11,
+};
+
+export const threadLinkText: CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+export const replyButton = (blocked: boolean): CSSProperties => ({
+  color: "var(--nf-midnight)",
+  opacity: blocked ? 0.45 : 1,
+  cursor: blocked ? "not-allowed" : undefined,
+});

--- a/client/src/components/messages/QuestionCard.tsx
+++ b/client/src/components/messages/QuestionCard.tsx
@@ -1,0 +1,183 @@
+import { ActionIcon, Box, Button, Group, Paper, Stack, Text, Tooltip } from "@mantine/core";
+import { IconExternalLink, IconPin, IconPinned, IconTrash } from "@tabler/icons-react";
+import { useHaptic } from "use-haptic";
+
+import type { Message } from "../../api/messageService";
+import { formatTimestamp } from "../../lib/formatTimestamp";
+import type { ThreadLink } from "../../lib/useThreadRoot";
+import { sunshineButton } from "../../styles/tokens";
+
+import * as styles from "./QuestionCard.styles";
+
+interface QuestionCardProps {
+  message: Message;
+  gradient: boolean;
+  pinned: boolean;
+  focused: boolean;
+  expanded: boolean;
+  justPinned: boolean;
+  deleting: boolean;
+  /** True while an unanswered thread root is holding this reply back. */
+  blocked: boolean;
+  /** A reply here would chain onto a pinned root rather than post standalone. */
+  inThread: boolean;
+  /** The Bluesky post this card's answer started, once it has one. */
+  threadLink?: ThreadLink;
+  onFocus: () => void;
+  onToggleExpanded: () => void;
+  onTogglePin: () => void;
+  onDelete: () => void;
+  cardRef: (el: HTMLDivElement | null) => void;
+  /** The composer, rendered by the grid so it can own the draft text. */
+  composer: React.ReactNode;
+}
+
+export function QuestionCard({
+  message,
+  gradient,
+  pinned,
+  focused,
+  expanded,
+  justPinned,
+  deleting,
+  blocked,
+  inThread,
+  threadLink,
+  onFocus,
+  onToggleExpanded,
+  onTogglePin,
+  onDelete,
+  cardRef,
+  composer,
+}: QuestionCardProps) {
+  const { triggerHaptic } = useHaptic(1);
+
+  return (
+    <Paper
+      id={`message-card-${message.tid}`}
+      ref={cardRef}
+      tabIndex={0}
+      role="button"
+      aria-expanded={expanded}
+      radius="lg"
+      onFocus={onFocus}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onToggleExpanded();
+        }
+      }}
+      className={justPinned ? "nf-pinned-card-enter" : undefined}
+      style={styles.card({ gradient, pinned, focused })}
+      onClick={() => {
+        triggerHaptic();
+        onToggleExpanded();
+      }}
+    >
+      <Stack gap="sm" style={{ flex: 1 }}>
+        <Group justify="space-between" align="center">
+          <Text fz={10} style={styles.timestamp}>
+            {formatTimestamp(message.createdAt)}
+          </Text>
+          <Group gap={2} align="center">
+            <Tooltip
+              label={pinned ? "Unpin thread" : "Pin as thread root"}
+              withArrow
+              position="left"
+              openDelay={500}
+            >
+              <ActionIcon
+                size="lg"
+                className={pinned ? "nf-pin-btn--active" : "nf-pin-btn"}
+                aria-label={pinned ? "Unpin thread root" : "Set as thread root"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onTogglePin();
+                }}
+                variant="transparent"
+                radius="md"
+                style={styles.iconButton(pinned)}
+              >
+                {pinned ? <IconPinned size={18} /> : <IconPin size={18} />}
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip
+              label={pinned ? "Unpin thread first" : "Delete message"}
+              withArrow
+              position="left"
+              openDelay={500}
+            >
+              <ActionIcon
+                size="lg"
+                className={pinned ? undefined : "nf-delete-btn"}
+                aria-label={pinned ? "Cannot delete thread root" : "Delete message"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (pinned) return;
+                  triggerHaptic();
+                  onDelete();
+                }}
+                variant="transparent"
+                radius="md"
+                loading={deleting}
+                style={pinned ? styles.disabledIconButton : styles.iconButton(false)}
+              >
+                <IconTrash size={18} />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
+        </Group>
+
+        <Box style={styles.bodyWrap}>
+          <Text fw={600} style={styles.body}>
+            {message.message}
+          </Text>
+        </Box>
+
+        {threadLink?.link && (
+          <Box>
+            <a
+              href={threadLink.link}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              style={styles.threadLink}
+            >
+              <IconExternalLink size={11} style={{ flexShrink: 0 }} />
+              <span style={styles.threadLinkText}>{threadLink.link.replace("https://", "")}</span>
+            </a>
+          </Box>
+        )}
+
+        {expanded ? (
+          composer
+        ) : (
+          <Box mt={4} onClick={(e) => e.stopPropagation()}>
+            <Tooltip
+              label="Respond to the thread root first"
+              disabled={!blocked}
+              withArrow
+              openDelay={300}
+            >
+              <Button
+                onClick={() => {
+                  if (blocked) return;
+                  triggerHaptic();
+                  onToggleExpanded();
+                }}
+                fullWidth
+                radius="md"
+                color="sunshine"
+                variant="filled"
+                fw={700}
+                style={{ ...sunshineButton, ...styles.replyButton(blocked) }}
+              >
+                {inThread ? "↩ Reply to thread" : "↩ Reply"}
+              </Button>
+            </Tooltip>
+          </Box>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/client/src/components/messages/QuestionGrid.tsx
+++ b/client/src/components/messages/QuestionGrid.tsx
@@ -1,0 +1,146 @@
+import { SimpleGrid } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+
+import type { Message } from "../../api/messageService";
+import { useCardKeyboardNav } from "../../lib/useCardKeyboardNav";
+import type { ThreadRoot } from "../../lib/useThreadRoot";
+
+import { QuestionCard } from "./QuestionCard";
+import { ReplyComposer } from "./ReplyComposer";
+
+/** Long enough for the composer's expansion to settle before we scroll to it. */
+const EXPAND_SCROLL_DELAY_MS = 150;
+
+interface QuestionGridProps {
+  messages: Message[];
+  thread: ThreadRoot;
+  gradient: boolean;
+  /** Which card has its composer open. Owned by the page, which also closes it. */
+  respondingTid: string | null;
+  onExpand: (tid: string) => void;
+  onCollapse: () => void;
+  responseText: string;
+  onResponseTextChange: (text: string) => void;
+  /** Character budget for a reply to this message, net of link and quote text. */
+  characterLimitFor: (message: Message) => number;
+  onSend: (message: Message, response: string) => void;
+  sending: boolean;
+  deletingTid: string | null;
+  onDelete: (tid: string) => void;
+  onTogglePin: (tid: string) => void;
+}
+
+/**
+ * The question grid, and the roving focus that walks it. Card contents are
+ * QuestionCard's problem; this owns only which card is focused and the effects
+ * that follow from expanding one.
+ */
+export function QuestionGrid({
+  messages,
+  thread,
+  gradient,
+  respondingTid,
+  onExpand,
+  onCollapse,
+  responseText,
+  onResponseTextChange,
+  characterLimitFor,
+  onSend,
+  sending,
+  deletingTid,
+  onDelete,
+  onTogglePin,
+}: QuestionGridProps) {
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const expandedIndex = messages.findIndex((m) => m.tid === respondingTid);
+
+  useCardKeyboardNav({
+    count: messages.length,
+    focusedIndex,
+    setFocusedIndex,
+    expandedIndex,
+    onCollapse,
+    cardRefs,
+  });
+
+  useEffect(() => {
+    cardRefs.current = messages.map(() => null);
+  }, [messages]);
+
+  // Deferred so the scroll lands after the composer's expansion reflows the
+  // grid; the cleanup stops a stale timer scrolling a card from a prior
+  // interaction.
+  useEffect(() => {
+    if (!respondingTid) return;
+    textareaRef.current?.focus();
+    const card = document.getElementById(`message-card-${respondingTid}`);
+    const handle = setTimeout(
+      /* istanbul ignore next */
+      () => card?.scrollIntoView({ behavior: "smooth", block: "nearest" }),
+      EXPAND_SCROLL_DELAY_MS
+    );
+    return () => clearTimeout(handle);
+  }, [respondingTid]);
+
+  return (
+    <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+      {messages.map((message, index) => {
+        const pinned = thread.isRoot(message.tid);
+        const expanded = respondingTid === message.tid;
+        const blocked = thread.isReplyBlocked(message.tid);
+        const inThread = !pinned && thread.rootTid !== null;
+
+        const toggleExpanded = () => {
+          if (expanded) {
+            onCollapse();
+            return;
+          }
+          setFocusedIndex(index);
+          onExpand(message.tid);
+        };
+
+        return (
+          <QuestionCard
+            key={message.tid}
+            message={message}
+            gradient={gradient}
+            pinned={pinned}
+            focused={focusedIndex === index}
+            expanded={expanded}
+            justPinned={thread.justPinnedTid === message.tid}
+            deleting={deletingTid === message.tid}
+            blocked={blocked}
+            inThread={inThread}
+            threadLink={pinned ? thread.linkFor(message.tid) : undefined}
+            onFocus={() => setFocusedIndex(index)}
+            onToggleExpanded={toggleExpanded}
+            onTogglePin={() => onTogglePin(message.tid)}
+            onDelete={() => onDelete(message.tid)}
+            cardRef={(el) => {
+              cardRefs.current[index] = el;
+            }}
+            composer={
+              <ReplyComposer
+                value={responseText}
+                onChange={onResponseTextChange}
+                characterLimit={characterLimitFor(message)}
+                onSend={() => onSend(message, responseText)}
+                onCancel={() => {
+                  onCollapse();
+                  cardRefs.current[index]?.focus();
+                }}
+                sending={sending}
+                blocked={blocked}
+                inThread={inThread}
+                textareaRef={textareaRef}
+              />
+            }
+          />
+        );
+      })}
+    </SimpleGrid>
+  );
+}

--- a/client/src/components/messages/ReplyComposer.styles.ts
+++ b/client/src/components/messages/ReplyComposer.styles.ts
@@ -1,0 +1,26 @@
+import type { CSSProperties } from "react";
+
+export const panel: CSSProperties = {
+  marginTop: 4,
+  background: "var(--nf-compose-bg)",
+  borderRadius: "var(--nf-radius-control)",
+  padding: 12,
+  border: "1.5px solid var(--nf-compose-border)",
+};
+
+export const textarea = {
+  input: {
+    background: "transparent",
+    color: "var(--nf-compose-fg)",
+    border: "none",
+    padding: 0,
+  },
+} as const;
+
+/**
+ * Not `c="dimmed"`: the page's dimmed colour is tuned for the page background
+ * and lands at 2.6:1 on the composer's paper in dark mode.
+ */
+export const count: CSSProperties = {
+  color: "var(--nf-compose-fg-muted)",
+};

--- a/client/src/components/messages/ReplyComposer.tsx
+++ b/client/src/components/messages/ReplyComposer.tsx
@@ -1,0 +1,92 @@
+import { Box, Button, Group, Text, Textarea, Tooltip } from "@mantine/core";
+import { IconSend2 } from "@tabler/icons-react";
+import { useHaptic } from "use-haptic";
+
+import { BRAND_GRADIENT } from "../../styles/tokens";
+
+import { CharRing } from "./CharRing";
+import * as styles from "./ReplyComposer.styles";
+
+interface ReplyComposerProps {
+  value: string;
+  onChange: (value: string) => void;
+  characterLimit: number;
+  onSend: () => void;
+  onCancel: () => void;
+  sending: boolean;
+  /** True while an unanswered thread root is holding this reply back. */
+  blocked: boolean;
+  /** Whether sending will chain onto an existing thread rather than post fresh. */
+  inThread: boolean;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+export function ReplyComposer({
+  value,
+  onChange,
+  characterLimit,
+  onSend,
+  onCancel,
+  sending,
+  blocked,
+  inThread,
+  textareaRef,
+}: ReplyComposerProps) {
+  const { triggerHaptic } = useHaptic(1);
+
+  return (
+    <Box onClick={(e) => e.stopPropagation()} style={styles.panel}>
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        maxLength={characterLimit}
+        onChange={(e) => onChange(e.target.value)}
+        autosize
+        minRows={2}
+        maxRows={4}
+        aria-label="Your response"
+        onKeyDown={(e) => {
+          e.stopPropagation();
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          } else if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            onSend();
+          }
+        }}
+        placeholder="write your reply…"
+        styles={styles.textarea}
+      />
+      <Group justify="space-between" align="center" mt={8}>
+        <Group gap={8} align="center">
+          <CharRing count={value.length} limit={characterLimit} />
+          <Text size="xs" style={styles.count}>
+            {value.length}/{characterLimit}
+          </Text>
+        </Group>
+        <Tooltip
+          label="Respond to the thread root first"
+          disabled={!blocked}
+          withArrow
+          openDelay={300}
+        >
+          <Button
+            size="xs"
+            onClick={() => {
+              triggerHaptic();
+              onSend();
+            }}
+            loading={sending}
+            disabled={blocked}
+            variant="gradient"
+            gradient={BRAND_GRADIENT}
+            leftSection={<IconSend2 size={12} />}
+          >
+            {inThread ? "Reply to thread" : "Reply"}
+          </Button>
+        </Tooltip>
+      </Group>
+    </Box>
+  );
+}

--- a/client/src/components/nav/FriendSection.styles.ts
+++ b/client/src/components/nav/FriendSection.styles.ts
@@ -1,0 +1,29 @@
+import type { CSSProperties } from "react";
+
+/** Sticky so the group label stays put while its list scrolls under it. */
+export const header: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 4,
+  width: "100%",
+  cursor: "pointer",
+  position: "sticky",
+  top: 0,
+  zIndex: 1,
+  background: "var(--mantine-color-body)",
+  paddingTop: "var(--mantine-spacing-lg)",
+};
+
+export const chevron = (open: boolean): CSSProperties => ({
+  color: "var(--mantine-color-dimmed)",
+  transition: "transform var(--nf-dur-fast) var(--nf-ease)",
+  transform: open ? "rotate(0deg)" : "rotate(-90deg)",
+  flexShrink: 0,
+});
+
+export const friendLink = {
+  root: {
+    borderRadius: 10,
+    transition: "background var(--nf-dur-fast) var(--nf-ease)",
+  },
+} as const;

--- a/client/src/components/nav/FriendSection.tsx
+++ b/client/src/components/nav/FriendSection.tsx
@@ -1,0 +1,94 @@
+import { Avatar, Box, Collapse, Group, NavLink, Text, UnstyledButton } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconChevronDown } from "@tabler/icons-react";
+import { Link } from "react-router";
+import { useHaptic } from "use-haptic";
+
+import type { Friend } from "../../api/profileService";
+import { isSectionOpen, setSectionOpen } from "../../lib/navSectionStorage";
+import { WinkMark } from "../WinkMark";
+
+import * as styles from "./FriendSection.styles";
+
+interface FriendSectionProps {
+  label: string;
+  friends: Friend[];
+  emptyText: string;
+  onLinkClick: () => void;
+  /** The signed-in account; the collapsed/expanded choice is stored per DID. */
+  did: string;
+}
+
+/** One collapsible group of Navyfragen users in the sidebar. */
+export function FriendSection({ label, friends, emptyText, onLinkClick, did }: FriendSectionProps) {
+  const [opened, { toggle }] = useDisclosure(isSectionOpen(label, did));
+  const { triggerHaptic } = useHaptic(1);
+
+  return (
+    <>
+      <UnstyledButton
+        onClick={() => {
+          triggerHaptic();
+          setSectionOpen(label, !opened, did);
+          toggle();
+        }}
+        mb="xs"
+        px={2}
+        aria-expanded={opened}
+        aria-label={`${label} — ${opened ? "collapse" : "expand"}`}
+        style={styles.header}
+      >
+        <Text size="xs" fw={600} c="dimmed" style={{ flex: 1 }}>
+          {label}
+        </Text>
+        <IconChevronDown size={12} style={styles.chevron(opened)} />
+      </UnstyledButton>
+
+      <Collapse expanded={opened}>
+        {friends.length > 0 ? (
+          <Box style={{ overflowX: "hidden" }}>
+            {friends.map((friend) => (
+              <NavLink
+                key={friend.did}
+                label={<FriendIdentity friend={friend} />}
+                component={Link}
+                to={`/profile/${friend.handle}`}
+                onClick={onLinkClick}
+                py={4}
+                styles={styles.friendLink}
+              />
+            ))}
+          </Box>
+        ) : (
+          <Text size="xs" c="dimmed" px={2} style={{ lineHeight: 1.6 }}>
+            {emptyText}
+          </Text>
+        )}
+      </Collapse>
+    </>
+  );
+}
+
+function FriendIdentity({ friend }: { friend: Friend }) {
+  return (
+    <Group gap={10} wrap="nowrap" style={{ overflow: "hidden", width: "100%" }}>
+      <Avatar
+        size={28}
+        radius="xl"
+        src={friend.avatar || undefined}
+        alt={friend.displayName || friend.handle}
+        style={{ flexShrink: 0 }}
+      >
+        <WinkMark size={22} sparkle={false} aria-hidden />
+      </Avatar>
+      <Box style={{ flex: 1, minWidth: 0 }}>
+        <Text fz={13} fw={600} truncate style={{ lineHeight: 1.3 }}>
+          {friend.displayName || friend.handle}
+        </Text>
+        <Text fz={10} c="dimmed" truncate style={{ lineHeight: 1.3 }}>
+          @{friend.handle}
+        </Text>
+      </Box>
+    </Group>
+  );
+}

--- a/client/src/components/nav/MessageCountBadge.styles.ts
+++ b/client/src/components/nav/MessageCountBadge.styles.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from "react";
+
+import { fontMono, radiusPill } from "../../styles/tokens";
+
+/** Sunshine fill demands the dark brand ink; white on it is 1.5:1. */
+export const badge: CSSProperties = {
+  background: "var(--nf-sunshine)",
+  color: "var(--nf-midnight)",
+  padding: "1px 7px",
+  borderRadius: radiusPill,
+  fontFamily: fontMono,
+  fontSize: 9,
+  fontWeight: 700,
+  lineHeight: 1.6,
+};

--- a/client/src/components/nav/MessageCountBadge.tsx
+++ b/client/src/components/nav/MessageCountBadge.tsx
@@ -1,0 +1,10 @@
+import * as styles from "./MessageCountBadge.styles";
+
+/** Unread count beside the Messages link. */
+export function MessageCountBadge({ count }: { count: number }) {
+  return (
+    <span style={styles.badge} aria-label={`${count} unread`}>
+      {count}
+    </span>
+  );
+}

--- a/client/src/components/profile/AskCard.styles.ts
+++ b/client/src/components/profile/AskCard.styles.ts
@@ -1,0 +1,45 @@
+import type { CSSProperties } from "react";
+
+import { borderColor, onGrad, onGradMuted, radiusCard } from "../../styles/tokens";
+
+export const card = (gradient: string): CSSProperties => ({
+  borderRadius: radiusCard,
+  padding: 28,
+  background: gradient,
+  border: `2px solid ${borderColor}`,
+  cursor: "text",
+  position: "relative",
+  overflow: "hidden",
+});
+
+export const headline: CSSProperties = {
+  color: onGrad,
+  letterSpacing: "-0.01em",
+};
+
+/** The input is a paper affordance on the gradient, same as the reply composer. */
+export const textarea = {
+  input: {
+    backgroundColor: "var(--nf-compose-bg)",
+    color: "var(--nf-compose-fg)",
+    border: "none",
+  },
+  description: {
+    color: onGradMuted,
+    textAlign: "right" as const,
+  },
+} as const;
+
+/** Red-on-gradient rather than the page's alert tint, which the card would swallow. */
+export const errorAlert = {
+  root: {
+    background: "rgba(220,38,38,0.18)",
+    border: "1px solid rgba(220,38,38,0.35)",
+  },
+  message: { color: "#FCA5A5" },
+  closeButton: { color: "#FCA5A5" },
+} as const;
+
+export const closedNotice: CSSProperties = {
+  color: onGradMuted,
+};

--- a/client/src/components/profile/AskCard.tsx
+++ b/client/src/components/profile/AskCard.tsx
@@ -1,0 +1,125 @@
+import { ActionIcon, Alert, Button, Group, Paper, Stack, Text, Textarea } from "@mantine/core";
+import { IconSend, IconX } from "@tabler/icons-react";
+import { useHaptic } from "use-haptic";
+
+import type { TouchpointTranslations } from "../../lib/touchpointTranslations";
+import { sunshineButton } from "../../styles/tokens";
+
+import * as styles from "./AskCard.styles";
+
+interface AskCardProps {
+  gradient: string;
+  headline: string;
+  maxLength: number;
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  sending: boolean;
+  /** False when the owner has closed their inbox; the composer is replaced. */
+  open: boolean;
+  error: string | null;
+  onDismissError: () => void;
+  translations: TouchpointTranslations;
+  cardRef: React.RefObject<HTMLDivElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+/** The anonymous-question composer: a brand-gradient card with a paper input. */
+export function AskCard({
+  gradient,
+  headline,
+  maxLength,
+  value,
+  onChange,
+  onSend,
+  sending,
+  open,
+  error,
+  onDismissError,
+  translations,
+  cardRef,
+  textareaRef,
+}: AskCardProps) {
+  const { triggerHaptic } = useHaptic(1);
+
+  return (
+    <Paper ref={cardRef} onClick={() => textareaRef.current?.focus()} style={styles.card(gradient)}>
+      <Text fw={700} mb="lg" ta="center" fz={22} style={styles.headline}>
+        {headline}
+      </Text>
+
+      <Stack gap="xs">
+        {error && (
+          <Alert
+            color="red"
+            withCloseButton
+            onClose={onDismissError}
+            role="alert"
+            styles={styles.errorAlert}
+          >
+            {error}
+          </Alert>
+        )}
+        {open ? (
+          <>
+            <Textarea
+              ref={textareaRef}
+              value={value}
+              onChange={(e) => onChange(e.target.value.slice(0, maxLength))}
+              minRows={2}
+              maxRows={4}
+              autosize
+              disabled={sending}
+              aria-label={headline}
+              placeholder={translations.placeholder}
+              description={`${value.length}/${maxLength}`}
+              onKeyDown={(e) => {
+                if (e.key !== "Enter") return;
+                if (e.shiftKey || e.altKey || e.metaKey) return;
+                e.preventDefault();
+                onSend();
+              }}
+              radius="md"
+              styles={styles.textarea}
+            />
+            <Group justify="flex-end" gap="xs">
+              <ActionIcon
+                onClick={(e) => {
+                  e.stopPropagation();
+                  triggerHaptic();
+                  onChange("");
+                }}
+                variant="subtle"
+                color="white"
+                size="lg"
+                radius="md"
+                aria-label="Clear message"
+              >
+                <IconX size={18} />
+              </ActionIcon>
+              <Button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  triggerHaptic();
+                  onSend();
+                }}
+                loading={sending}
+                radius="md"
+                leftSection={<IconSend size={16} />}
+                color="sunshine"
+                variant="filled"
+                style={sunshineButton}
+              >
+                {translations.sendLabel}
+              </Button>
+            </Group>
+          </>
+        ) : (
+          <Text ta="center" fz={15} style={styles.closedNotice}>
+            {translations.inboxClosed}
+          </Text>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/client/src/components/profile/ProfileCard.styles.ts
+++ b/client/src/components/profile/ProfileCard.styles.ts
@@ -1,0 +1,54 @@
+import type { CSSProperties } from "react";
+
+import { borderColor, gradMark, radiusPanel, surfaceGhost, textDefault } from "../../styles/tokens";
+
+const BANNER_HEIGHT = 160;
+const AVATAR_SIZE = 84;
+
+export const card: CSSProperties = {
+  borderRadius: radiusPanel,
+  overflow: "hidden",
+};
+
+export const banner = (url?: string): CSSProperties => ({
+  height: BANNER_HEIGHT,
+  background: url ? `url(${url}) center/cover no-repeat` : gradMark,
+  position: "relative",
+});
+
+/** Darkens an arbitrary user banner so the avatar's ring stays visible on it. */
+export const bannerScrim: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  background: "rgba(0,0,0,0.2)",
+};
+
+export const body: CSSProperties = {
+  padding: "0 24px 18px",
+  position: "relative",
+  background: surfaceGhost,
+};
+
+export const avatar: CSSProperties = {
+  border: "4px solid var(--mantine-color-body)",
+  position: "absolute",
+  top: -AVATAR_SIZE / 2,
+  left: 16,
+};
+
+export const displayName: CSSProperties = {
+  letterSpacing: "-0.02em",
+  lineHeight: 1.1,
+};
+
+export const blueskyLink: CSSProperties = {
+  flexShrink: 0,
+  borderColor,
+  color: textDefault,
+};
+
+export const description: CSSProperties = {
+  lineHeight: 1.5,
+  wordBreak: "break-word",
+  whiteSpace: "pre-wrap",
+};

--- a/client/src/components/profile/ProfileCard.tsx
+++ b/client/src/components/profile/ProfileCard.tsx
@@ -1,0 +1,68 @@
+import { Avatar, Box, Button, Group, Paper, Text } from "@mantine/core";
+import { IconExternalLink } from "@tabler/icons-react";
+
+import { parseRichText } from "../../utils/parseRichText";
+import { WinkMark } from "../WinkMark";
+
+import * as styles from "./ProfileCard.styles";
+
+export interface ProfileSummary {
+  handle?: string;
+  displayName?: string;
+  description?: string;
+  avatar?: string;
+  banner?: string;
+}
+
+/** Bluesky-style banner + avatar + bio header for the profile being viewed. */
+export function ProfileCard({ profile }: { profile: ProfileSummary }) {
+  return (
+    <Paper mb="lg" withBorder style={styles.card}>
+      <Box style={styles.banner(profile.banner)}>
+        {profile.banner && <Box style={styles.bannerScrim} />}
+      </Box>
+
+      <Box style={styles.body}>
+        <Avatar
+          src={profile.avatar}
+          alt={profile.displayName || profile.handle || "User"}
+          size={84}
+          radius="xl"
+          style={styles.avatar}
+        >
+          <WinkMark size={60} sparkle={false} aria-hidden />
+        </Avatar>
+
+        <Group justify="space-between" align="flex-start" pt={48}>
+          <Box>
+            <Text fw={800} fz={24} style={styles.displayName}>
+              {profile.displayName}
+            </Text>
+            <Text c="dimmed" mt={2} fz={13}>
+              @{profile.handle}
+            </Text>
+          </Box>
+          <Button
+            component="a"
+            href={`https://bsky.app/profile/${profile.handle}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="outline"
+            size="xs"
+            radius="md"
+            style={styles.blueskyLink}
+            leftSection={<IconExternalLink size={12} />}
+          >
+            View on Bluesky
+          </Button>
+        </Group>
+
+        {profile.description && (
+          <Text mt="sm" fz={14} style={styles.description}>
+            {parseRichText(profile.description)}
+          </Text>
+        )}
+      </Box>
+    </Paper>
+  );
+}

--- a/client/src/components/profile/ProfileNotice.tsx
+++ b/client/src/components/profile/ProfileNotice.tsx
@@ -1,0 +1,23 @@
+import { Alert, Container } from "@mantine/core";
+
+interface ProfileNoticeProps {
+  tone: "yellow" | "red";
+  title: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Terminal state for a profile that cannot be shown — bad handle, no Bluesky
+ * account, no Navyfragen inbox, load failure. One shape for all four, and an
+ * `Alert` rather than a bare `Paper` so the title picks up the tone colours the
+ * theme already tunes for contrast.
+ */
+export function ProfileNotice({ tone, title, children }: ProfileNoticeProps) {
+  return (
+    <Container>
+      <Alert color={tone} title={title} withCloseButton={false}>
+        {children}
+      </Alert>
+    </Container>
+  );
+}

--- a/client/src/components/profile/ProfileSkeleton.styles.ts
+++ b/client/src/components/profile/ProfileSkeleton.styles.ts
@@ -1,0 +1,13 @@
+import type { CSSProperties } from "react";
+
+import { gradMark } from "../../styles/tokens";
+
+import { card } from "./AskCard.styles";
+
+export const body: CSSProperties = {
+  padding: "0 24px 18px",
+  position: "relative",
+};
+
+/** Same geometry as the real ask card, on the default brand gradient. */
+export const askCard: CSSProperties = card(gradMark);

--- a/client/src/components/profile/ProfileSkeleton.tsx
+++ b/client/src/components/profile/ProfileSkeleton.tsx
@@ -1,0 +1,38 @@
+import { Box, Container, Group, Paper, Skeleton } from "@mantine/core";
+
+import * as cardStyles from "./ProfileCard.styles";
+import * as styles from "./ProfileSkeleton.styles";
+
+/** Placeholder matching the loaded profile's geometry, so nothing jumps. */
+export function ProfileSkeleton() {
+  return (
+    <Container>
+      <Skeleton height={28} width={180} radius={999} mb="sm" />
+
+      <Paper mb="lg" withBorder style={cardStyles.card}>
+        <Skeleton height={160} radius={0} />
+        <Box style={styles.body}>
+          <Skeleton circle height={84} width={84} style={cardStyles.avatar} />
+          <Group justify="space-between" align="flex-start" pt={52}>
+            <Box>
+              <Skeleton height={28} width={180} mb={6} />
+              <Skeleton height={14} width={120} />
+            </Box>
+            <Skeleton height={28} width={130} radius={999} />
+          </Group>
+          <Skeleton height={14} mt="sm" />
+          <Skeleton height={14} mt={6} width="75%" />
+        </Box>
+      </Paper>
+
+      <Paper style={styles.askCard}>
+        <Skeleton height={26} width="70%" mx="auto" mb="lg" />
+        <Skeleton height={80} radius="md" mb="xs" />
+        <Group justify="flex-end" gap="xs">
+          <Skeleton height={36} width={36} radius="md" />
+          <Skeleton height={36} width={90} radius={999} />
+        </Group>
+      </Paper>
+    </Container>
+  );
+}

--- a/client/src/components/profile/ProfileUrlBar.styles.ts
+++ b/client/src/components/profile/ProfileUrlBar.styles.ts
@@ -1,0 +1,34 @@
+import type { CSSProperties } from "react";
+
+import {
+  border,
+  fontMono,
+  radiusPill,
+  surfaceGhost,
+  textDefault,
+  textDimmed,
+} from "../../styles/tokens";
+
+export const pill: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  background: surfaceGhost,
+  border,
+  padding: "6px 12px 6px 10px",
+  borderRadius: radiusPill,
+  fontFamily: fontMono,
+  fontSize: 12,
+  color: textDimmed,
+};
+
+export const pillHandle: CSSProperties = {
+  color: textDefault,
+  fontWeight: 600,
+};
+
+export const action: CSSProperties = {
+  background: surfaceGhost,
+  border,
+  color: textDimmed,
+};

--- a/client/src/components/profile/ProfileUrlBar.tsx
+++ b/client/src/components/profile/ProfileUrlBar.tsx
@@ -1,0 +1,78 @@
+import { ActionIcon, Box, CopyButton, Group, Text, Tooltip } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { IconClipboard, IconShare, IconWorld } from "@tabler/icons-react";
+import { useHaptic } from "use-haptic";
+
+import * as styles from "./ProfileUrlBar.styles";
+
+interface ProfileUrlBarProps {
+  handle: string;
+  url: string;
+  shareTitle: string;
+}
+
+/** The "fragen.navy/<handle>" pill, with copy and native-share affordances. */
+export function ProfileUrlBar({ handle, url, shareTitle }: ProfileUrlBarProps) {
+  const { triggerHaptic } = useHaptic(1);
+
+  const share = async () => {
+    triggerHaptic();
+    try {
+      await navigator.share({ title: shareTitle, url });
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      notifications.show({
+        color: "red",
+        title: "Share failed",
+        message: "Could not share link.",
+      });
+    }
+  };
+
+  return (
+    <Group justify="space-between" align="center" mb="sm">
+      <Box component="span" style={styles.pill}>
+        <IconWorld size={12} />
+        fragen.navy/
+        <Text component="span" inherit style={styles.pillHandle}>
+          {handle}
+        </Text>
+      </Box>
+
+      <Group gap="xs">
+        <CopyButton value={url}>
+          {({ copied, copy }) => (
+            <Tooltip label={copied ? "Copied!" : "Copy link"} withArrow>
+              <ActionIcon
+                onClick={() => {
+                  triggerHaptic();
+                  copy();
+                }}
+                variant="subtle"
+                radius="xl"
+                size="md"
+                aria-label="Copy profile link"
+                style={styles.action}
+              >
+                <IconClipboard size={14} />
+              </ActionIcon>
+            </Tooltip>
+          )}
+        </CopyButton>
+
+        {"share" in navigator && (
+          <ActionIcon
+            onClick={share}
+            variant="subtle"
+            radius="xl"
+            size="md"
+            aria-label="Share profile link"
+            style={styles.action}
+          >
+            <IconShare size={14} />
+          </ActionIcon>
+        )}
+      </Group>
+    </Group>
+  );
+}

--- a/client/src/components/settings/AccountOverview.styles.ts
+++ b/client/src/components/settings/AccountOverview.styles.ts
@@ -1,0 +1,16 @@
+import type { CSSProperties } from "react";
+
+import { accentText, surface } from "../../styles/tokens";
+
+export const panel: CSSProperties = {
+  borderRadius: 14,
+  padding: 24,
+  background: surface,
+};
+
+export const value = (fontSize: number): CSSProperties => ({
+  fontSize,
+  color: accentText,
+  letterSpacing: "-0.02em",
+  lineHeight: 1.1,
+});

--- a/client/src/components/settings/AccountOverview.tsx
+++ b/client/src/components/settings/AccountOverview.tsx
@@ -1,0 +1,51 @@
+import { Paper, SimpleGrid, Skeleton, Stack, Text } from "@mantine/core";
+
+import * as styles from "./AccountOverview.styles";
+
+/** Deliberately unequal, to create visual hierarchy. */
+const SIZE = { large: 32, medium: 22, small: 13 } as const;
+
+export interface Stat {
+  value: string | number;
+  label: string;
+  size: keyof typeof SIZE;
+  truncate?: boolean;
+}
+
+interface AccountOverviewProps {
+  loading: boolean;
+  stats: Stat[];
+}
+
+export function AccountOverview({ loading, stats }: AccountOverviewProps) {
+  return (
+    <Paper withBorder style={styles.panel}>
+      <Text fw={700} fz={18} mb={18}>
+        Account Overview
+      </Text>
+      {loading ? (
+        <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="xl">
+          {stats.map((stat) => (
+            <Stack key={stat.label} gap={4}>
+              <Skeleton height={28} width="60%" radius="sm" />
+              <Skeleton height={12} width="80%" radius="sm" />
+            </Stack>
+          ))}
+        </SimpleGrid>
+      ) : (
+        <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="xl" style={{ alignItems: "flex-end" }}>
+          {stats.map((stat) => (
+            <Stack key={stat.label} gap={2} style={stat.truncate ? { minWidth: 0 } : undefined}>
+              <Text fw={800} truncate={stat.truncate} style={styles.value(SIZE[stat.size])}>
+                {stat.value}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {stat.label}
+              </Text>
+            </Stack>
+          ))}
+        </SimpleGrid>
+      )}
+    </Paper>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -74,8 +74,8 @@ body {
   width: 1400px;
   max-width: 100vw;
   pointer-events: none;
-  border-left: 1px solid var(--nf-app-boundary-border);
-  border-right: 1px solid var(--nf-app-boundary-border);
+  border-left: 1px solid var(--nf-boundary-border);
+  border-right: 1px solid var(--nf-boundary-border);
   z-index: 200;
 }
 
@@ -102,95 +102,222 @@ body {
   }
 }
 
-/* Brand CSS tokens */
+/* ══════════════════════════════════════════════════════════════════════════
+   DESIGN TOKENS
+
+   Three layers, and components may only read from the third:
+
+   1. Brand primitives — the raw palette and gradients. Scheme-independent.
+      Nothing outside this file should reference them directly; they exist so
+      the semantic layer has a single place to read a hue from.
+   2. Semantic tokens — named for the job rather than the colour (`--nf-surface`,
+      not `--nf-lavender-ish`). Light values live on `:root` and dark values
+      override them under [data-mantine-color-scheme="dark"], so a component
+      writes `var(--nf-surface)` once and both schemes follow. This is why no
+      component needs `useComputedColorScheme` to pick a background.
+   3. On-gradient tokens — the one family that is deliberately scheme-independent,
+      because the brand gradients are dark in both schemes, so text painted on
+      one has a single correct colour either way.
+
+   Contrast is not a matter of taste here: src/tests/theme/contrast.test.ts
+   parses this file and fails the build if any documented text/background pair
+   drops below WCAG AA.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Layer 1: brand primitives ── */
 :root {
   --nf-midnight: #1e1b4b;
   --nf-royal: #3b5bff;
+  --nf-royal-deep: #2a47e6;
   --nf-purple: #8b5cf6;
+  --nf-purple-deep: #7847e0;
   --nf-lavender: #c4b5fd;
   --nf-paper: #fdf8ff;
-  --nf-paper-2: #f2ebff;
   --nf-sunshine: #facc15;
-  --nf-void: #0b0a24;
-  --nf-surface-d: #15192b;
-  --nf-text-muted: #5b5680;
-  --nf-border: #e6ddff;
-  --nf-grad-hero: linear-gradient(135deg, #3b5bff 0%, #6626fc 55%, #491bff 100%);
+  --nf-crimson: #c92a2a;
+
   --nf-grad-mark: linear-gradient(135deg, #3349e0 0%, #5322c5 55%, #4f1fa6 100%);
   --nf-grad-dark: linear-gradient(135deg, #1e1b4b 0%, #3b2e78 50%, #6b3fd4 100%);
-  /* Curated ask-card colour presets (#275). All keep white headline/textarea
-     legible. royal reuses --nf-grad-mark (the pre-existing default). */
-  --nf-grad-aurora: linear-gradient(135deg, #2563eb 0%, #0ea5e9 55%, #06b6d4 100%);
-  --nf-grad-ember: linear-gradient(135deg, #ea580c 0%, #db2777 55%, #be185d 100%);
-  --nf-grad-verdant: linear-gradient(135deg, #0d9488 0%, #10b981 55%, #059669 100%);
+
+  /* Curated ask-card colour presets (#275). Every stop is dark enough that the
+     white headline / Send button clear AA across the whole ramp — the earlier
+     mid-tone cyan, emerald and orange stops did not. */
+  --nf-grad-aurora: linear-gradient(135deg, #1d4ed8 0%, #0369a1 55%, #0e7490 100%);
+  --nf-grad-ember: linear-gradient(135deg, #c2410c 0%, #be123c 55%, #9f1239 100%);
+  --nf-grad-verdant: linear-gradient(135deg, #0f766e 0%, #047857 55%, #065f46 100%);
+
   --nf-font-sans: "Inter", system-ui, sans-serif;
+  --nf-font-mono: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace;
+
   --nf-ease: cubic-bezier(0.2, 0.7, 0.2, 1);
   --nf-dur-fast: 120ms;
   --nf-dur-base: 200ms;
 
-  /* Nav active state — default (dark mode) */
-  --nf-nav-active-bg: rgba(107, 63, 212, 0.22);
-  --nf-nav-active-color: #fdf8ff;
-  --nf-nav-active-shadow: none;
-
-  /* App boundary divider — stronger than --nf-border since it sits between
-     two areas of identical background (no bg contrast to lean on) */
-  --nf-app-boundary-border: rgba(255, 255, 255, 0.14);
+  --nf-radius-card: 18px;
+  --nf-radius-panel: 16px;
+  --nf-radius-control: 12px;
+  --nf-radius-pill: 999px;
 }
 
-/* ── Light mode: white cards on cream page background ── */
-[data-mantine-color-scheme="light"] {
-  --mantine-color-body: #fdf8ff;
-  --mantine-color-default: #ffffff;
-  --mantine-color-default-border: #e6ddff;
+/* ── Layer 2: semantic tokens — light ── */
+:root {
+  /* Card sitting on the page background, and the barely-there step above it. */
+  --nf-surface: #f2ebff;
+  --nf-surface-ghost: #faf7ff;
+  /* Halo behind the login / OAuth panels. */
+  --nf-surface-glow: radial-gradient(
+    ellipse 60% 100% at 50% 0%,
+    rgba(196, 181, 253, 0.4),
+    transparent 70%
+  );
+  /* Keyboard-focus wash on a suggestion row. */
+  --nf-surface-highlight: rgba(51, 73, 224, 0.08);
 
-  /* Nav active state — light mode: subtle tint with dark text for accessibility */
+  --nf-link: var(--nf-purple-deep);
+  --nf-accent-text: var(--nf-royal-deep);
+
   --nf-nav-active-bg: #ede9ff;
-  --nf-nav-active-color: #1e1b4b;
-  --nf-nav-active-shadow: none;
+  --nf-nav-active-color: var(--nf-midnight);
 
-  --nf-app-boundary-border: rgba(30, 27, 75, 0.14);
+  /* Sits between two areas of identical background, so it needs to read
+     stronger than an ordinary card border. */
+  --nf-boundary-border: rgba(30, 27, 75, 0.14);
+
+  --nf-danger-fg: var(--nf-crimson);
+  --nf-danger-bg: rgba(201, 42, 42, 0.12);
+  --nf-selected-bg: rgba(59, 91, 255, 0.12);
+  --nf-selected-border: var(--nf-royal);
+
+  /* Alert title colours. The alert's own background is an alpha tint of the
+     tone, so these are read against a very pale wash and have to be far darker
+     than the tone itself. */
+  --nf-tone-red: #b02525;
+  --nf-tone-green: #166534;
+  --nf-tone-yellow: #7a6105;
+  --nf-tone-royal: #2a47e6;
+  --nf-tone-purple: #522ba3;
+
+  /* Fallbacks for the card-local foreground pair below. A question card
+     overrides both on its own root; anything using the classes outside one still
+     gets readable text rather than an unresolved var. */
+  --nf-card-fg: var(--mantine-color-text);
+  --nf-card-fg-muted: var(--mantine-color-dimmed);
+  --nf-card-fg-faint: var(--mantine-color-dimmed);
+  --nf-card-accent: var(--nf-link);
+  --nf-card-edge: var(--mantine-color-default-border);
 }
 
-/* ── Dark mode ── */
-[data-mantine-color-scheme="dark"] {
-  --nf-bg: #0b0a24;
-  --nf-surface: #15192b;
-  --nf-surface-subtle: #1a1f35;
-  --nf-text: var(--nf-paper);
-  --nf-text-muted: rgba(253, 248, 255, 0.55);
-  --nf-border: rgba(255, 255, 255, 0.06);
+/* ── Layer 2: semantic tokens — dark ── */
+:root[data-mantine-color-scheme="dark"] {
+  --nf-surface: rgba(255, 255, 255, 0.06);
+  --nf-surface-ghost: rgba(255, 255, 255, 0.03);
+  --nf-surface-glow: radial-gradient(
+    ellipse 60% 100% at 50% 0%,
+    rgba(139, 92, 246, 0.15),
+    transparent 70%
+  );
+  --nf-surface-highlight: rgba(107, 63, 212, 0.2);
 
-  /* Mantine card/border overrides for dark mode */
+  --nf-link: var(--nf-lavender);
+  --nf-accent-text: var(--nf-lavender);
+
+  --nf-nav-active-bg: rgba(107, 63, 212, 0.22);
+  --nf-nav-active-color: var(--nf-paper);
+
+  --nf-boundary-border: rgba(255, 255, 255, 0.14);
+
+  --nf-danger-fg: #fca5a5;
+  --nf-danger-bg: rgba(220, 38, 38, 0.18);
+  --nf-selected-bg: rgba(59, 91, 255, 0.18);
+  --nf-selected-border: #6178ff;
+
+  --nf-tone-red: #ff8787;
+  --nf-tone-green: #69db7c;
+  --nf-tone-yellow: #ffe57a;
+  --nf-tone-royal: #849bff;
+  --nf-tone-purple: #ac8afd;
+}
+
+/* ── Mantine bridges ── */
+/* Scoped to `:root[…]` rather than the bare attribute so these match the
+   specificity of Mantine's own scheme blocks; at (0,1,0) they were being
+   outranked and silently doing nothing. Only variables Mantine does not
+   re-emit at runtime can be set here — `--mantine-color-body` comes from
+   `theme.white` / `dark[7]` instead, and brand text uses the `--nf-*` tokens
+   above rather than fighting the provider's `-text` variables. */
+:root[data-mantine-color-scheme="light"] {
+  --mantine-color-default-border: #e6ddff;
+  /* Mantine's default (gray-6) reads 2.9:1 on --nf-surface, which had every
+     card description in the app below AA. */
+  --mantine-color-dimmed: #5b5680;
+}
+
+:root[data-mantine-color-scheme="dark"] {
   --mantine-color-default-border: rgba(255, 255, 255, 0.08);
-
-  /* Promo card — dark mode */
-  --nf-promo-bg: rgba(139, 92, 246, 0.1);
-  --nf-promo-border: rgba(139, 92, 246, 0.25);
+  --mantine-color-dimmed: #8b87b5;
 }
 
-/* Delete button hover */
+/* ── Layer 3: on-gradient tokens ── */
+/* The brand gradients are dark in both schemes, so these do not flip. -muted is
+   the lightest alpha that still clears AA over the lightest gradient stop;
+   -faint is for rules and progress tracks only, never text. */
+:root {
+  --nf-on-grad: var(--nf-paper);
+  --nf-on-grad-muted: rgba(253, 248, 255, 0.85);
+  --nf-on-grad-accent: #e9ddff;
+  --nf-on-grad-faint: rgba(253, 248, 255, 0.4);
+  --nf-on-grad-fill: rgba(253, 248, 255, 0.15);
+  --nf-on-grad-border: rgba(253, 248, 255, 0.25);
+}
+
+/* ── Reply composer ── */
+/* The composer is a paper affordance: it stays light on top of whichever card
+   surface it lands on, in both schemes, because it stands for the post being
+   written rather than for the app around it. Its accents therefore have to be
+   read against white, not against the page. */
+:root {
+  --nf-compose-bg: #ffffff;
+  --nf-compose-fg: var(--nf-midnight);
+  --nf-compose-fg-muted: #5b5680;
+  --nf-compose-border: var(--nf-royal);
+  --nf-compose-accent: var(--nf-royal);
+  --nf-compose-warn: #8f7206;
+  --nf-compose-track: rgba(30, 27, 75, 0.15);
+}
+
+/* ── Card-local foreground ── */
+/* A question card is painted either with a brand gradient or with the ordinary
+   surface, and its contents have to follow. The card sets these two on its own
+   root (see QuestionCard.styles.ts) and every descendant reads them, so the
+   choice is made once instead of at each Text. */
+.nf-oncard {
+  color: var(--nf-card-fg);
+}
+.nf-oncard-muted {
+  color: var(--nf-card-fg-muted);
+}
+
+/* ── Icon buttons on a question card ── */
 .nf-delete-btn:hover,
 .nf-delete-btn:focus-visible {
-  color: #fca5a5 !important;
-  background: rgba(220, 38, 38, 0.18) !important;
+  color: var(--nf-danger-fg) !important;
+  background: var(--nf-danger-bg) !important;
 }
 
-/* Pin button hover */
 .nf-pin-btn:hover,
 .nf-pin-btn:focus-visible {
   color: var(--nf-royal) !important;
-  background: rgba(59, 91, 255, 0.18) !important;
+  background: var(--nf-selected-bg) !important;
 }
 
-/* Pin button hover when already pinned (unpin action) */
+/* Already pinned, so the hover affordance is "unpin" rather than "pin". */
 .nf-pin-btn--active:hover,
 .nf-pin-btn--active:focus-visible {
-  color: var(--nf-lavender) !important;
+  color: var(--nf-on-grad-accent) !important;
   background: rgba(196, 181, 253, 0.15) !important;
 }
 
-/* Thread pin — card settle animation */
+/* ── Animation ── */
 @keyframes nf-pin-settle {
   from {
     opacity: 0.55;
@@ -220,8 +347,14 @@ body {
   animation: nf-bounce-spin 6s linear infinite;
 }
 
-/* Alert / notification brand radius */
-.mantine-Alert-root {
-  border-radius: 12px;
+@media (prefers-reduced-motion: reduce) {
+  .nf-pinned-card-enter,
+  .nf-bounce-spin {
+    animation: none;
+  }
 }
 
+/* Alert / notification brand radius */
+.mantine-Alert-root {
+  border-radius: var(--nf-radius-control);
+}

--- a/client/src/lib/formatTimestamp.ts
+++ b/client/src/lib/formatTimestamp.ts
@@ -1,0 +1,16 @@
+/**
+ * Absolute, timezone-qualified timestamp for a received question.
+ *
+ * @see [formatTimestamp.test.ts](../tests/lib/formatTimestamp.test.ts): pins the
+ * year, the zero-padded minutes, and the timezone abbreviation.
+ */
+export function formatTimestamp(dateStr: string): string {
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}

--- a/client/src/lib/navSectionStorage.ts
+++ b/client/src/lib/navSectionStorage.ts
@@ -1,0 +1,32 @@
+/**
+ * Which friend sections the user has collapsed, per account.
+ *
+ * Keyed by DID because two accounts on one device shouldn't share the choice.
+ * Every access is guarded: localStorage throws in private-browsing modes and a
+ * collapsed-sections preference is never worth taking the sidebar down for.
+ *
+ * @see [navSectionStorage.test.ts](../tests/lib/navSectionStorage.test.ts):
+ * pins the default-open behaviour and the unreadable-storage fallback.
+ */
+
+const key = (did: string) => `navyfragen_friends_sections_open_${did}`;
+
+export function isSectionOpen(label: string, did: string): boolean {
+  try {
+    const raw = localStorage.getItem(key(did));
+    if (!raw) return true;
+    return JSON.parse(raw)[label] !== false;
+  } catch {
+    return true;
+  }
+}
+
+export function setSectionOpen(label: string, open: boolean, did: string) {
+  try {
+    const raw = localStorage.getItem(key(did));
+    const parsed = raw ? JSON.parse(raw) : {};
+    localStorage.setItem(key(did), JSON.stringify({ ...parsed, [label]: open }));
+  } catch {
+    // localStorage unavailable (private browsing quota, etc.)
+  }
+}

--- a/client/src/lib/useCardKeyboardNav.ts
+++ b/client/src/lib/useCardKeyboardNav.ts
@@ -1,0 +1,73 @@
+import { useEffect, type RefObject } from "react";
+
+const TEXT_ENTRY_TAGS = ["INPUT", "TEXTAREA", "SELECT"];
+
+interface CardKeyboardNav {
+  /**
+   * How many cards are on screen; navigation wraps at both ends. The grid only
+   * mounts with at least one card, so this is never zero.
+   */
+  count: number;
+  focusedIndex: number;
+  setFocusedIndex: (index: number) => void;
+  /** Index of the card whose composer is open, or -1 when none is. */
+  expandedIndex: number;
+  onCollapse: () => void;
+  cardRefs: RefObject<(HTMLDivElement | null)[]>;
+}
+
+/**
+ * Alt/⌘+R to enter and cycle the question grid, arrows to walk it, Escape to
+ * close an open composer and land focus back on its card.
+ *
+ * Escape is handled ahead of the text-entry guard on purpose: it is the only
+ * shortcut that has to work while the composer's textarea has focus.
+ *
+ * @see [Messages.test.tsx](../tests/pages/Messages.test.tsx): pins the wrap in
+ * both directions and that typing in the composer does not trigger navigation.
+ */
+export function useCardKeyboardNav({
+  count,
+  focusedIndex,
+  setFocusedIndex,
+  expandedIndex,
+  onCollapse,
+  cardRefs,
+}: CardKeyboardNav) {
+  useEffect(() => {
+    const moveTo = (index: number) => {
+      setFocusedIndex(index);
+      cardRefs.current[index]?.focus();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && expandedIndex !== -1) {
+        event.preventDefault();
+        onCollapse();
+        cardRefs.current[expandedIndex]?.focus();
+        return;
+      }
+
+      if (TEXT_ENTRY_TAGS.includes((event.target as HTMLElement)?.nodeName)) return;
+
+      if ((event.altKey || event.metaKey) && event.key.toUpperCase() === "R") {
+        event.preventDefault();
+        moveTo(focusedIndex === -1 ? 0 : (focusedIndex + 1) % count);
+        return;
+      }
+
+      if (focusedIndex === -1) return;
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        moveTo((focusedIndex + 1) % count);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        moveTo((focusedIndex - 1 + count) % count);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [count, focusedIndex, setFocusedIndex, expandedIndex, onCollapse, cardRefs]);
+}

--- a/client/src/lib/useHandleSearch.ts
+++ b/client/src/lib/useHandleSearch.ts
@@ -1,0 +1,136 @@
+import { useDebouncedValue } from "@mantine/hooks";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+
+import { apiClient } from "../api/apiClient";
+
+export interface BlueskyActor {
+  did: string;
+  handle: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+/** Shortest thing that could plausibly be a full handle: "a.bc". */
+const MIN_HANDLE_LENGTH = 3;
+
+/**
+ * Lower score = higher in the list. Exact full-handle match → 0, local-part
+ * exact → 1, handle prefix → 2, display-name prefix → 3, anything else → 4.
+ */
+export function rankActor(actor: BlueskyActor, localQ: string, fullHandle: string): number {
+  const handle = actor.handle.toLowerCase();
+  if (handle === fullHandle) return 0;
+  if (handle === localQ || handle.startsWith(`${localQ}.`)) return 1;
+  if (handle.startsWith(localQ)) return 2;
+  if ((actor.displayName ?? "").toLowerCase().startsWith(localQ)) return 3;
+  return 4;
+}
+
+export interface HandleSearch {
+  /** Raw input, including any leading "@" the user typed. */
+  input: string;
+  setInput: (value: string) => void;
+  /** Input with "@" and surrounding whitespace removed. */
+  cleanHandle: string;
+  /** Long enough and dotted enough to be worth submitting. */
+  isHandleReady: boolean;
+  suggestions: BlueskyActor[];
+  /** Set once the user (or an exact match) has settled on one actor. */
+  selectedActor: BlueskyActor | null;
+  select: (actor: BlueskyActor) => void;
+  clearSelection: () => void;
+  /** A newer query is in flight or still debouncing. */
+  isSearching: boolean;
+  /** Search settled with nothing to offer. */
+  noResults: boolean;
+}
+
+/**
+ * Typeahead over Bluesky's actor search, ranked so the handle the user is
+ * actually typing surfaces first.
+ *
+ * @see [Login.test.tsx](../tests/pages/Login.test.tsx): pins the ranking, the
+ * auto-selection of a lone exact match, and the unindexed-PDS fallback.
+ */
+export function useHandleSearch(): HandleSearch {
+  const [input, setInput] = useState("");
+  const [debouncedInput] = useDebouncedValue(input, DEBOUNCE_MS);
+  // Explicit picks only; auto-selection is derived, so no setState-in-effect.
+  const [manualSelectedActor, setManualSelectedActor] = useState<BlueskyActor | null>(null);
+
+  const debouncedQuery = debouncedInput.replace(/^@/, "").trim();
+  const cleanHandle = input.replace(/^@/, "").trim();
+  const isHandleReady = cleanHandle.length >= MIN_HANDLE_LENGTH && cleanHandle.includes(".");
+
+  // "karan.bsky.social" → "karan", so prefix matching works for full handles too.
+  const dotIdx = debouncedQuery.indexOf(".");
+  const searchQ = dotIdx > 1 ? debouncedQuery.slice(0, dotIdx) : debouncedQuery;
+
+  const { data: actors = [], isFetching } = useQuery({
+    queryKey: ["bsky-handle-search", searchQ],
+    queryFn: async (): Promise<BlueskyActor[]> => {
+      const data = await apiClient.get<{ actors: BlueskyActor[] }>(
+        `/handle-search?q=${encodeURIComponent(searchQ)}`
+      );
+      return data.actors ?? [];
+    },
+    enabled: searchQ.length >= MIN_QUERY_LENGTH && !manualSelectedActor,
+    staleTime: 30_000,
+    throwOnError: false,
+  });
+
+  // Reads manualSelectedActor rather than the derived selectedActor: the latter
+  // depends on this value.
+  const isSearching =
+    !manualSelectedActor &&
+    cleanHandle.length >= MIN_QUERY_LENGTH &&
+    (cleanHandle !== debouncedQuery || isFetching);
+
+  const suggestions = useMemo(() => {
+    if (actors.length <= 1) return actors;
+    const full = cleanHandle.toLowerCase();
+    const q = searchQ.toLowerCase();
+    return [...actors].sort((a, b) => rankActor(a, q, full) - rankActor(b, q, full));
+  }, [actors, cleanHandle, searchQ]);
+
+  // A lone exact handle match auto-selects so Enter goes straight to Continue.
+  const selectedActor = useMemo(() => {
+    if (manualSelectedActor) return manualSelectedActor;
+    if (
+      !isSearching &&
+      actors.length === 1 &&
+      actors[0].handle.toLowerCase() === cleanHandle.toLowerCase()
+    ) {
+      return actors[0];
+    }
+    return null;
+  }, [manualSelectedActor, isSearching, actors, cleanHandle]);
+
+  const select = useCallback((actor: BlueskyActor) => {
+    setManualSelectedActor(actor);
+    setInput(actor.handle);
+  }, []);
+
+  return {
+    input,
+    setInput: (value) => {
+      setInput(value);
+      setManualSelectedActor(null);
+    },
+    cleanHandle,
+    isHandleReady,
+    suggestions,
+    selectedActor,
+    select,
+    clearSelection: () => setManualSelectedActor(null),
+    isSearching,
+    noResults:
+      !selectedActor &&
+      !isSearching &&
+      cleanHandle.length >= MIN_QUERY_LENGTH &&
+      actors.length === 0,
+  };
+}

--- a/client/src/lib/useMessagePreferences.ts
+++ b/client/src/lib/useMessagePreferences.ts
@@ -1,0 +1,74 @@
+import { useLocalStorage } from "@mantine/hooks";
+
+/**
+ * The device-local posting preferences shown on the Messages page.
+ *
+ * Each one is its own localStorage entry (unchanged from when they were five
+ * separate `useLocalStorage` calls in the page), but callers see one record and
+ * one setter, so adding a preference no longer means threading another
+ * value/setter pair through the component tree.
+ */
+
+export const PREFERENCE_KEYS = [
+  "appendProfileLink",
+  "useGradients",
+  "includeQuestionAsImage",
+  "confirmBeforeDelete",
+  "autoScrollToMessages",
+] as const;
+
+export type PreferenceKey = (typeof PREFERENCE_KEYS)[number];
+export type MessagePreferences = Record<PreferenceKey, boolean>;
+
+const DEFAULTS: MessagePreferences = {
+  appendProfileLink: false,
+  useGradients: true,
+  includeQuestionAsImage: true,
+  confirmBeforeDelete: false,
+  autoScrollToMessages: true,
+};
+
+function usePreference(key: PreferenceKey) {
+  return useLocalStorage({
+    key,
+    defaultValue: DEFAULTS[key],
+    getInitialValueInEffect: true,
+  });
+}
+
+export interface MessagePreferencesState {
+  preferences: MessagePreferences;
+  setPreference: (key: PreferenceKey, value: boolean) => void;
+  enabledCount: number;
+}
+
+export function useMessagePreferences(): MessagePreferencesState {
+  const [appendProfileLink, setAppendProfileLink] = usePreference("appendProfileLink");
+  const [useGradients, setUseGradients] = usePreference("useGradients");
+  const [includeQuestionAsImage, setIncludeQuestionAsImage] =
+    usePreference("includeQuestionAsImage");
+  const [confirmBeforeDelete, setConfirmBeforeDelete] = usePreference("confirmBeforeDelete");
+  const [autoScrollToMessages, setAutoScrollToMessages] = usePreference("autoScrollToMessages");
+
+  const preferences: MessagePreferences = {
+    appendProfileLink,
+    useGradients,
+    includeQuestionAsImage,
+    confirmBeforeDelete,
+    autoScrollToMessages,
+  };
+
+  const setters: Record<PreferenceKey, (value: boolean) => void> = {
+    appendProfileLink: setAppendProfileLink,
+    useGradients: setUseGradients,
+    includeQuestionAsImage: setIncludeQuestionAsImage,
+    confirmBeforeDelete: setConfirmBeforeDelete,
+    autoScrollToMessages: setAutoScrollToMessages,
+  };
+
+  return {
+    preferences,
+    setPreference: (key, value) => setters[key](value),
+    enabledCount: PREFERENCE_KEYS.filter((key) => preferences[key]).length,
+  };
+}

--- a/client/src/lib/useNavShortcuts.ts
+++ b/client/src/lib/useNavShortcuts.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+
+const TEXT_ENTRY_TAGS = ["INPUT", "TEXTAREA", "SELECT"];
+
+/** Alt+letter → route. Entries marked `private` need a session to be reachable. */
+const ROUTES: { key: string; path: string; private: boolean }[] = [
+  { key: "H", path: "/", private: false },
+  { key: "M", path: "/messages", private: true },
+  { key: "C", path: "/customise", private: true },
+  { key: "S", path: "/settings", private: true },
+];
+
+/**
+ * Global Alt+key navigation.
+ *
+ * @see [Navigation.test.tsx](../tests/Navigation.test.tsx): pins that the
+ * logged-out shortcuts are inert and that typing in a field never navigates.
+ */
+export function useNavShortcuts({
+  isLoggedIn,
+  isSessionLoading,
+  onNavigate,
+}: {
+  isLoggedIn: boolean;
+  isSessionLoading: boolean;
+  onNavigate?: () => void;
+}) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const targetFor = (key: string): string | null => {
+      if (key === "L") return !isLoggedIn && !isSessionLoading ? "/login" : null;
+      const route = ROUTES.find((r) => r.key === key);
+      if (!route) return null;
+      return route.private && !isLoggedIn ? null : route.path;
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.altKey) return;
+      if (TEXT_ENTRY_TAGS.includes((event.target as HTMLElement)?.nodeName)) return;
+
+      const path = targetFor(event.key.toUpperCase());
+      if (!path) return;
+
+      event.preventDefault();
+      navigate(path);
+      onNavigate?.();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isLoggedIn, isSessionLoading, navigate, onNavigate]);
+}

--- a/client/src/lib/useThreadRoot.ts
+++ b/client/src/lib/useThreadRoot.ts
@@ -1,0 +1,109 @@
+import { useLocalStorage } from "@mantine/hooks";
+import { useEffect, useMemo, useState } from "react";
+
+import type { Message } from "../api/messageService";
+
+/**
+ * The "thread root" a session's answers are being chained under.
+ *
+ * Per the architecture note in CLAUDE.md, the association between an NF message
+ * and the Bluesky post that answered it is deliberately client-side only — that
+ * is what `threadLinks` is, and why it lives in localStorage rather than being
+ * sent to the server.
+ *
+ * @see [Messages.test.tsx](../tests/pages/Messages.test.tsx): pins pinning,
+ * unpinning, the reply-order rule, and the cleanup when a pinned message is
+ * deleted elsewhere.
+ */
+
+export interface ThreadLink {
+  uri: string;
+  cid: string;
+  link?: string;
+}
+
+const PIN_SETTLE_MS = 420;
+
+export interface ThreadRoot {
+  rootTid: string | null;
+  /** Set for one animation frame after pinning, so the card can settle in. */
+  justPinnedTid: string | null;
+  /** Messages with the pinned one hoisted to the front. */
+  ordered: Message[];
+  isRoot: (tid: string) => boolean;
+  /** The Bluesky post a pinned message was answered with, once there is one. */
+  linkFor: (tid: string) => ThreadLink | undefined;
+  /**
+   * A thread has to start somewhere: while a root is pinned but unanswered,
+   * every other message is held back so replies cannot orphan themselves.
+   */
+  isReplyBlocked: (tid: string) => boolean;
+  /** The post a reply to `tid` should hang off, or undefined to post standalone. */
+  replyTarget: (tid: string) => Pick<ThreadLink, "uri" | "cid"> | undefined;
+  togglePin: (tid: string) => void;
+  recordReply: (tid: string, link: ThreadLink) => void;
+}
+
+export function useThreadRoot(
+  did: string | null | undefined,
+  messages: Message[] | undefined
+): ThreadRoot {
+  const scope = did ?? "";
+  const [rootTid, setRootTid] = useLocalStorage<string | null>({
+    key: `threadRootTid-${scope}`,
+    defaultValue: null,
+    getInitialValueInEffect: true,
+  });
+  const [links, setLinks] = useLocalStorage<Record<string, ThreadLink>>({
+    key: `threadLinks-${scope}`,
+    defaultValue: {},
+    getInitialValueInEffect: true,
+  });
+  const [justPinnedTid, setJustPinnedTid] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!messages || !rootTid) return;
+    if (messages.some((m) => m.tid === rootTid)) return;
+    setLinks((prev) => {
+      const next = { ...prev };
+      delete next[rootTid];
+      return next;
+    });
+    setRootTid(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messages, rootTid]);
+
+  const ordered = useMemo(() => {
+    const list = messages ?? [];
+    if (!rootTid) return list;
+    const idx = list.findIndex((m) => m.tid === rootTid);
+    if (idx <= 0) return list;
+    return [list[idx], ...list.slice(0, idx), ...list.slice(idx + 1)];
+  }, [messages, rootTid]);
+
+  const isRoot = (tid: string) => rootTid === tid;
+  const rootLink = rootTid ? links[rootTid] : undefined;
+
+  return {
+    rootTid,
+    justPinnedTid,
+    ordered,
+    isRoot,
+    linkFor: (tid) => links[tid],
+    isReplyBlocked: (tid) => !isRoot(tid) && !!rootTid && !rootLink?.uri,
+    replyTarget: (tid) =>
+      !isRoot(tid) && rootLink?.uri && rootLink?.cid
+        ? { uri: rootLink.uri, cid: rootLink.cid }
+        : undefined,
+    togglePin: (tid) => {
+      if (isRoot(tid)) {
+        setRootTid(null);
+        return;
+      }
+      setRootTid(tid);
+      setJustPinnedTid(tid);
+      setTimeout(() => setJustPinnedTid(null), PIN_SETTLE_MS);
+    },
+    recordReply: (tid, link) => setLinks((prev) => ({ ...prev, [tid]: link })),
+  };
+}

--- a/client/src/pages/Customise.tsx
+++ b/client/src/pages/Customise.tsx
@@ -1,27 +1,26 @@
 import {
-  Title,
-  Grid,
-  Text,
-  Stack,
-  Group,
   Alert,
+  Badge,
   Button,
+  Grid,
+  Group,
   Select,
+  Skeleton,
   Switch,
   TextInput,
-  Skeleton,
-  Badge,
+  Title,
 } from "@mantine/core";
 import { useState, useEffect } from "react";
-import { useComputedColorScheme } from "@mantine/core";
 
 import { useSession } from "../api/authService";
 import { useUserSettings, useUpdateUserSettings } from "../api/settingsService";
+import { ProfileThemeSwatches } from "../components/customise/ProfileThemeSwatches";
+import { SettingsSection } from "../components/customise/SettingsSection";
 import { SettingsCard } from "../components/SettingsCard";
-import { profileCardThemes } from "../lib/themes";
 import { touchpointLocales } from "../lib/touchpointTranslations";
 
 const MAX_PROMPT_LENGTH = 100;
+const CARD_SPAN = { base: 12, md: 6, lg: 4 };
 
 /**
  * SQLite sends 0/1 and Postgres sends false/true for the same column.
@@ -33,7 +32,6 @@ function on(value: number | boolean | null | undefined): boolean {
 }
 
 export default function Customise() {
-  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
   const { data: session, isLoading: sessionLoading } = useSession();
   const {
     data: userSettings,
@@ -51,251 +49,157 @@ export default function Customise() {
     setPromptDraft(userSettings?.customPrompt ?? "");
   }, [userSettings?.customPrompt]);
 
-  const settingsLoadError = (
-    <Alert color="red" title="Failed to load settings" withCloseButton={false}>
-      <Button size="xs" onClick={() => refetchSettings()} variant="light" mt="xs">
-        Retry
-      </Button>
-    </Alert>
-  );
-
   const busy = updateSettings.isPending;
+
+  /** Every card shows the same three states, so they share one renderer. */
+  const field = (skeletonHeight: number, control: React.ReactNode) => {
+    if (settingsLoading) return <Skeleton height={skeletonHeight} radius="sm" />;
+    if (settingsError) {
+      return (
+        <Alert color="red" title="Failed to load settings" withCloseButton={false}>
+          <Button size="xs" onClick={() => refetchSettings()} variant="light" mt="xs">
+            Retry
+          </Button>
+        </Alert>
+      );
+    }
+    return control;
+  };
+
+  if (!session?.isLoggedIn && !sessionLoading) {
+    return (
+      <Alert title="Error" color="red">
+        You cannot access this page without logging in.
+      </Alert>
+    );
+  }
 
   return (
     <>
-      {!session?.isLoggedIn && !sessionLoading ? (
-        <Alert title="Error" color="red">
-          You cannot access this page without logging in.
-        </Alert>
-      ) : (
-        <>
-          <Group gap="sm" align="center" mb="xs">
-            <Title order={1} style={{ letterSpacing: "-0.03em" }}>
-              Customise
-            </Title>
-            <Badge color="purple" variant="light" radius="sm">
-              Beta
-            </Badge>
-          </Group>
+      <Group gap="sm" align="center" mb="xs">
+        <Title order={1} style={{ letterSpacing: "-0.03em" }}>
+          Customise
+        </Title>
+        <Badge color="purple" variant="light" radius="sm">
+          Beta
+        </Badge>
+      </Group>
 
-          <Section
-            eyebrow="Your public profile"
-            help="What visitors see before they send you an anonymous message."
+      <SettingsSection
+        eyebrow="Your public profile"
+        help="What visitors see before they send you an anonymous message."
+      >
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Profile prompt"
+            description="The headline shown above your message box. Leave blank to fall back to “Send [you] an anonymous message”."
           >
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Profile prompt"
-                description="The headline shown above your message box. Leave blank to fall back to “Send [you] an anonymous message”."
-                isDark={isDark}
-              >
-                {settingsLoading ? (
-                  <Skeleton height={36} radius="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <TextInput
-                    value={promptDraft}
-                    onChange={(e) => setPromptDraft(e.target.value.slice(0, MAX_PROMPT_LENGTH))}
-                    onBlur={() => {
-                      if (promptInSync) return;
-                      updateSettings.mutate({ customPrompt: promptDraft.trim() || null });
-                    }}
-                    placeholder="Ask me anything…"
-                    maxLength={MAX_PROMPT_LENGTH}
-                    disabled={busy}
-                    aria-label="Profile prompt"
-                    description={`${promptDraft.length}/${MAX_PROMPT_LENGTH}`}
-                  />
-                )}
-              </SettingsCard>
-            </Grid.Col>
+            {field(
+              36,
+              <TextInput
+                value={promptDraft}
+                onChange={(e) => setPromptDraft(e.target.value.slice(0, MAX_PROMPT_LENGTH))}
+                onBlur={() => {
+                  if (promptInSync) return;
+                  updateSettings.mutate({ customPrompt: promptDraft.trim() || null });
+                }}
+                placeholder="Ask me anything…"
+                maxLength={MAX_PROMPT_LENGTH}
+                disabled={busy}
+                aria-label="Profile prompt"
+                description={`${promptDraft.length}/${MAX_PROMPT_LENGTH}`}
+              />
+            )}
+          </SettingsCard>
+        </Grid.Col>
 
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Message language"
-                description="Language of the prompt, share text, and anonymity disclaimer shown to visitors and your audience. Your custom message prompt overrides this setting."
-                isDark={isDark}
-              >
-                {settingsLoading ? (
-                  <Skeleton height={36} radius="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <Select
-                    data={touchpointLocales}
-                    value={
-                      touchpointLocales.some((l) => l.value === userSettings?.touchpointLocale)
-                        ? userSettings!.touchpointLocale!
-                        : "en"
-                    }
-                    onChange={(value) => {
-                      // allowDeselect={false} — Mantine never emits null/"" here.
-                      /* istanbul ignore next */
-                      updateSettings.mutate({ touchpointLocale: value || null });
-                    }}
-                    disabled={busy}
-                    allowDeselect={false}
-                    aria-label="Message language"
-                  />
-                )}
-              </SettingsCard>
-            </Grid.Col>
-
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Profile card colour"
-                description="The colour treatment of your ask card. Curated presets keep the text and button legible on every option."
-                isDark={isDark}
-              >
-                {settingsLoading ? (
-                  <Skeleton height={56} radius="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <ProfileThemeSwatches
-                    value={userSettings?.profileCardTheme ?? null}
-                    disabled={busy}
-                    onPick={(value) => updateSettings.mutate({ profileCardTheme: value })}
-                  />
-                )}
-              </SettingsCard>
-            </Grid.Col>
-          </Section>
-
-          <Section
-            eyebrow="Message intake"
-            help="Who can reach your inbox, and what gets through."
-            last
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Message language"
+            description="Language of the prompt, share text, and anonymity disclaimer shown to visitors and your audience. Your custom message prompt overrides this setting."
           >
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Inbox"
-                description="Turn off to stop receiving new messages while keeping your account, history, and settings intact. Visitors see a “not accepting messages” state."
-                isDark={isDark}
-              >
-                {settingsLoading ? (
-                  <Skeleton height={28} radius="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <Switch
-                    label="Accepting messages"
-                    checked={on(userSettings?.inboxEnabled)}
-                    onChange={(e) =>
-                      updateSettings.mutate({ inboxEnabled: e.currentTarget.checked })
-                    }
-                    disabled={busy}
-                    aria-label="Accepting messages"
-                  />
-                )}
-              </SettingsCard>
-            </Grid.Col>
+            {field(
+              36,
+              <Select
+                data={touchpointLocales}
+                value={
+                  touchpointLocales.some((l) => l.value === userSettings?.touchpointLocale)
+                    ? userSettings!.touchpointLocale!
+                    : "en"
+                }
+                onChange={(value) => {
+                  // allowDeselect={false} — Mantine never emits null/"" here.
+                  /* istanbul ignore next */
+                  updateSettings.mutate({ touchpointLocale: value || null });
+                }}
+                disabled={busy}
+                allowDeselect={false}
+                aria-label="Message language"
+              />
+            )}
+          </SettingsCard>
+        </Grid.Col>
 
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Profanity filter"
-                description="When on, incoming messages are screened against a wordlist. Flagged messages are silently dropped - the sender sees a success response, but the message never reaches your inbox."
-                isDark={isDark}
-              >
-                {settingsLoading ? (
-                  <Skeleton height={28} radius="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <Switch
-                    label="Filter enabled"
-                    checked={on(userSettings?.profanityFilterEnabled)}
-                    onChange={(e) =>
-                      updateSettings.mutate({
-                        profanityFilterEnabled: e.currentTarget.checked,
-                      })
-                    }
-                    disabled={busy}
-                    aria-label="Filter enabled"
-                  />
-                )}
-              </SettingsCard>
-            </Grid.Col>
-          </Section>
-        </>
-      )}
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Profile card colour"
+            description="The colour treatment of your ask card. Curated presets keep the text and button legible on every option."
+          >
+            {field(
+              56,
+              <ProfileThemeSwatches
+                value={userSettings?.profileCardTheme ?? null}
+                disabled={busy}
+                onPick={(value) => updateSettings.mutate({ profileCardTheme: value })}
+              />
+            )}
+          </SettingsCard>
+        </Grid.Col>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Message intake"
+        help="Who can reach your inbox, and what gets through."
+        last
+      >
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Inbox"
+            description="Turn off to stop receiving new messages while keeping your account, history, and settings intact. Visitors see a “not accepting messages” state."
+          >
+            {field(
+              28,
+              <Switch
+                label="Accepting messages"
+                checked={on(userSettings?.inboxEnabled)}
+                onChange={(e) => updateSettings.mutate({ inboxEnabled: e.currentTarget.checked })}
+                disabled={busy}
+                aria-label="Accepting messages"
+              />
+            )}
+          </SettingsCard>
+        </Grid.Col>
+
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Profanity filter"
+            description="When on, incoming messages are screened against a wordlist. Flagged messages are silently dropped - the sender sees a success response, but the message never reaches your inbox."
+          >
+            {field(
+              28,
+              <Switch
+                label="Filter enabled"
+                checked={on(userSettings?.profanityFilterEnabled)}
+                onChange={(e) =>
+                  updateSettings.mutate({ profanityFilterEnabled: e.currentTarget.checked })
+                }
+                disabled={busy}
+                aria-label="Filter enabled"
+              />
+            )}
+          </SettingsCard>
+        </Grid.Col>
+      </SettingsSection>
     </>
-  );
-}
-
-interface SectionProps {
-  eyebrow: string;
-  help: string;
-  last?: boolean;
-  children: React.ReactNode;
-}
-
-function Section({ eyebrow, help, last, children }: SectionProps) {
-  return (
-    <div style={{ marginBottom: last ? 0 : 34 }}>
-      <Text tt="uppercase" fw={700} fz={12} c="dimmed" style={{ letterSpacing: "0.05em" }}>
-        {eyebrow}
-      </Text>
-      <Text c="dimmed" fz={13} mb="md">
-        {help}
-      </Text>
-      <Grid style={{ gap: "var(--mantine-spacing-md)" }}>{children}</Grid>
-    </div>
-  );
-}
-
-/** Lighter-weight sibling of Messages.tsx's ThemeCard: the preview is a
- * gradient fill rather than a card mockup. */
-function ProfileThemeSwatches({
-  value,
-  disabled,
-  onPick,
-}: {
-  value: string | null;
-  disabled: boolean;
-  onPick: (value: string) => void;
-}) {
-  return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-        gap: 10,
-      }}
-    >
-      {Object.entries(profileCardThemes).map(([themeValue, theme]) => {
-        const selected = (value ?? "royal") === themeValue;
-        return (
-          <button
-            key={themeValue}
-            type="button"
-            onClick={() => onPick(themeValue)}
-            disabled={disabled}
-            aria-pressed={selected}
-            aria-label={`${theme.label} theme`}
-            style={{
-              background: selected ? "rgba(59,91,255,0.12)" : "transparent",
-              border: selected
-                ? "1.5px solid #3B5BFF"
-                : "1.5px solid var(--mantine-color-default-border)",
-              borderRadius: 10,
-              padding: 8,
-              cursor: disabled ? "default" : "pointer",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}
-          >
-            <div
-              style={{
-                aspectRatio: "4/3",
-                borderRadius: 5,
-                background: theme.gradient,
-              }}
-            />
-          </button>
-        );
-      })}
-    </div>
   );
 }

--- a/client/src/pages/Home.styles.ts
+++ b/client/src/pages/Home.styles.ts
@@ -1,0 +1,41 @@
+import type { CSSProperties } from "react";
+
+import { accentText, link, surface, textDimmed } from "../styles/tokens";
+
+export const infoCard: CSSProperties = {
+  background: surface,
+};
+
+export const infoHeading: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: textDimmed,
+  marginBottom: "var(--mantine-spacing-sm)",
+};
+
+export const hero: CSSProperties = {
+  padding: "40px 24px",
+  textAlign: "center",
+  background: surface,
+};
+
+export const heroAvatar: CSSProperties = {
+  border: "3px solid var(--mantine-color-default-border)",
+};
+
+export const greeting: CSSProperties = {
+  letterSpacing: "-0.025em",
+};
+
+export const greetingName: CSSProperties = {
+  color: accentText,
+};
+
+export const contactLink: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  fontSize: 15,
+  color: link,
+  textDecoration: "none",
+};

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,11 +10,9 @@ import {
   Skeleton,
   Stack,
   Center,
-  Box,
   Text,
   Title,
   Tooltip,
-  useComputedColorScheme,
 } from "@mantine/core";
 import { IconBrandGithub, IconButterfly, IconClipboard, IconShare } from "@tabler/icons-react";
 import React from "react";
@@ -22,32 +20,45 @@ import { Link } from "react-router";
 
 import { useSession } from "../api/authService";
 import { useSyncMessages } from "../api/messageService";
+import { ShortcutList, type Shortcut } from "../components/ShortcutList";
 import { WinkMark } from "../components/WinkMark";
-import { surfaceBg } from "../styles/tokens";
+import { BRAND_GRADIENT } from "../styles/tokens";
+
+import * as styles from "./Home.styles";
 
 const shortlinkurl = import.meta.env.VITE_SHORTLINK_URL || "localhost:5173/profile";
 
-function ShortcutHint({ label, hint }: { label: string; hint: string }) {
-  return (
-    <Box
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-        padding: "5px 0",
-      }}
-    >
-      <Text fz={13}>{label}</Text>
-      <Text fz={12} c="dimmed">
-        {hint.replace("Alt", "Alt/Cmd")}
-      </Text>
-    </Box>
-  );
-}
+const SIGNED_OUT_SHORTCUTS: Shortcut[] = [
+  { label: "Home", hint: "Alt+H" },
+  { label: "Login", hint: "Alt+L" },
+];
+
+const SIGNED_IN_SHORTCUTS: Shortcut[] = [
+  { label: "Home", hint: "Alt+H" },
+  { label: "Messages", hint: "Alt+M" },
+  { label: "Settings", hint: "Alt+S" },
+  { label: "Focus / cycle cards", hint: "Alt+R" },
+  { label: "Navigate cards", hint: "↑ / ↓" },
+];
+
+const SELLING_POINTS = [
+  {
+    title: "Fast and free",
+    body: "No downloads required, just log in with your Bluesky credentials and share your inbox link",
+  },
+  {
+    title: "Spam protection, without captchas",
+    body: "Protected by Anubis, a powerful bot detection service",
+  },
+  {
+    title: "Open source",
+    body: "Contribute directly to the project, or host your own version if you want!",
+  },
+];
 
 export default function Home() {
   const { data: sessionData, isLoading } = useSession();
   const syncMessagesMutation = useSyncMessages();
-  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
   const isLoggedIn = !!sessionData?.isLoggedIn;
 
   React.useEffect(() => {
@@ -67,207 +78,40 @@ export default function Home() {
       </Text>
 
       {isLoading ? (
-        <Paper p="xl" radius="lg" withBorder>
-          <Stack gap="lg">
-            <Skeleton height={30} width="60%" />
-            <Skeleton height={20} />
-            <Skeleton height={20} />
-            <Center mt="md">
-              <Skeleton height={42} width={180} radius="md" />
-            </Center>
-          </Stack>
-        </Paper>
+        <HeroSkeleton />
       ) : sessionData?.profile ? (
-        <Paper
-          radius="lg"
-          withBorder
-          style={{
-            padding: "40px 24px",
-            textAlign: "center",
-            background: surfaceBg(isDark),
-          }}
-        >
-          <Stack gap="md">
-            <Center>
-              <Avatar
-                src={sessionData.profile.avatar ?? undefined}
-                alt={sessionData.profile.displayName || sessionData.profile.handle}
-                size={84}
-                radius="xl"
-                style={{
-                  border: "3px solid rgba(255,255,255,0.25)",
-                }}
-              >
-                <WinkMark size={60} sparkle={false} aria-hidden />
-              </Avatar>
-            </Center>
-            <Center>
-              <Text fw={800} fz={26} style={{ letterSpacing: "-0.025em" }}>
-                Good to see you again,{" "}
-                <Text component="span" c="royal" fw={800} inherit>
-                  {sessionData.profile.displayName || sessionData.profile.handle}
-                </Text>
-                !
-              </Text>
-            </Center>
-          </Stack>
-          <Center mt="xl" style={{ position: "relative" }}>
-            <Group gap="xs" align="center" wrap="wrap" justify="center">
-              <Button
-                component={Link}
-                to="/messages"
-                size="lg"
-                radius="md"
-                style={{
-                  background: "var(--nf-grad-hero)",
-                  color: "white",
-                  border: "none",
-                }}
-              >
-                View Your Messages
-              </Button>
-              <CopyButton value={`https://${shortlinkurl}/${sessionData.profile.handle}`}>
-                {({ copied, copy }) => (
-                  <Tooltip label={copied ? "Copied!" : "Copy profile link"} withArrow>
-                    <Button
-                      onClick={copy}
-                      size="sm"
-                      radius="xl"
-                      variant="dark"
-                      leftSection={<IconClipboard size={14} />}
-                    >
-                      {copied ? "Copied!" : "Copy Link"}
-                    </Button>
-                  </Tooltip>
-                )}
-              </CopyButton>
-              <Button
-                size="sm"
-                radius="xl"
-                variant="dark"
-                leftSection={<IconShare size={14} />}
-                onClick={async () => {
-                  const url = `https://${shortlinkurl}/${sessionData.profile!.handle}`;
-                  if (navigator.share) {
-                    try {
-                      await navigator.share({
-                        title: "Send me anonymous messages on Navyfragen!",
-                        url,
-                      });
-                    } catch {
-                      // share sheet dismissed or unavailable
-                    }
-                  } else if (navigator.clipboard) {
-                    await navigator.clipboard.writeText(url);
-                  }
-                }}
-              >
-                Share
-              </Button>
-            </Group>
-          </Center>
-        </Paper>
+        <WelcomeBack profile={sessionData.profile} />
       ) : (
-        <Paper p="xl" radius="lg" withBorder style={{ background: surfaceBg(isDark) }}>
-          <List spacing="md" size="md">
-            <List.Item>
-              <Text fw={500}>Fast and free</Text>
-              <Text c="dimmed">
-                No downloads required, just log in with your Bluesky credentials and share your
-                inbox link
-              </Text>
-            </List.Item>
-            <List.Item>
-              <Text fw={500}>Spam protection, without captchas</Text>
-              <Text c="dimmed">Protected by Anubis, a powerful bot detection service</Text>
-            </List.Item>
-            <List.Item>
-              <Text fw={500}>Open source</Text>
-              <Text c="dimmed">
-                Contribute directly to the project, or host your own version if you want!
-              </Text>
-            </List.Item>
-          </List>
-          <Center mt="xl">
-            <Button
-              component={Link}
-              to="/login"
-              size="lg"
-              radius="md"
-              variant="gradient"
-              gradient={{ from: "royal", to: "purple", deg: 135 }}
-            >
-              Get Started
-            </Button>
-          </Center>
-        </Paper>
+        <SignedOutHero />
       )}
 
       <SimpleGrid cols={{ base: 1, sm: 2 }} mt="md">
-        <Paper p="lg" radius="md" withBorder style={{ background: surfaceBg(isDark) }}>
-          <Title order={2} fw={600} mb="sm" c="dimmed" fz={12}>
-            Keyboard Shortcuts
-          </Title>
-          <Stack gap={6}>
-            <ShortcutHint label="Home" hint="Alt+H" />
-            {isLoggedIn ? (
-              <>
-                <ShortcutHint label="Messages" hint="Alt+M" />
-                <ShortcutHint label="Settings" hint="Alt+S" />
-                <ShortcutHint label="Focus/Cycle Cards" hint="Alt+R" />
-                <ShortcutHint label="Navigate Cards" hint="↑/↓" />
-              </>
-            ) : (
-              <ShortcutHint label="Login" hint="Alt+L" />
-            )}
-          </Stack>
+        <Paper p="lg" radius="md" withBorder style={styles.infoCard}>
+          <ShortcutList
+            title="Keyboard Shortcuts"
+            shortcuts={isLoggedIn ? SIGNED_IN_SHORTCUTS : SIGNED_OUT_SHORTCUTS}
+          />
         </Paper>
 
-        <Paper p="lg" radius="md" withBorder style={{ background: surfaceBg(isDark) }}>
-          <Title order={2} fw={600} mb="sm" c="dimmed" fz={12}>
+        <Paper p="lg" radius="md" withBorder style={styles.infoCard}>
+          <Title order={2} style={styles.infoHeading}>
             Questions? Feedback?
           </Title>
           <Stack gap="sm">
-            <div>
-              <Text fz={15} mb={4}>
-                Reach out on Bluesky
-              </Text>
-              <a
-                href="https://bsky.app/profile/navyfragen.app"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  fontSize: 15,
-                  color: isDark ? "var(--nf-lavender)" : "var(--nf-purple)",
-                  textDecoration: "none",
-                }}
-              >
-                <IconButterfly size={18} /> @navyfragen.app
-              </a>
-            </div>
-            <div>
-              <Text fz={15} mb={4}>
-                Submit an issue on GitHub
-              </Text>
-              <a
-                href="https://github.com/karanshukla/navyfragen-app"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  fontSize: 15,
-                  color: isDark ? "var(--nf-lavender)" : "var(--nf-purple)",
-                  textDecoration: "none",
-                }}
-              >
-                <IconBrandGithub size={18} /> GitHub - Navyfragen
-              </a>
-            </div>
+            <ContactLink
+              caption="Reach out on Bluesky"
+              href="https://bsky.app/profile/navyfragen.app"
+              icon={<IconButterfly size={18} />}
+            >
+              @navyfragen.app
+            </ContactLink>
+            <ContactLink
+              caption="Submit an issue on GitHub"
+              href="https://github.com/karanshukla/navyfragen-app"
+              icon={<IconBrandGithub size={18} />}
+            >
+              GitHub - Navyfragen
+            </ContactLink>
             <Divider />
             <Text fz={13}>
               Disclaimer: Please follow Bluesky&apos;s ToS. Cookies are used to keep you logged in.
@@ -277,5 +121,158 @@ export default function Home() {
         </Paper>
       </SimpleGrid>
     </>
+  );
+}
+
+function HeroSkeleton() {
+  return (
+    <Paper p="xl" radius="lg" withBorder>
+      <Stack gap="lg">
+        <Skeleton height={30} width="60%" />
+        <Skeleton height={20} />
+        <Skeleton height={20} />
+        <Center mt="md">
+          <Skeleton height={42} width={180} radius="md" />
+        </Center>
+      </Stack>
+    </Paper>
+  );
+}
+
+interface SessionProfile {
+  avatar?: string | null;
+  displayName?: string | null;
+  handle?: string;
+}
+
+function WelcomeBack({ profile }: { profile: SessionProfile }) {
+  const name = profile.displayName || profile.handle;
+  const url = `https://${shortlinkurl}/${profile.handle}`;
+
+  const share = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "Send me anonymous messages on Navyfragen!", url });
+      } catch {
+        // share sheet dismissed or unavailable
+      }
+    } else if (navigator.clipboard) {
+      await navigator.clipboard.writeText(url);
+    }
+  };
+
+  return (
+    <Paper radius="lg" withBorder style={styles.hero}>
+      <Stack gap="md">
+        <Center>
+          <Avatar
+            src={profile.avatar ?? undefined}
+            alt={name}
+            size={84}
+            radius="xl"
+            style={styles.heroAvatar}
+          >
+            <WinkMark size={60} sparkle={false} aria-hidden />
+          </Avatar>
+        </Center>
+        <Center>
+          <Text fw={800} fz={26} style={styles.greeting}>
+            Good to see you again,{" "}
+            <Text component="span" fw={800} inherit style={styles.greetingName}>
+              {name}
+            </Text>
+            !
+          </Text>
+        </Center>
+      </Stack>
+      <Center mt="xl">
+        <Group gap="xs" align="center" wrap="wrap" justify="center">
+          <Button
+            component={Link}
+            to="/messages"
+            size="lg"
+            radius="md"
+            variant="gradient"
+            gradient={BRAND_GRADIENT}
+          >
+            View Your Messages
+          </Button>
+          <CopyButton value={url}>
+            {({ copied, copy }) => (
+              <Tooltip label={copied ? "Copied!" : "Copy profile link"} withArrow>
+                <Button
+                  onClick={copy}
+                  size="sm"
+                  radius="xl"
+                  variant="default"
+                  leftSection={<IconClipboard size={14} />}
+                >
+                  {copied ? "Copied!" : "Copy Link"}
+                </Button>
+              </Tooltip>
+            )}
+          </CopyButton>
+          <Button
+            size="sm"
+            radius="xl"
+            variant="default"
+            leftSection={<IconShare size={14} />}
+            onClick={share}
+          >
+            Share
+          </Button>
+        </Group>
+      </Center>
+    </Paper>
+  );
+}
+
+function SignedOutHero() {
+  return (
+    <Paper p="xl" radius="lg" withBorder style={styles.infoCard}>
+      <List spacing="md" size="md">
+        {SELLING_POINTS.map(({ title, body }) => (
+          <List.Item key={title}>
+            <Text fw={500}>{title}</Text>
+            <Text c="dimmed">{body}</Text>
+          </List.Item>
+        ))}
+      </List>
+      <Center mt="xl">
+        <Button
+          component={Link}
+          to="/login"
+          size="lg"
+          radius="md"
+          variant="gradient"
+          gradient={BRAND_GRADIENT}
+        >
+          Get Started
+        </Button>
+      </Center>
+    </Paper>
+  );
+}
+
+function ContactLink({
+  caption,
+  href,
+  icon,
+  children,
+}: {
+  caption: string;
+  href: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Text fz={15} mb={4}>
+        {caption}
+      </Text>
+      <a href={href} target="_blank" rel="noopener noreferrer" style={styles.contactLink}>
+        {icon} {children}
+      </a>
+    </div>
   );
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,302 +1,28 @@
-import {
-  Alert,
-  Avatar,
-  Button,
-  Group,
-  Paper,
-  PasswordInput,
-  Skeleton,
-  Stack,
-  TextInput,
-  Title,
-  Text,
-  Box,
-  Center,
-  UnstyledButton,
-  useComputedColorScheme,
-} from "@mantine/core";
-import { useDebouncedValue } from "@mantine/hooks";
-import { useQuery } from "@tanstack/react-query";
-import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { Alert, Box, Button, Center, Text, TextInput, Title } from "@mantine/core";
+import { useRef, useState } from "react";
+import { useLocation } from "react-router";
 import { useHaptic } from "use-haptic";
 // Namespace import, not `import { z }` — that one binding comes back undefined
 // through Vitest's module runner on Bun. See docs/testing-notes.md.
 import * as z from "zod";
 
-import { apiClient } from "../api/apiClient";
-import { authKeys, useE2ELogin, useLogin } from "../api/authService";
-import { queryClient } from "../api/queryClient";
+import { useLogin } from "../api/authService";
+import { AuthPanel } from "../components/AuthPanel";
+import * as panelStyles from "../components/AuthPanel.styles";
+import { E2ELoginPanel } from "../components/login/E2ELoginPanel";
+import { HandleSuggestions } from "../components/login/HandleSuggestions";
 import { WinkMark } from "../components/WinkMark";
-import { surfaceBg } from "../styles/tokens";
+import { useHandleSearch } from "../lib/useHandleSearch";
+import { BRAND_GRADIENT } from "../styles/tokens";
 
 const handleSchema = z
   .string()
   .min(1, { error: "Handle is required" })
   .max(64, { error: "Handle too long" });
 
-interface BlueskyActor {
-  did: string;
-  handle: string;
-  displayName?: string;
-  avatar?: string;
-}
-
-// Bypasses the OAuth redirect with an app password so Playwright can drive a
-// real account on a private PDS. Only built when VITE_E2E_TESTING=true.
-function E2ELoginPanel() {
-  const [identifier, setIdentifier] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const navigate = useNavigate();
-  const { mutate: e2eLogin, isPending } = useE2ELogin();
-
-  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setError(null);
-    e2eLogin(
-      { identifier, password },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: authKeys.session });
-          navigate("/messages");
-        },
-        onError: (err: any) => {
-          setError(err.error || "E2E login failed");
-        },
-      }
-    );
-  };
-
-  return (
-    <Box maw={480} mx="auto" mt="xl">
-      <Paper
-        radius="lg"
-        p="xl"
-        withBorder
-        style={{ borderColor: "var(--mantine-color-orange-5)", borderWidth: 2 }}
-      >
-        <Stack gap="md">
-          <Text fw={700} c="orange" size="sm">
-            E2E Test Mode - not for production use
-          </Text>
-          {error && (
-            <Alert color="red" withCloseButton onClose={() => setError(null)}>
-              {error}
-            </Alert>
-          )}
-          <form onSubmit={onSubmit}>
-            <Stack gap="sm">
-              <TextInput
-                label="Identifier"
-                placeholder="handle.pds.example"
-                value={identifier}
-                onChange={(e) => setIdentifier(e.target.value)}
-                required
-                autoCorrect="off"
-                autoCapitalize="none"
-                spellCheck={false}
-                data-testid="e2e-identifier"
-              />
-              <PasswordInput
-                label="App Password"
-                placeholder="xxxx-xxxx-xxxx-xxxx"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                data-testid="e2e-password"
-              />
-              <Button
-                type="submit"
-                loading={isPending}
-                fullWidth
-                color="orange"
-                mt="xs"
-                data-testid="e2e-submit"
-              >
-                Sign In (E2E)
-              </Button>
-            </Stack>
-          </form>
-        </Stack>
-      </Paper>
-    </Box>
-  );
-}
-
-const ROW_H = 64;
-
-// Lower score = higher in the list.
-// Exact full-handle match → 0, local-part exact → 1, handle prefix → 2,
-// display-name prefix → 3, anything else → 4.
-function rankActor(actor: BlueskyActor, localQ: string, fullHandle: string): number {
-  const handle = actor.handle.toLowerCase();
-  if (handle === fullHandle) return 0;
-  if (handle === localQ || handle.startsWith(`${localQ}.`)) return 1;
-  if (handle.startsWith(localQ)) return 2;
-  if ((actor.displayName ?? "").toLowerCase().startsWith(localQ)) return 3;
-  return 4;
-}
-
-function SuggestionRow({
-  actor,
-  onClick,
-  buttonRef,
-  onEscape,
-}: {
-  actor: BlueskyActor;
-  onClick: () => void;
-  buttonRef?: RefObject<HTMLButtonElement | null>;
-  onEscape?: () => void;
-}) {
-  const [isFocused, setIsFocused] = useState(false);
-
-  return (
-    <UnstyledButton
-      ref={buttonRef}
-      onClick={onClick}
-      onFocus={(e) => setIsFocused(e.currentTarget.matches(":focus-visible"))}
-      onBlur={() => setIsFocused(false)}
-      onKeyDown={(e: React.KeyboardEvent) => {
-        if (e.key === "Escape" || e.key === "ArrowUp") {
-          e.preventDefault();
-          onEscape?.();
-        }
-      }}
-      w="100%"
-      role="option"
-      aria-selected={false}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        height: ROW_H,
-        outline: isFocused ? "2px solid var(--mantine-color-violet-5)" : "none",
-        outlineOffset: "-2px",
-        background: isFocused
-          ? "light-dark(rgba(51,73,224,0.08), rgba(107,63,212,0.20))"
-          : undefined,
-      }}
-    >
-      <Group gap="sm" wrap="nowrap" px="sm" w="100%">
-        <Avatar src={actor.avatar ?? null} size={40} radius="xl" />
-        <Box style={{ minWidth: 0 }}>
-          <Text size="sm" fw={500} truncate>
-            {actor.displayName || actor.handle}
-          </Text>
-          <Text size="xs" c="dimmed" truncate>
-            @{actor.handle}
-          </Text>
-        </Box>
-      </Group>
-    </UnstyledButton>
-  );
-}
-
-function SkeletonRow() {
-  return (
-    <Box style={{ display: "flex", alignItems: "center", height: ROW_H }} px="sm">
-      <Group gap="sm" wrap="nowrap" w="100%">
-        <Skeleton circle height={40} width={40} />
-        <Box style={{ flex: 1 }}>
-          <Skeleton height={12} width="55%" mb={6} />
-          <Skeleton height={10} width="38%" />
-        </Box>
-      </Group>
-    </Box>
-  );
-}
-
-function HandleSuggestionBox({
-  selectedActor,
-  isSearchPending,
-  suggestions,
-  noResults,
-  isHandleReady,
-  cleanHandle,
-  onSelect,
-  suggestionRef,
-  onEscape,
-}: {
-  selectedActor: BlueskyActor | null;
-  isSearchPending: boolean;
-  suggestions: BlueskyActor[];
-  noResults: boolean;
-  isHandleReady: boolean;
-  cleanHandle: string;
-  onSelect: (actor: BlueskyActor) => void;
-  suggestionRef: RefObject<HTMLButtonElement | null>;
-  onEscape: () => void;
-}) {
-  const skeletonRow = useMemo(() => <SkeletonRow />, []);
-  const hasSuggestion = !selectedActor && (suggestions.length > 0 || (noResults && isHandleReady));
-
-  return (
-    <Paper
-      radius="md"
-      withBorder
-      mt="xs"
-      role={hasSuggestion ? "listbox" : undefined}
-      aria-label={hasSuggestion ? "Handle suggestions" : undefined}
-      style={{
-        background: "light-dark(rgba(0,0,0,0.04), rgba(255,255,255,0.09))",
-        overflow: "hidden",
-      }}
-    >
-      {selectedActor ? (
-        <Box style={{ display: "flex", alignItems: "center", height: ROW_H }} px="sm">
-          <Group gap="sm" wrap="nowrap" w="100%">
-            <Avatar src={selectedActor.avatar ?? null} size={40} radius="xl" />
-            <Box style={{ minWidth: 0 }}>
-              <Text size="sm" fw={600} truncate>
-                {selectedActor.displayName || selectedActor.handle}
-              </Text>
-              <Text size="xs" c="dimmed" truncate>
-                @{selectedActor.handle}
-              </Text>
-            </Box>
-          </Group>
-        </Box>
-      ) : isSearchPending ? (
-        skeletonRow
-      ) : suggestions.length > 0 ? (
-        <SuggestionRow
-          actor={suggestions[0]}
-          onClick={() => onSelect(suggestions[0])}
-          buttonRef={suggestionRef}
-          onEscape={onEscape}
-        />
-      ) : noResults && isHandleReady ? (
-        // Nothing in the Bluesky index, but the handle looks complete — offer it
-        // directly so users on unindexed third-party PDSes can still proceed.
-        <SuggestionRow
-          actor={{ did: "", handle: cleanHandle }}
-          onClick={() => onSelect({ did: "", handle: cleanHandle })}
-          buttonRef={suggestionRef}
-          onEscape={onEscape}
-        />
-      ) : noResults ? (
-        <Center style={{ height: ROW_H }} aria-live="polite">
-          <Text size="xs" c="dimmed">
-            No handles found
-          </Text>
-        </Center>
-      ) : (
-        <Center style={{ height: ROW_H }}>
-          <Text size="xs" c="dimmed">
-            Start typing to get handle suggestions
-          </Text>
-        </Center>
-      )}
-    </Paper>
-  );
-}
-
 function LoginForm() {
   const location = useLocation();
-  const [handle, setHandle] = useState("");
-  const [debouncedHandle] = useDebouncedValue(handle, 300);
-  // Explicit picks only; auto-selection is derived, so no setState-in-effect.
-  const [manualSelectedActor, setManualSelectedActor] = useState<BlueskyActor | null>(null);
+  const search = useHandleSearch();
   const [error, setError] = useState<string | null>(() =>
     new URLSearchParams(location.search).get("error") === "oauth_failed"
       ? "Login failed. Please try again."
@@ -305,84 +31,22 @@ function LoginForm() {
   const [isRedirecting, setIsRedirecting] = useState(false);
   const { mutate: login, isPending } = useLogin();
   const { triggerHaptic } = useHaptic(1);
-  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
 
   const inputRef = useRef<HTMLInputElement>(null);
   const suggestionRef = useRef<HTMLButtonElement>(null);
 
-  const debouncedQuery = debouncedHandle.replace(/^@/, "").trim();
-  const cleanHandle = handle.replace(/^@/, "").trim();
-  const isHandleReady = cleanHandle.length >= 3 && cleanHandle.includes(".");
-
-  // "karan.bsky.social" → "karan", so prefix matching works for full handles too.
-  const dotIdx = debouncedQuery.indexOf(".");
-  const searchQ = dotIdx > 1 ? debouncedQuery.slice(0, dotIdx) : debouncedQuery;
-
-  const { data: actorSuggestions = [], isFetching: isSuggestionsLoading } = useQuery({
-    queryKey: ["bsky-handle-search", searchQ],
-    queryFn: async (): Promise<BlueskyActor[]> => {
-      const data = await apiClient.get<{ actors: BlueskyActor[] }>(
-        `/handle-search?q=${encodeURIComponent(searchQ)}`
-      );
-      return data.actors ?? [];
-    },
-    enabled: searchQ.length >= 2 && !manualSelectedActor,
-    staleTime: 30_000,
-    throwOnError: false,
-  });
-
-  // Reads manualSelectedActor rather than the derived selectedActor: the latter
-  // depends on this value.
-  const isSearchPending =
-    !manualSelectedActor &&
-    cleanHandle.length >= 2 &&
-    (cleanHandle !== debouncedQuery || isSuggestionsLoading);
-
-  const sortedSuggestions = useMemo(() => {
-    if (actorSuggestions.length <= 1) return actorSuggestions;
-    const full = cleanHandle.toLowerCase();
-    const q = searchQ.toLowerCase();
-    return [...actorSuggestions].sort((a, b) => rankActor(a, q, full) - rankActor(b, q, full));
-  }, [actorSuggestions, cleanHandle, searchQ]);
-
-  // A lone exact handle match auto-selects so Enter goes straight to Continue.
-  const selectedActor = useMemo(() => {
-    if (manualSelectedActor) return manualSelectedActor;
-    if (
-      !isSearchPending &&
-      actorSuggestions.length === 1 &&
-      actorSuggestions[0].handle.toLowerCase() === cleanHandle.toLowerCase()
-    ) {
-      return actorSuggestions[0];
-    }
-    return null;
-  }, [manualSelectedActor, isSearchPending, actorSuggestions, cleanHandle]);
-
-  const noResults =
-    !selectedActor && !isSearchPending && cleanHandle.length >= 2 && actorSuggestions.length === 0;
-
-  const selectActor = useCallback((actor: BlueskyActor) => {
-    setManualSelectedActor(actor);
-    setHandle(actor.handle);
-  }, []);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setHandle(e.target.value);
-    if (manualSelectedActor) setManualSelectedActor(null);
-  };
-
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isHandleReady) return;
+    if (!search.isHandleReady) return;
     triggerHaptic();
     setError(null);
-    const result = handleSchema.safeParse(cleanHandle);
+    const result = handleSchema.safeParse(search.cleanHandle);
     if (!result.success) {
       setError(result.error.issues[0].message);
       return;
     }
     login(
-      { handle: cleanHandle },
+      { handle: search.cleanHandle },
       {
         onSuccess: (data) => {
           if (data.redirectUrl) {
@@ -391,6 +55,7 @@ function LoginForm() {
             window.location.href = data.redirectUrl;
           }
         },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onError: (err: any) => {
           setError(err.error || "Login failed. Please try again.");
         },
@@ -400,106 +65,71 @@ function LoginForm() {
 
   return (
     <Box maw={480} mx="auto">
-      <Paper
-        radius="lg"
-        p="xl"
-        withBorder
-        style={{
-          background: surfaceBg(isDark),
-          position: "relative",
-          overflow: "hidden",
-        }}
-      >
-        <Box
-          style={{
-            position: "absolute",
-            inset: 0,
-            background: isDark
-              ? "radial-gradient(ellipse 60% 100% at 50% 0%, rgba(139,92,246,0.15), transparent 70%)"
-              : "radial-gradient(ellipse 60% 100% at 50% 0%, rgba(196,181,253,0.4), transparent 70%)",
-            pointerEvents: "none",
-          }}
-        />
+      <AuthPanel>
+        <Center>
+          <WinkMark size={60} sparkle style={panelStyles.mark} />
+        </Center>
+        <Box ta="center">
+          <Title order={1} fw={800} fz={24}>
+            Log in to Navyfragen
+          </Title>
+          <Text size="sm" c="dimmed" mt={4}>
+            Enter your AT Protocol handle to continue
+          </Text>
+        </Box>
 
-        <Stack gap="md" style={{ position: "relative" }}>
-          <Center>
-            <WinkMark
-              size={60}
-              sparkle
-              style={{
-                borderRadius: 16,
-                boxShadow: "0 12px 30px -10px rgba(20,18,58,0.4)",
-              }}
-            />
-          </Center>
-          <Box ta="center">
-            <Title order={1} fw={800} fz={24}>
-              Log in to Navyfragen
-            </Title>
-            <Text size="sm" c="dimmed" mt={4}>
-              Enter your AT Protocol handle to continue
-            </Text>
-          </Box>
+        {error && (
+          <Alert color="red" withCloseButton onClose={() => setError(null)} role="alert">
+            {error}
+          </Alert>
+        )}
 
-          {error && (
-            <Alert color="red" withCloseButton onClose={() => setError(null)} role="alert">
-              {error}
-            </Alert>
-          )}
+        <form onSubmit={onSubmit}>
+          <TextInput
+            ref={inputRef}
+            label="Atmosphere Handle"
+            placeholder="e.g. yourname.bsky.social"
+            value={search.input}
+            onChange={(e) => search.setInput(e.target.value)}
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown" && suggestionRef.current) {
+                e.preventDefault();
+                suggestionRef.current.focus();
+              } else if (e.key === "Escape") {
+                search.clearSelection();
+              }
+            }}
+            aria-haspopup="listbox"
+            aria-autocomplete="list"
+          />
 
-          <form onSubmit={onSubmit}>
-            <TextInput
-              ref={inputRef}
-              label="Atmosphere Handle"
-              placeholder="e.g. yourname.bsky.social"
-              value={handle}
-              onChange={handleChange}
-              autoCorrect="off"
-              autoCapitalize="none"
-              spellCheck={false}
-              onKeyDown={(e) => {
-                if (e.key === "ArrowDown" && suggestionRef.current) {
-                  e.preventDefault();
-                  suggestionRef.current.focus();
-                } else if (e.key === "Escape" && manualSelectedActor) {
-                  setManualSelectedActor(null);
-                }
-              }}
-              aria-haspopup="listbox"
-              aria-autocomplete="list"
-            />
+          <HandleSuggestions
+            search={search}
+            suggestionRef={suggestionRef}
+            onEscape={() => inputRef.current?.focus()}
+          />
 
-            <HandleSuggestionBox
-              selectedActor={selectedActor}
-              isSearchPending={isSearchPending}
-              suggestions={sortedSuggestions}
-              noResults={noResults}
-              isHandleReady={isHandleReady}
-              cleanHandle={cleanHandle}
-              onSelect={selectActor}
-              suggestionRef={suggestionRef}
-              onEscape={() => inputRef.current?.focus()}
-            />
-
-            <Button
-              type="submit"
-              mt="xs"
-              fullWidth
-              loading={isPending || isRedirecting}
-              variant="gradient"
-              gradient={{ from: "royal", to: "purple", deg: 135 }}
-              size="md"
-              radius="md"
-              style={{
-                opacity: isHandleReady ? 1 : 0.45,
-                cursor: isHandleReady ? undefined : "not-allowed",
-              }}
-            >
-              Continue
-            </Button>
-          </form>
-        </Stack>
-      </Paper>
+          <Button
+            type="submit"
+            mt="xs"
+            fullWidth
+            loading={isPending || isRedirecting}
+            variant="gradient"
+            gradient={BRAND_GRADIENT}
+            size="md"
+            radius="md"
+            style={{
+              opacity: search.isHandleReady ? 1 : 0.45,
+              cursor: search.isHandleReady ? undefined : "not-allowed",
+            }}
+          >
+            Continue
+          </Button>
+        </form>
+      </AuthPanel>
 
       <Text size="xs" c="dimmed" ta="center" mt="md" style={{ lineHeight: 1.6 }}>
         You will be directed to Bluesky to authenticate. Navyfragen does not have access to your

--- a/client/src/pages/Messages.tsx
+++ b/client/src/pages/Messages.tsx
@@ -1,35 +1,6 @@
-import {
-  Title,
-  Text,
-  Paper,
-  Stack,
-  Loader,
-  Center,
-  Alert,
-  Button,
-  ActionIcon,
-  Group,
-  Textarea,
-  CopyButton,
-  Tooltip,
-  Switch,
-  Box,
-  SimpleGrid,
-  useComputedColorScheme,
-  Collapse,
-} from "@mantine/core";
-import { useLocalStorage } from "@mantine/hooks";
+import { Alert, Box, Button, Center, Group, Loader, SimpleGrid, Text, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import {
-  IconChevronDown,
-  IconClipboard,
-  IconExternalLink,
-  IconPin,
-  IconPinned,
-  IconSend2,
-  IconTrash,
-} from "@tabler/icons-react";
-import { useEffect, useMemo, useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useHaptic } from "use-haptic";
 
 import { ApiError } from "../api/apiClient";
@@ -43,379 +14,28 @@ import {
 } from "../api/messageService";
 import { useUserSettings, useUpdateUserSettings } from "../api/settingsService";
 import { ConfirmationModal } from "../components/ConfirmationModal";
-import ShareButton from "../components/ShareButton";
-import { themes } from "../lib/themes";
+import { ImageThemePicker } from "../components/messages/ImageThemePicker";
+import { InboxLinkCard } from "../components/messages/InboxLinkCard";
+import { PostingPreferences } from "../components/messages/PostingPreferences";
+import { QuestionGrid } from "../components/messages/QuestionGrid";
 import { getTouchpointTranslations } from "../lib/touchpointTranslations";
-import { surfaceBg } from "../styles/tokens";
-
-const replyTextareaStyles = {
-  input: {
-    background: "transparent",
-    color: "var(--nf-midnight)",
-    border: "none",
-    padding: 0,
-  },
-} as const;
+import { useMessagePreferences } from "../lib/useMessagePreferences";
+import { useThreadRoot } from "../lib/useThreadRoot";
+import { sunshineButton } from "../styles/tokens";
 
 const shortlinkurl = import.meta.env.VITE_SHORTLINK_URL || "localhost:5173/profile";
 
 const MAX_BSKY_POST_LENGTH = 280;
 const GENERAL_BUFFER = 3;
-
-interface ThreadLinkData {
-  uri: string;
-  cid: string;
-  link?: string;
-}
-
-export function formatTimestamp(dateStr: string): string {
-  return new Date(dateStr).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    timeZoneName: "short",
-  });
-}
-
-function CharRing({ count, limit }: { count: number; limit: number }) {
-  const r = 9;
-  const circ = 2 * Math.PI * r;
-  const pct = Math.min(count / limit, 1);
-  const danger = count > limit * 0.9;
-  const color = danger ? "var(--nf-sunshine)" : "var(--nf-royal)";
-  return (
-    <svg width={22} height={22} viewBox="0 0 22 22" style={{ flexShrink: 0 }}>
-      <circle
-        cx={11}
-        cy={11}
-        r={r}
-        fill="none"
-        stroke="rgba(253,248,255,0.15)" /* track */
-        strokeWidth={2.5}
-      />
-      <circle
-        cx={11}
-        cy={11}
-        r={r}
-        fill="none"
-        stroke={color}
-        strokeWidth={2.5}
-        strokeDasharray={circ}
-        strokeDashoffset={circ - pct * circ}
-        transform="rotate(-90 11 11)"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
-
-function ThemeCardPreview({ value }: { value: string }) {
-  if (value === "default") {
-    return (
-      <div
-        style={{
-          background: "var(--nf-grad-dark)",
-          height: "100%",
-          borderRadius: 5,
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "stretch",
-          justifyContent: "center",
-          padding: "8px 10px",
-          gap: 6,
-        }}
-      >
-        <div style={{ display: "flex", justifyContent: "center" }}>
-          <div
-            style={{
-              height: 2.5,
-              background: "rgba(255,255,255,0.7)",
-              borderRadius: 2,
-              width: "55%",
-            }}
-          />
-        </div>
-        <div
-          style={{
-            background: "#fff",
-            borderRadius: 8,
-            padding: "6px 10px",
-            boxShadow: "0 3px 10px rgba(0,0,0,0.3)",
-          }}
-        >
-          <div
-            style={{
-              height: 3.5,
-              background: "#ccc",
-              borderRadius: 2,
-              marginBottom: 4,
-            }}
-          />
-          <div
-            style={{
-              height: 3.5,
-              background: "#ccc",
-              borderRadius: 2,
-              width: "65%",
-            }}
-          />
-        </div>
-        <div style={{ display: "flex", justifyContent: "center" }}>
-          <div
-            style={{
-              height: 2,
-              background: "rgba(255,255,255,0.4)",
-              borderRadius: 2,
-              width: "40%",
-            }}
-          />
-        </div>
-      </div>
-    );
-  }
-  if (value === "compressed") {
-    return (
-      <div
-        style={{
-          background: "#1a1a2a",
-          height: "100%",
-          borderRadius: 5,
-          display: "flex",
-          alignItems: "center",
-          padding: 8,
-        }}
-      >
-        <div
-          style={{
-            background: "#22223a",
-            borderLeft: "3px solid #7c3aed",
-            borderRadius: 6,
-            padding: "7px 9px",
-            width: "100%",
-          }}
-        >
-          <div
-            style={{
-              height: 3,
-              background: "#a78bfa",
-              borderRadius: 3,
-              marginBottom: 5,
-              width: "45%",
-            }}
-          />
-          <div
-            style={{
-              height: 3,
-              background: "#4a4a6a",
-              borderRadius: 3,
-              marginBottom: 3,
-            }}
-          />
-          <div
-            style={{
-              height: 3,
-              background: "#4a4a6a",
-              borderRadius: 3,
-              width: "70%",
-              marginBottom: 5,
-            }}
-          />
-          <div
-            style={{
-              height: 2.5,
-              background: "#3a3a5a",
-              borderRadius: 2,
-              width: "45%",
-            }}
-          />
-        </div>
-      </div>
-    );
-  }
-  // twitter
-  return (
-    <div
-      style={{
-        background: "#ffffff",
-        height: "100%",
-        borderRadius: 5,
-        display: "flex",
-        alignItems: "center",
-        padding: 0,
-      }}
-    >
-      <div
-        style={{
-          background: "#fff",
-          border: "1px solid #cfd9de",
-          borderRadius: 8,
-          padding: "7px 9px",
-          width: "100%",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            gap: 5,
-            marginBottom: 5,
-            alignItems: "center",
-          }}
-        >
-          <div
-            style={{
-              width: 12,
-              height: 12,
-              borderRadius: "50%",
-              background: "#1d9bf0",
-              flexShrink: 0,
-            }}
-          />
-          <div style={{ flex: 1 }}>
-            <div
-              style={{
-                height: 2.5,
-                background: "#333",
-                borderRadius: 2,
-                marginBottom: 2,
-              }}
-            />
-            <div
-              style={{
-                height: 2.5,
-                background: "#aaa",
-                borderRadius: 2,
-                width: "55%",
-              }}
-            />
-          </div>
-        </div>
-        <div
-          style={{
-            height: 2.5,
-            background: "#ccc",
-            borderRadius: 2,
-            marginBottom: 3,
-          }}
-        />
-        <div
-          style={{
-            height: 2.5,
-            background: "#ccc",
-            borderRadius: 2,
-            width: "75%",
-            marginBottom: 4,
-          }}
-        />
-        <div style={{ height: 1, background: "#eff3f4", marginBottom: 3 }} />
-        <div
-          style={{
-            height: 2.5,
-            background: "#1d9bf0",
-            borderRadius: 2,
-            width: "40%",
-          }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function ThemeCard({
-  value,
-  label,
-  selected,
-  onClick,
-}: {
-  value: string;
-  label: string;
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      style={{
-        background: selected ? "rgba(59,91,255,0.12)" : "transparent",
-        border: selected
-          ? "1.5px solid #3B5BFF"
-          : "1.5px solid var(--mantine-color-default-border)",
-        borderRadius: 10,
-        padding: 8,
-        cursor: "pointer",
-        display: "flex",
-        flexDirection: "column",
-        gap: 6,
-        flex: 1,
-      }}
-    >
-      <div style={{ aspectRatio: "4/3", borderRadius: 5, overflow: "hidden" }}>
-        <ThemeCardPreview value={value} />
-      </div>
-      <Text size="xs" fw={600} ta="center" style={{ color: "var(--mantine-color-text)" }}>
-        {label}
-      </Text>
-    </button>
-  );
-}
+/** How the question is quoted into the post when it is not sent as an image. */
+const quotedQuestion = (message: string) => ` \\n\\nAnon asked via 💙📩❓: *${message}*`;
 
 export default function Messages() {
-  const [respondingTid, setRespondingTid] = useState<string | null>(null);
-  const [responseText, setResponseText] = useState<string>("");
-  const [focusedCardIndex, setFocusedCardIndex] = useState<number>(-1);
-  const [postingPrefsOpen, setPostingPrefsOpen] = useState(true);
-  const [imageThemeOpen, setImageThemeOpen] = useState(true);
-  const messageCardRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
   const { triggerHaptic } = useHaptic(1);
-
-  const [appendProfileLink, setAppendProfileLink] = useLocalStorage({
-    key: "appendProfileLink",
-    defaultValue: false,
-    getInitialValueInEffect: true,
-  });
-  const [useGradients, setUseGradients] = useLocalStorage({
-    key: "useGradients",
-    defaultValue: true,
-    getInitialValueInEffect: true,
-  });
-  const [includeQuestionAsImage, setIncludeQuestionAsImage] = useLocalStorage({
-    key: "includeQuestionAsImage",
-    defaultValue: true,
-    getInitialValueInEffect: true,
-  });
-  const [confirmBeforeDelete, setConfirmBeforeDelete] = useLocalStorage({
-    key: "confirmBeforeDelete",
-    defaultValue: false,
-    getInitialValueInEffect: true,
-  });
-  const [autoScrollToMessages, setAutoScrollToMessages] = useLocalStorage({
-    key: "autoScrollToMessages",
-    defaultValue: true,
-    getInitialValueInEffect: true,
-  });
-
   const { data: session, isLoading: sessionLoading } = useSession();
-
-  const [threadRootTid, setThreadRootTid] = useLocalStorage<string | null>({
-    key: `threadRootTid-${session?.did ?? ""}`,
-    defaultValue: null,
-    getInitialValueInEffect: true,
-  });
-  const [threadLinks, setThreadLinks] = useLocalStorage<Record<string, ThreadLinkData>>({
-    key: `threadLinks-${session?.did ?? ""}`,
-    defaultValue: {},
-    getInitialValueInEffect: true,
-  });
-  const [justPinnedTid, setJustPinnedTid] = useState<string | null>(null);
-
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const messagesTopRef = useRef<HTMLDivElement>(null);
-  const prevMsgCountRef = useRef<number>(0);
-  const [deleteModalOpened, setDeleteModalOpened] = useState<boolean>(false);
-  const [messageIdToDelete, setMessageIdToDelete] = useState<string | null>(null);
-  const [deletingTid, setDeletingTid] = useState<string | null>(null);
+  const prefs = useMessagePreferences();
+  const { appendProfileLink, useGradients, includeQuestionAsImage, confirmBeforeDelete } =
+    prefs.preferences;
 
   const {
     data: messagesData,
@@ -426,6 +46,8 @@ export default function Messages() {
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
   });
+
+  const thread = useThreadRoot(session?.did, messagesData?.messages);
 
   const { mutate: deleteMessage, isPending: deleteLoading } = useDeleteMessage();
   const { mutate: respondToMessage, isPending: respondLoading } = useRespondToMessage();
@@ -442,59 +64,24 @@ export default function Messages() {
     },
   });
 
-  const characterLimit = useMemo(() => {
-    let maxLength = MAX_BSKY_POST_LENGTH - GENERAL_BUFFER;
-    if (appendProfileLink && session?.profile?.handle) {
-      maxLength -= ` ${shortlinkurl}/${session.profile.handle}`.length;
-    }
-    if (!includeQuestionAsImage && respondingTid && messagesData?.messages) {
-      const msg = messagesData.messages.find((m) => m.tid === respondingTid);
-      if (msg) {
-        maxLength -= ` \\n\\nAnon asked via 💙📩❓: *${msg.message}*`.length;
-      }
-    }
-    return Math.max(0, maxLength);
-  }, [
-    appendProfileLink,
-    session?.profile?.handle,
-    includeQuestionAsImage,
-    respondingTid,
-    messagesData,
-  ]);
+  const [respondingTid, setRespondingTid] = useState<string | null>(null);
+  const [responseText, setResponseText] = useState("");
+  const [deleteModalOpened, setDeleteModalOpened] = useState(false);
+  const [messageIdToDelete, setMessageIdToDelete] = useState<string | null>(null);
+  const [deletingTid, setDeletingTid] = useState<string | null>(null);
 
-  const sortedMessages = useMemo(() => {
-    const msgs = messagesData?.messages ?? [];
-    if (!threadRootTid) return msgs;
-    const idx = msgs.findIndex((m) => m.tid === threadRootTid);
-    if (idx <= 0) return msgs;
-    return [msgs[idx], ...msgs.slice(0, idx), ...msgs.slice(idx + 1)];
-  }, [messagesData, threadRootTid]);
+  const handle = session?.profile?.handle ?? "";
+  const shortUrl = `${shortlinkurl}/${handle}`;
 
-  useEffect(() => {
-    if (!messagesData || !threadRootTid) return;
-    const found = messagesData.messages.some((m) => m.tid === threadRootTid);
-    if (!found) {
-      setThreadLinks((prev) => {
-        const next = { ...prev };
-        delete next[threadRootTid];
-        return next;
-      });
-      setThreadRootTid(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messagesData, threadRootTid]);
+  const characterLimitFor = (message: Message) => {
+    let budget = MAX_BSKY_POST_LENGTH - GENERAL_BUFFER;
+    if (appendProfileLink && handle) budget -= ` ${shortUrl}`.length;
+    if (!includeQuestionAsImage) budget -= quotedQuestion(message.message).length;
+    return Math.max(0, budget);
+  };
 
-  useEffect(() => {
-    const isNewLogin = sessionStorage.getItem("newLogin");
-    if (isNewLogin === "true") {
-      notifications.show({
-        title: "Welcome back!",
-        message: "You have successfully logged in.",
-        color: "green",
-      });
-      sessionStorage.removeItem("newLogin");
-    }
-  }, []);
+  useWelcomeBackToast();
+  useScrollToNewMessages(messagesData?.messages, prefs.preferences.autoScrollToMessages);
 
   const handleAddExampleMessages = () => {
     if (!session?.did) return;
@@ -511,39 +98,17 @@ export default function Messages() {
     });
   };
 
-  const handleTogglePin = (tid: string) => {
-    triggerHaptic();
-    if (threadRootTid === tid) {
-      setThreadRootTid(null);
-    } else {
-      setThreadRootTid(tid);
-      setJustPinnedTid(tid);
-      setTimeout(() => setJustPinnedTid(null), 420);
-    }
-  };
-
-  const handleDeleteRequest = (tid: string) => {
-    // Unreachable via the UI: the trash icon guards on isPinned first. See
-    // docs/testing-notes.md.
-    /* istanbul ignore if */
-    if (threadRootTid === tid) return;
-    if (confirmBeforeDelete) {
-      setMessageIdToDelete(tid);
-      setDeleteModalOpened(true);
-    } else {
-      performDelete(tid);
-    }
-  };
-
   const performDelete = (tid: string, fromModal = false) => {
+    const closeModal = () => {
+      if (!fromModal) return;
+      setDeleteModalOpened(false);
+      setMessageIdToDelete(null);
+    };
     setDeletingTid(tid);
     deleteMessage(tid, {
       onSuccess: () => {
         if (respondingTid === tid) setRespondingTid(null);
-        if (fromModal) {
-          setDeleteModalOpened(false);
-          setMessageIdToDelete(null);
-        }
+        closeModal();
         refetchMessages().finally(() => setDeletingTid(null));
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -553,34 +118,23 @@ export default function Messages() {
           message: err.error || "Failed to delete message.",
           color: "red",
         });
-        if (fromModal) {
-          setDeleteModalOpened(false);
-          setMessageIdToDelete(null);
-        }
+        closeModal();
         setDeletingTid(null);
       },
     });
   };
 
-  const handleConfirmDelete = () => {
-    // Unreachable via the UI: the Confirm button only exists while the modal is
-    // open, and opening it sets messageIdToDelete. See docs/testing-notes.md.
-    /* istanbul ignore else */
-    if (messageIdToDelete) performDelete(messageIdToDelete, true);
+  const handleDeleteRequest = (tid: string) => {
+    if (confirmBeforeDelete) {
+      setMessageIdToDelete(tid);
+      setDeleteModalOpened(true);
+      return;
+    }
+    performDelete(tid);
   };
 
-  const handlePrepareResponse = (tid: string) => {
-    setRespondingTid(tid);
-    setResponseText("");
-    const idx = sortedMessages.findIndex((m) => m.tid === tid);
-    // Unreachable: every caller passes a tid from sortedMessages. See
-    // docs/testing-notes.md.
-    /* istanbul ignore else */
-    if (idx !== -1) setFocusedCardIndex(idx);
-  };
-
-  const handleSendResponse = (msg: Message) => {
-    if (!responseText.trim()) {
+  const handleSendResponse = (message: Message, response: string) => {
+    if (!response.trim()) {
       notifications.show({
         title: "Empty Response",
         message: "Response cannot be empty.",
@@ -588,57 +142,29 @@ export default function Messages() {
       });
       return;
     }
-    const text =
-      appendProfileLink && session?.profile?.handle
-        ? responseText + ` ${shortlinkurl}/${session.profile.handle}`
-        : responseText;
 
-    const isPinnedMsg = threadRootTid === msg.tid;
-    const rootData = threadRootTid ? threadLinks[threadRootTid] : undefined;
-    const replyTo =
-      !isPinnedMsg && rootData?.uri && rootData?.cid
-        ? { uri: rootData.uri, cid: rootData.cid }
-        : undefined;
+    const text = appendProfileLink && handle ? `${response} ${shortUrl}` : response;
+    const replyTo = thread.replyTarget(message.tid);
 
     respondToMessage(
       {
-        tid: msg.tid,
-        recipient: msg.recipient,
-        original: msg.message,
+        tid: message.tid,
+        recipient: message.recipient,
+        original: message.message,
         response: text,
         includeQuestionAsImage,
         replyTo,
       },
       {
         onSuccess: (data) => {
-          if (isPinnedMsg && data.uri && data.cid) {
-            setThreadLinks((prev) => ({
-              ...prev,
-              [msg.tid]: { uri: data.uri!, cid: data.cid!, link: data.link },
-            }));
+          if (thread.isRoot(message.tid) && data.uri && data.cid) {
+            thread.recordReply(message.tid, { uri: data.uri, cid: data.cid, link: data.link });
           }
           setRespondingTid(null);
           setResponseText("");
-          const successMsg: React.ReactNode = data.link ? (
-            <>
-              {replyTo ? "Added to thread." : "Your response has been posted."}{" "}
-              <a
-                href={data.link}
-                target="_blank"
-                rel="noreferrer"
-                style={{ color: "inherit", textDecoration: "underline" }}
-              >
-                {data.link}
-              </a>
-            </>
-          ) : replyTo ? (
-            "Added to thread."
-          ) : (
-            "Your response has been posted."
-          );
           notifications.show({
             title: replyTo ? "Added to thread!" : "Response Sent!",
-            message: successMsg,
+            message: <PostedNotice link={data.link} inThread={!!replyTo} />,
             color: "green",
             autoClose: 8000,
           });
@@ -656,775 +182,119 @@ export default function Messages() {
     );
   };
 
-  useEffect(() => {
-    if (respondingTid && textareaRef.current) {
-      textareaRef.current.focus();
-      const el = document.getElementById(`message-card-${respondingTid}`);
-      // Unreachable false arm: respondingTid always names a card rendered in the
-      // same commit. See docs/testing-notes.md.
-      // Deferred so the scroll lands after the textarea-expansion layout shift;
-      // the cleanup stops a stale timer scrolling a card from a prior interaction.
-      let handle: ReturnType<typeof setTimeout> | undefined;
-      /* istanbul ignore else */
-      if (el)
-        handle = setTimeout(
-          /* istanbul ignore next */
-          () => el.scrollIntoView({ behavior: "smooth", block: "nearest" }),
-          150
-        );
-      return () => {
-        /* istanbul ignore else */
-        if (handle) clearTimeout(handle);
-      };
-    }
-  }, [respondingTid]);
-
-  useEffect(() => {
-    messageCardRefs.current = sortedMessages.map(() => null);
-  }, [sortedMessages]);
-
-  useEffect(() => {
-    const messages = messagesData?.messages;
-    const count = messages?.length ?? 0;
-    const prev = prevMsgCountRef.current;
-    prevMsgCountRef.current = count;
-    if (autoScrollToMessages && count > prev && messages?.[0]) {
-      const newestCard = document.getElementById(`message-card-${messages[0].tid}`);
-      // The fallback and the guard's false arm are both unreachable: messages[0]
-      // implies its card rendered in this commit. See docs/testing-notes.md.
-      /* istanbul ignore next */
-      const target = newestCard ?? messagesTopRef.current;
-      /* istanbul ignore else */
-      if (target) {
-        const { top, bottom } = target.getBoundingClientRect();
-        if (top >= window.innerHeight || bottom <= 0) {
-          target.scrollIntoView({ behavior: "smooth", block: "nearest" });
-        }
-      }
-    }
-  }, [messagesData, autoScrollToMessages]);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const tag = (event.target as HTMLElement)?.nodeName;
-
-      if (event.key === "Escape" && respondingTid) {
-        event.preventDefault();
-        const idx = sortedMessages.findIndex((m) => m.tid === respondingTid);
-        setRespondingTid(null);
-        // Unreachable -1 branch: respondingTid is always in sortedMessages. See
-        // docs/testing-notes.md.
-        /* istanbul ignore else */
-        if (idx !== -1) messageCardRefs.current[idx]?.focus();
-        return;
-      }
-
-      if (["INPUT", "TEXTAREA", "SELECT"].includes(tag)) return;
-
-      if ((event.altKey || event.metaKey) && event.key.toUpperCase() === "R") {
-        event.preventDefault();
-        if (sortedMessages.length) {
-          const newIdx =
-            focusedCardIndex === -1 ? 0 : (focusedCardIndex + 1) % sortedMessages.length;
-          setFocusedCardIndex(newIdx);
-          messageCardRefs.current[newIdx]?.focus();
-        }
-      }
-      if (focusedCardIndex !== -1 && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
-        event.preventDefault();
-        if (sortedMessages.length) {
-          const newIdx =
-            event.key === "ArrowDown"
-              ? (focusedCardIndex + 1) % sortedMessages.length
-              : (focusedCardIndex - 1 + sortedMessages.length) % sortedMessages.length;
-          setFocusedCardIndex(newIdx);
-          messageCardRefs.current[newIdx]?.focus();
-        }
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [focusedCardIndex, sortedMessages, respondingTid]);
-
   const msgCount = messagesData?.messages?.length ?? 0;
-  const handle = session?.profile?.handle ?? "";
-  const fullUrl = `https://${shortlinkurl}/${handle}`;
+
+  if (sessionLoading) {
+    return (
+      <Center>
+        <Loader size="xl" />
+      </Center>
+    );
+  }
+
+  if (!session?.isLoggedIn) {
+    return (
+      <Alert color="red" title="Not logged in">
+        Please log in to see your messages.
+      </Alert>
+    );
+  }
+
+  const ownerName = session.profile?.displayName || session.profile?.handle || "";
+  // Localised because this text leaves the DOM into a tweet/DM, where Google
+  // Translate cannot reach it (#266).
+  const t = getTouchpointTranslations(userSettings?.touchpointLocale);
 
   return (
     <Box maw={1080}>
-      {sessionLoading ? (
+      <Group justify="space-between" align="flex-end" mb="lg" wrap="wrap" gap="sm">
+        <Box>
+          <Title order={1} style={{ letterSpacing: "-0.03em" }}>
+            Messages
+          </Title>
+          {!messagesLoading && <MessageCount count={msgCount} />}
+        </Box>
+      </Group>
+
+      <InboxLinkCard
+        shortUrl={shortUrl}
+        fullUrl={`https://${shortUrl}`}
+        shareData={{
+          title: t.inboxShareTitle,
+          text: t.inboxShareText(ownerName),
+          url: `https://${shortUrl}`,
+        }}
+      />
+
+      {messagesLoading ? (
         <Center>
-          <Loader size="xl" />
+          <Loader size="lg" />
         </Center>
-      ) : !session?.isLoggedIn ? (
-        <Alert color="red" title="Not logged in">
-          Please log in to see your messages.
-        </Alert>
-      ) : (
+      ) : msgCount > 0 ? (
         <>
-          {/* ── Header row ── */}
-          <Group justify="space-between" align="flex-end" mb="lg" wrap="wrap" gap="sm">
-            <Box>
-              <Title order={1} style={{ letterSpacing: "-0.03em" }}>
-                Messages
-              </Title>
-              {!messagesLoading && (
-                <Text fz={11} c="dimmed" mt={6} style={{ letterSpacing: "0.05em" }}>
-                  {msgCount > 0 ? (
-                    <>
-                      <span style={{ color: "var(--nf-sunshine)" }}>●</span> {msgCount} new
-                    </>
-                  ) : (
-                    "no messages"
-                  )}
-                </Text>
-              )}
-            </Box>
-          </Group>
-
-          {/* ── Gradient inbox link hero card ── */}
-          <Paper
-            mb="md"
-            p="lg"
-            style={{
-              borderRadius: 18,
-              background: "var(--nf-grad-dark)",
-              position: "relative",
-              overflow: "hidden",
-            }}
+          <SimpleGrid
+            cols={{ base: 1, md: 2 }}
+            spacing="md"
+            mb="lg"
+            style={{ alignItems: "start" }}
           >
-            <Group align="center" gap="md" wrap="wrap" style={{ position: "relative" }}>
-              <Box style={{ flex: 1, minWidth: 200 }}>
-                <Text size="xs" c="white" opacity={0.7} fw={500} mb={6}>
-                  Your inbox link · publicly accessible
-                </Text>
-                <Text fw={700} fz={17} style={{ color: "var(--nf-lavender)" }}>
-                  {shortlinkurl}/{handle}
-                </Text>
-              </Box>
-              <Group gap="xs" wrap="wrap">
-                <CopyButton value={fullUrl}>
-                  {({ copied, copy }) => (
-                    <Tooltip label={copied ? "Copied!" : "Copy link"} withArrow>
-                      <Button
-                        onClick={() => {
-                          triggerHaptic();
-                          copy();
-                        }}
-                        size="sm"
-                        radius="xl"
-                        variant="transparent"
-                        leftSection={<IconClipboard size={14} />}
-                        style={
-                          {
-                            background: "rgba(255,255,255,0.15)",
-                            border: "1px solid rgba(255,255,255,0.2)",
-                            "--button-color": "var(--mantine-white)",
-                          } as React.CSSProperties
-                        }
-                      >
-                        {copied ? "Copied!" : "Copy"}
-                      </Button>
-                    </Tooltip>
-                  )}
-                </CopyButton>
-                {(() => {
-                  // Localised because this text leaves the DOM into a tweet/DM,
-                  // where Google Translate cannot reach it (#266).
-                  const ownerName = session.profile?.displayName || session.profile?.handle || "";
-                  const t = getTouchpointTranslations(userSettings?.touchpointLocale);
-                  const sharePayload = {
-                    title: t.inboxShareTitle,
-                    text: t.inboxShareText(ownerName),
-                    url: fullUrl,
-                  };
-                  return <ShareButton shareData={sharePayload} />;
-                })()}
-              </Group>
-            </Group>
-          </Paper>
+            <PostingPreferences state={prefs} />
+            <ImageThemePicker
+              selected={settingsLoading ? null : (userSettings?.imageTheme ?? null)}
+              disabled={settingsLoading || updateSettings.isPending}
+              onSelect={(imageTheme) =>
+                updateSettings.mutate({
+                  imageTheme,
+                  pdsSyncEnabled: Boolean(userSettings?.pdsSyncEnabled),
+                })
+              }
+            />
+          </SimpleGrid>
 
-          {messagesLoading ? (
-            <Center>
-              <Loader size="lg" />
-            </Center>
-          ) : msgCount > 0 ? (
-            <>
-              {/* ── Two-column: Preferences + Image theme ── */}
-              <SimpleGrid
-                cols={{ base: 1, md: 2 }}
-                spacing="md"
-                mb="lg"
-                style={{ alignItems: "start" }}
-              >
-                {/* Posting preferences accordion */}
-                <Paper
-                  withBorder
-                  p={0}
-                  style={{
-                    borderRadius: 16,
-                    overflow: "hidden",
-                    background: surfaceBg(isDark),
-                  }}
-                >
-                  <Box
-                    style={{
-                      cursor: "pointer",
-                      padding: "14px 20px",
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      userSelect: "none",
-                    }}
-                    onClick={() => {
-                      triggerHaptic();
-                      setPostingPrefsOpen((o) => !o);
-                    }}
-                  >
-                    <Text fw={700} fz={15}>
-                      Posting preferences
-                    </Text>
-                    <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                      <Text size="xs" c="dimmed">
-                        {
-                          [
-                            appendProfileLink,
-                            useGradients,
-                            includeQuestionAsImage,
-                            confirmBeforeDelete,
-                            autoScrollToMessages,
-                          ].filter(Boolean).length
-                        }{" "}
-                        of 5 on
-                      </Text>
-                      <IconChevronDown
-                        size={16}
-                        style={{
-                          transition: "transform 200ms ease",
-                          transform: postingPrefsOpen ? "rotate(180deg)" : "rotate(0deg)",
-                          color: "var(--mantine-color-dimmed)",
-                        }}
-                      />
-                    </span>
-                  </Box>
-                  <Collapse expanded={postingPrefsOpen}>
-                    <Box
-                      px="md"
-                      pb="sm"
-                      style={{
-                        borderTop: "1px solid var(--mantine-color-default-border)",
-                      }}
-                    >
-                      {[
-                        {
-                          checked: appendProfileLink,
-                          onChange: setAppendProfileLink,
-                          label: "Auto-append inbox link",
-                          sub: "Appends your link to every post. Reduces character budget.",
-                        },
-                        {
-                          checked: useGradients,
-                          onChange: setUseGradients,
-                          label: "Gradient backgrounds",
-                          sub: "Pretty for screenshots. Turn off for higher contrast.",
-                        },
-                        {
-                          checked: includeQuestionAsImage,
-                          onChange: setIncludeQuestionAsImage,
-                          label: "Question as image",
-                          sub: "Generates a shareable image with auto alt text.",
-                        },
-                        {
-                          checked: confirmBeforeDelete,
-                          onChange: setConfirmBeforeDelete,
-                          label: "Confirm before deleting",
-                          sub: "Leave off if you want to bulk-delete messages.",
-                        },
-                        {
-                          checked: autoScrollToMessages,
-                          onChange: setAutoScrollToMessages,
-                          label: "Auto-scroll to messages",
-                          sub: "Scrolls new messages into view when they load.",
-                        },
-                      ].map(({ checked, onChange, label, sub }) => (
-                        <Box
-                          key={label}
-                          py="xs"
-                          style={{
-                            borderBottom: "1px solid var(--mantine-color-default-border)",
-                          }}
-                        >
-                          <Switch
-                            checked={!!checked}
-                            onChange={(e) => onChange(e.currentTarget.checked)}
-                            label={
-                              <Box>
-                                <Text fw={600} size="sm">
-                                  {label}
-                                </Text>
-                                <Text size="xs" c="dimmed" mt={2}>
-                                  {sub}
-                                </Text>
-                              </Box>
-                            }
-                          />
-                        </Box>
-                      ))}
-                    </Box>
-                  </Collapse>
-                </Paper>
-
-                {/* Image theme visual picker */}
-                <Paper
-                  withBorder
-                  p={0}
-                  style={{
-                    borderRadius: 16,
-                    overflow: "hidden",
-                    background: surfaceBg(isDark),
-                  }}
-                >
-                  <Box
-                    style={{
-                      cursor: "pointer",
-                      padding: "14px 20px",
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      userSelect: "none",
-                    }}
-                    onClick={() => {
-                      triggerHaptic();
-                      setImageThemeOpen((o) => !o);
-                    }}
-                  >
-                    <Text fw={700} fz={15}>
-                      Image theme
-                    </Text>
-                    <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                      <Text size="xs" c="dimmed">
-                        {
-                          themes[
-                            (settingsLoading
-                              ? "default"
-                              : userSettings?.imageTheme || "default") as keyof typeof themes
-                          ]
-                        }
-                      </Text>
-                      <IconChevronDown
-                        size={16}
-                        style={{
-                          transition: "transform 200ms ease",
-                          transform: imageThemeOpen ? "rotate(180deg)" : "rotate(0deg)",
-                          color: "var(--mantine-color-dimmed)",
-                        }}
-                      />
-                    </span>
-                  </Box>
-                  <Collapse expanded={imageThemeOpen}>
-                    <Box
-                      px="md"
-                      pb="md"
-                      style={{
-                        borderTop: "1px solid var(--mantine-color-default-border)",
-                      }}
-                    >
-                      <Group grow gap="sm" mt="sm">
-                        {Object.entries(themes).map(([value, label]) => (
-                          <ThemeCard
-                            key={value}
-                            value={value}
-                            label={label as string}
-                            selected={
-                              settingsLoading
-                                ? value === "default"
-                                : (userSettings?.imageTheme || "default") === value
-                            }
-                            onClick={() => {
-                              if (!settingsLoading && !updateSettings.isPending) {
-                                updateSettings.mutate({
-                                  imageTheme: value,
-                                  pdsSyncEnabled: Boolean(userSettings?.pdsSyncEnabled),
-                                });
-                              }
-                            }}
-                          />
-                        ))}
-                      </Group>
-
-                      <Box
-                        mt="md"
-                        pt="md"
-                        style={{
-                          borderTop: "1px solid var(--mantine-color-default-border)",
-                        }}
-                      >
-                        <Text fw={600} c="dimmed" mb="xs" fz={11}>
-                          Keyboard Shortcuts
-                        </Text>
-                        <Stack gap={2}>
-                          {[
-                            { label: "Focus / cycle cards", hint: "Alt+R" },
-                            { label: "Navigate cards", hint: "↑ / ↓" },
-                            { label: "Close expanded card", hint: "Esc" },
-                          ].map(({ label, hint }) => (
-                            <Box
-                              key={label}
-                              style={{
-                                display: "flex",
-                                justifyContent: "space-between",
-                                padding: "3px 0",
-                              }}
-                            >
-                              <Text fz={12}>{label}</Text>
-                              <Text fz={11} c="dimmed">
-                                {hint.replace("Alt", "Alt/⌘")}
-                              </Text>
-                            </Box>
-                          ))}
-                        </Stack>
-                      </Box>
-                    </Box>
-                  </Collapse>
-                </Paper>
-              </SimpleGrid>
-
-              {/* ── Question cards grid ── */}
-              <div ref={messagesTopRef} />
-              <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
-                {sortedMessages.map((msg: Message, index: number) => {
-                  const isExpanded = respondingTid === msg.tid;
-                  const isFocused = focusedCardIndex === index;
-                  const isPinned = threadRootTid === msg.tid;
-                  const threadLinkData = isPinned ? threadLinks[msg.tid] : undefined;
-
-                  return (
-                    <Paper
-                      id={`message-card-${msg.tid}`}
-                      ref={(el) => {
-                        messageCardRefs.current[index] = el;
-                      }}
-                      key={msg.tid}
-                      tabIndex={0}
-                      role="button"
-                      aria-expanded={isExpanded}
-                      radius="lg"
-                      onFocus={() => setFocusedCardIndex(index)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          if (isExpanded) {
-                            setRespondingTid(null);
-                          } else {
-                            handlePrepareResponse(msg.tid);
-                          }
-                        }
-                      }}
-                      className={justPinnedTid === msg.tid ? "nf-pinned-card-enter" : undefined}
-                      style={{
-                        borderRadius: 18,
-                        background: useGradients ? "var(--nf-grad-dark)" : surfaceBg(isDark),
-                        border: isPinned
-                          ? "2px solid var(--nf-royal)"
-                          : isFocused
-                            ? "2px solid var(--nf-purple)"
-                            : "2px solid rgba(255,255,255,0.06)",
-                        boxShadow: isPinned
-                          ? "0 4px 22px -4px rgba(59,91,255,0.38)"
-                          : "0 4px 16px -8px rgba(0,0,0,0.3)",
-                        padding: "8px 20px 20px",
-                        transition: "border-color 0.15s ease, box-shadow 0.15s ease",
-                        cursor: "pointer",
-                        display: "flex",
-                        flexDirection: "column",
-                      }}
-                      onClick={() => {
-                        triggerHaptic();
-                        if (isExpanded) {
-                          setRespondingTid(null);
-                        } else {
-                          handlePrepareResponse(msg.tid);
-                        }
-                      }}
-                    >
-                      <Stack gap="sm" style={{ flex: 1 }}>
-                        {/* Timestamp + action row */}
-                        <Group justify="space-between" align="center">
-                          <Group gap={6} align="center">
-                            <Text
-                              fz={10}
-                              c="white"
-                              opacity={0.8}
-                              style={{
-                                letterSpacing: "0.08em",
-                                textTransform: "uppercase",
-                              }}
-                            >
-                              {formatTimestamp(msg.createdAt)}
-                            </Text>
-                          </Group>
-                          <Group gap={2} align="center">
-                            <Tooltip
-                              label={isPinned ? "Unpin thread" : "Pin as thread root"}
-                              withArrow
-                              position="left"
-                              openDelay={500}
-                            >
-                              <ActionIcon
-                                size="lg"
-                                className={isPinned ? "nf-pin-btn--active" : "nf-pin-btn"}
-                                aria-label={isPinned ? "Unpin thread root" : "Set as thread root"}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleTogglePin(msg.tid);
-                                }}
-                                variant="transparent"
-                                radius="md"
-                                style={{
-                                  color: isPinned ? "var(--nf-royal)" : "rgba(253,248,255,0.4)",
-                                  transition: "color 150ms ease, background 150ms ease",
-                                }}
-                              >
-                                {isPinned ? <IconPinned size={18} /> : <IconPin size={18} />}
-                              </ActionIcon>
-                            </Tooltip>
-                            <Tooltip
-                              label={isPinned ? "Unpin thread first" : "Delete message"}
-                              withArrow
-                              position="left"
-                              openDelay={500}
-                            >
-                              <ActionIcon
-                                size="lg"
-                                className={isPinned ? undefined : "nf-delete-btn"}
-                                aria-label={
-                                  isPinned ? "Cannot delete thread root" : "Delete message"
-                                }
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  if (isPinned) return;
-                                  triggerHaptic();
-                                  handleDeleteRequest(msg.tid);
-                                }}
-                                variant="transparent"
-                                radius="md"
-                                loading={deletingTid === msg.tid}
-                                style={{
-                                  color: isPinned
-                                    ? "rgba(253,248,255,0.2)"
-                                    : "rgba(253,248,255,0.5)",
-                                  cursor: isPinned ? "not-allowed" : "pointer",
-                                  transition: "color 150ms ease, background 150ms ease",
-                                }}
-                              >
-                                <IconTrash size={18} />
-                              </ActionIcon>
-                            </Tooltip>
-                          </Group>
-                        </Group>
-
-                        {/* Message text */}
-                        <Box
-                          style={{
-                            flex: 1,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                          }}
-                        >
-                          <Text
-                            c="white"
-                            fw={600}
-                            style={
-                              {
-                                fontSize: 20,
-                                lineHeight: 1.35,
-                                wordBreak: "break-word",
-                                whiteSpace: "pre-wrap",
-                                textAlign: "center",
-                                textWrap: "balance",
-                                width: "100%",
-                              } as React.CSSProperties
-                            }
-                          >
-                            {msg.message}
-                          </Text>
-                        </Box>
-
-                        {/* Thread parent link */}
-                        {threadLinkData?.link && (
-                          <Box>
-                            <a
-                              href={threadLinkData.link}
-                              target="_blank"
-                              rel="noreferrer"
-                              onClick={(e) => e.stopPropagation()}
-                              style={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: 4,
-                                color: "var(--nf-lavender)",
-                                textDecoration: "none",
-                                fontSize: 11,
-                                opacity: 0.75,
-                              }}
-                            >
-                              <IconExternalLink size={11} style={{ flexShrink: 0 }} />
-                              <span
-                                style={{
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {threadLinkData.link.replace("https://", "")}
-                              </span>
-                            </a>
-                          </Box>
-                        )}
-
-                        {/* Action area */}
-                        {isExpanded ? (
-                          <Box
-                            onClick={(e) => e.stopPropagation()}
-                            style={{
-                              marginTop: 4,
-                              background: "#fff",
-                              borderRadius: 12,
-                              padding: 12,
-                              border: "1.5px solid #5B7BFF",
-                            }}
-                          >
-                            <Textarea
-                              ref={textareaRef}
-                              value={responseText}
-                              maxLength={characterLimit}
-                              onChange={(e) => setResponseText(e.target.value)}
-                              autosize
-                              minRows={2}
-                              maxRows={4}
-                              aria-label="Your response"
-                              onKeyDown={(e) => {
-                                e.stopPropagation();
-                                if (e.key === "Escape") {
-                                  e.preventDefault();
-                                  setRespondingTid(null);
-                                  messageCardRefs.current[index]?.focus();
-                                } else if (e.key === "Enter" && !e.shiftKey) {
-                                  e.preventDefault();
-                                  handleSendResponse(msg);
-                                }
-                              }}
-                              placeholder="write your reply…"
-                              styles={replyTextareaStyles}
-                            />
-                            <Group justify="space-between" align="center" mt={8}>
-                              <Group gap={8} align="center">
-                                <CharRing count={responseText.length} limit={characterLimit} />
-                                <Text size="xs" c="dimmed">
-                                  {responseText.length}/{characterLimit}
-                                </Text>
-                              </Group>
-                              <Tooltip
-                                label="Respond to the thread root first"
-                                disabled={
-                                  !(
-                                    !isPinned &&
-                                    !!threadRootTid &&
-                                    !threadLinks[threadRootTid]?.uri
-                                  )
-                                }
-                                withArrow
-                                openDelay={300}
-                              >
-                                <Button
-                                  size="xs"
-                                  onClick={() => {
-                                    triggerHaptic();
-                                    handleSendResponse(msg);
-                                  }}
-                                  loading={respondLoading}
-                                  disabled={
-                                    !isPinned && !!threadRootTid && !threadLinks[threadRootTid]?.uri
-                                  }
-                                  variant="gradient"
-                                  gradient={{
-                                    from: "royal",
-                                    to: "purple",
-                                    deg: 135,
-                                  }}
-                                  leftSection={<IconSend2 size={12} />}
-                                >
-                                  {!isPinned && threadRootTid ? "Reply to thread" : "Reply"}
-                                </Button>
-                              </Tooltip>
-                            </Group>
-                          </Box>
-                        ) : (
-                          <Box mt={4} onClick={(e) => e.stopPropagation()}>
-                            {(() => {
-                              const blocked =
-                                !isPinned && !!threadRootTid && !threadLinks[threadRootTid]?.uri;
-                              return (
-                                <Tooltip
-                                  label="Respond to the thread root first"
-                                  disabled={!blocked}
-                                  withArrow
-                                  openDelay={300}
-                                >
-                                  <Button
-                                    onClick={() => {
-                                      if (blocked) return;
-                                      triggerHaptic();
-                                      handlePrepareResponse(msg.tid);
-                                    }}
-                                    fullWidth
-                                    radius="md"
-                                    color="sunshine"
-                                    variant="filled"
-                                    fw={700}
-                                    style={{
-                                      color: "var(--nf-midnight)",
-                                      opacity: blocked ? 0.45 : 1,
-                                      cursor: blocked ? "not-allowed" : undefined,
-                                    }}
-                                  >
-                                    {!isPinned && threadRootTid ? "↩ Reply to thread" : "↩ Reply"}
-                                  </Button>
-                                </Tooltip>
-                              );
-                            })()}
-                          </Box>
-                        )}
-                      </Stack>
-                    </Paper>
-                  );
-                })}
-              </SimpleGrid>
-            </>
-          ) : (
-            <Alert color="royal" title="No messages">
-              <Text fz="sm" mb="sm">
-                You don&apos;t have any messages yet. Share your profile link to receive anonymous
-                questions.
-              </Text>
-              <Button
-                onClick={() => {
-                  triggerHaptic();
-                  handleAddExampleMessages();
-                }}
-                loading={examplesLoading}
-                size="xs"
-                radius="md"
-                color="sunshine"
-                variant="filled"
-                style={{ color: "var(--nf-midnight)", fontWeight: 700 }}
-              >
-                Add example messages
-              </Button>
-            </Alert>
-          )}
+          <QuestionGrid
+            messages={thread.ordered}
+            thread={thread}
+            gradient={useGradients}
+            respondingTid={respondingTid}
+            onExpand={(tid) => {
+              setRespondingTid(tid);
+              setResponseText("");
+            }}
+            onCollapse={() => setRespondingTid(null)}
+            responseText={responseText}
+            onResponseTextChange={setResponseText}
+            characterLimitFor={characterLimitFor}
+            onSend={handleSendResponse}
+            sending={respondLoading}
+            deletingTid={deletingTid}
+            onDelete={handleDeleteRequest}
+            onTogglePin={(tid) => {
+              triggerHaptic();
+              thread.togglePin(tid);
+            }}
+          />
         </>
+      ) : (
+        <Alert color="royal" title="No messages">
+          <Text fz="sm" mb="sm">
+            You don&apos;t have any messages yet. Share your profile link to receive anonymous
+            questions.
+          </Text>
+          <Button
+            onClick={() => {
+              triggerHaptic();
+              handleAddExampleMessages();
+            }}
+            loading={examplesLoading}
+            size="xs"
+            radius="md"
+            color="sunshine"
+            variant="filled"
+            style={sunshineButton}
+          >
+            Add example messages
+          </Button>
+        </Alert>
       )}
 
       <ConfirmationModal
@@ -1435,13 +305,82 @@ export default function Messages() {
             setMessageIdToDelete(null);
           }
         }}
-        onConfirm={handleConfirmDelete}
+        onConfirm={() => performDelete(messageIdToDelete!, true)}
         title="Confirm Deletion"
         message="Are you sure you want to delete this message? This action cannot be undone."
         confirmLabel="Delete"
         cancelLabel="Cancel"
+        destructive
         loading={deletingTid !== null && deletingTid === messageIdToDelete}
       />
     </Box>
   );
+}
+
+function MessageCount({ count }: { count: number }) {
+  return (
+    <Text fz={11} c="dimmed" mt={6} style={{ letterSpacing: "0.05em" }}>
+      {count > 0 ? (
+        <>
+          <span style={{ color: "var(--nf-sunshine)" }} aria-hidden>
+            ●
+          </span>{" "}
+          {count} new
+        </>
+      ) : (
+        "no messages"
+      )}
+    </Text>
+  );
+}
+
+function PostedNotice({ link, inThread }: { link?: string; inThread: boolean }) {
+  const summary = inThread ? "Added to thread." : "Your response has been posted.";
+  if (!link) return <>{summary}</>;
+  return (
+    <>
+      {summary}{" "}
+      <a
+        href={link}
+        target="_blank"
+        rel="noreferrer"
+        style={{ color: "inherit", textDecoration: "underline" }}
+      >
+        {link}
+      </a>
+    </>
+  );
+}
+
+/** One-shot greeting after the OAuth round trip lands back on this page. */
+function useWelcomeBackToast() {
+  useEffect(() => {
+    if (sessionStorage.getItem("newLogin") !== "true") return;
+    notifications.show({
+      title: "Welcome back!",
+      message: "You have successfully logged in.",
+      color: "green",
+    });
+    sessionStorage.removeItem("newLogin");
+  }, []);
+}
+
+/** Brings a newly arrived question into view, but only if it landed off screen. */
+function useScrollToNewMessages(messages: Message[] | undefined, enabled: boolean) {
+  const previousCount = useRef(0);
+
+  useEffect(() => {
+    const count = messages?.length ?? 0;
+    const grew = count > previousCount.current;
+    previousCount.current = count;
+    if (!enabled || !grew || !messages?.[0]) return;
+
+    const newest = document.getElementById(`message-card-${messages[0].tid}`);
+    /* istanbul ignore next */
+    if (!newest) return;
+    const { top, bottom } = newest.getBoundingClientRect();
+    if (top >= window.innerHeight || bottom <= 0) {
+      newest.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [messages, enabled]);
 }

--- a/client/src/pages/OAuthCallback.tsx
+++ b/client/src/pages/OAuthCallback.tsx
@@ -1,22 +1,14 @@
-import {
-  Box,
-  Loader,
-  Stack,
-  Text,
-  Title,
-  Paper,
-  Button,
-  useComputedColorScheme,
-} from "@mantine/core";
+import { Box, Button, Loader, Text, Title } from "@mantine/core";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
-import { useNavigate, useLocation } from "react-router";
+import { Link, useNavigate, useLocation } from "react-router";
 
 import { apiClient } from "../api/apiClient";
 import { authKeys } from "../api/authService";
+import { AuthPanel } from "../components/AuthPanel";
+import * as panelStyles from "../components/AuthPanel.styles";
 import { WinkMark } from "../components/WinkMark";
-import { surfaceBg } from "../styles/tokens";
+import { BRAND_GRADIENT, dangerText } from "../styles/tokens";
 
 export default function OAuthCallback() {
   const navigate = useNavigate();
@@ -27,7 +19,6 @@ export default function OAuthCallback() {
     !token ? "Missing OAuth token in callback URL." : null
   );
   const [loading, setLoading] = useState(!!token);
-  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
 
   useEffect(() => {
     if (!token) return;
@@ -47,69 +38,44 @@ export default function OAuthCallback() {
 
   return (
     <Box maw={480} mx="auto" mt="xl">
-      <Paper
-        radius="lg"
-        p="xl"
-        withBorder
-        style={{
-          background: surfaceBg(isDark),
-          position: "relative",
-          overflow: "hidden",
-        }}
-      >
-        <Box
-          style={{
-            position: "absolute",
-            inset: 0,
-            background: isDark
-              ? "radial-gradient(ellipse 60% 100% at 50% 0%, rgba(139,92,246,0.15), transparent 70%)"
-              : "radial-gradient(ellipse 60% 100% at 50% 0%, rgba(196,181,253,0.4), transparent 70%)",
-            pointerEvents: "none",
-          }}
-        />
+      <AuthPanel>
+        <Box ta="center">
+          <WinkMark size={60} sparkle={loading} style={panelStyles.mark} />
+        </Box>
 
-        <Stack gap="md" align="center" style={{ position: "relative" }}>
-          <WinkMark
-            size={60}
-            sparkle={loading}
-            style={{
-              borderRadius: 16,
-              boxShadow: "0 12px 30px -10px rgba(20,18,58,0.4)",
-            }}
-          />
-
-          {loading ? (
-            <>
-              <Title order={2} fw={800} fz={24} ta="center">
-                Logging you in…
-              </Title>
-              <Text size="sm" c="dimmed" ta="center">
-                Completing your Bluesky authentication
-              </Text>
+        {loading ? (
+          <>
+            <Title order={2} fw={800} fz={24} ta="center">
+              Logging you in…
+            </Title>
+            <Text size="sm" c="dimmed" ta="center">
+              Completing your Bluesky authentication
+            </Text>
+            <Box ta="center">
               <Loader size="sm" />
-            </>
-          ) : (
-            <>
-              <Title order={2} fw={800} fz={24} ta="center" c="red">
-                Login failed
-              </Title>
-              <Text size="sm" c="dimmed" ta="center">
-                {error}
-              </Text>
-              <Button
-                component={Link}
-                to="/login"
-                variant="gradient"
-                gradient={{ from: "royal", to: "purple", deg: 135 }}
-                fullWidth
-                radius="md"
-              >
-                Try again
-              </Button>
-            </>
-          )}
-        </Stack>
-      </Paper>
+            </Box>
+          </>
+        ) : (
+          <>
+            <Title order={2} fw={800} fz={24} ta="center" style={{ color: dangerText }}>
+              Login failed
+            </Title>
+            <Text size="sm" c="dimmed" ta="center">
+              {error}
+            </Text>
+            <Button
+              component={Link}
+              to="/login"
+              variant="gradient"
+              gradient={BRAND_GRADIENT}
+              fullWidth
+              radius="md"
+            >
+              Try again
+            </Button>
+          </>
+        )}
+      </AuthPanel>
 
       <Text size="xs" c="dimmed" ta="center" mt="md" style={{ lineHeight: 1.6 }}>
         You will be redirected automatically once login is complete.

--- a/client/src/pages/PublicProfile.styles.ts
+++ b/client/src/pages/PublicProfile.styles.ts
@@ -1,0 +1,9 @@
+import type { CSSProperties } from "react";
+
+import { radiusControl, surfaceGhost } from "../styles/tokens";
+
+export const disclaimer: CSSProperties = {
+  background: surfaceGhost,
+  borderRadius: radiusControl,
+  padding: "12px 14px",
+};

--- a/client/src/pages/PublicProfile.tsx
+++ b/client/src/pages/PublicProfile.tsx
@@ -1,67 +1,21 @@
-import {
-  Container,
-  Text,
-  Paper,
-  Stack,
-  Button,
-  ActionIcon,
-  Group,
-  Textarea,
-  Avatar,
-  Box,
-  Alert,
-  Skeleton,
-  Tooltip,
-  CopyButton,
-  useComputedColorScheme,
-} from "@mantine/core";
+import { Container, Group, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { IconSend, IconX, IconWorld, IconClipboard, IconShare } from "@tabler/icons-react";
 import { useState, useRef, useEffect } from "react";
 import { useParams } from "react-router";
-import { useHaptic } from "use-haptic";
 
 import { useSendMessage } from "../api/messageService";
 import { useResolveHandle, usePublicProfile } from "../api/profileService";
 import { ConfirmationModal } from "../components/ConfirmationModal";
-import { WinkMark } from "../components/WinkMark";
+import { AskCard } from "../components/profile/AskCard";
+import { ProfileCard } from "../components/profile/ProfileCard";
+import { ProfileNotice } from "../components/profile/ProfileNotice";
+import { ProfileSkeleton } from "../components/profile/ProfileSkeleton";
+import { ProfileUrlBar } from "../components/profile/ProfileUrlBar";
 import { profileCardGradient } from "../lib/themes";
 import { getTouchpointTranslations } from "../lib/touchpointTranslations";
-import { ghostBg } from "../styles/tokens";
-import { parseRichText } from "../utils/parseRichText";
+import * as styles from "./PublicProfile.styles";
 
 const MAX_MESSAGE_LENGTH = 150;
-
-const askCardTextareaStyles = {
-  input: {
-    backgroundColor: "rgba(255,255,255,0.95)",
-    color: "#1a1a2e",
-    border: "none",
-  },
-  description: {
-    color: "rgba(255,255,255,0.5)",
-    textAlign: "right" as const,
-  },
-} as const;
-
-function ExternalLinkIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M18 2h3v3" />
-      <path d="M21 2L10 13" />
-      <path d="M21 12v6a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3h6" />
-    </svg>
-  );
-}
 
 export default function PublicProfile() {
   const { handle } = useParams<{ handle: string }>();
@@ -82,25 +36,14 @@ export default function PublicProfile() {
   const profile = profileData?.profile || null;
 
   const { mutate: sendMessage, isPending: sendLoading } = useSendMessage();
-  const { triggerHaptic } = useHaptic(1);
-  const isDark = useComputedColorScheme("light", { getInitialValueInEffect: true }) === "dark";
 
-  const touchpointLocale = profileData?.touchpointLocale ?? null;
-  const t = getTouchpointTranslations(touchpointLocale);
-  const askCardGradient = profileCardGradient(profileData?.profileCardTheme ?? null);
-  // The server sends a real boolean; undefined means the field wasn't returned.
-  const inboxOpen = profileData?.inboxEnabled !== false;
-  const ownerName = profile?.displayName || profile?.handle || "";
+  useFocusScroll(textareaRef);
+  useRevealAskCard(askCardRef, !handleLoading && !profileLoading && !!profile);
 
   const handleSend = () => {
     setFormError(null);
     if (!message.trim()) {
       setFormError("Message cannot be empty.");
-      return;
-    }
-    /* istanbul ignore if */
-    if (message.length > MAX_MESSAGE_LENGTH) {
-      setFormError(`Message cannot be longer than ${MAX_MESSAGE_LENGTH} characters.`);
       return;
     }
     setModalOpened(true);
@@ -129,13 +72,9 @@ export default function PublicProfile() {
           setModalOpened(false);
         },
         onError: (err: unknown) => {
-          const e = err as Record<string, unknown>;
           notifications.show({
             title: "Failed to send",
-            message:
-              (typeof e?.message === "string" ? e.message : undefined) ??
-              (typeof e?.error === "string" ? e.error : undefined) ??
-              "Failed to send message. Please try again.",
+            message: sendFailureMessage(err),
             color: "red",
           });
           setModalOpened(false);
@@ -144,457 +83,125 @@ export default function PublicProfile() {
     );
   };
 
-  const isLoading = handleLoading || profileLoading;
-
-  useEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    const handleFocus = () => el.scrollIntoView({ behavior: "smooth", block: "center" });
-    el.addEventListener("focus", handleFocus);
-    return () => el.removeEventListener("focus", handleFocus);
-  }, []);
-
-  useEffect(() => {
-    if (!isLoading && profile && askCardRef.current) {
-      const rect = askCardRef.current.getBoundingClientRect();
-      if (rect.bottom > window.innerHeight) {
-        askCardRef.current.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-        });
-      }
-    }
-  }, [isLoading, profile]);
-
   if (handleError) {
-    const errObj =
-      typeof handleError === "object" && handleError !== null
-        ? (handleError as unknown as Record<string, unknown>)
-        : null;
-    const is404 = errObj !== null && errObj["status"] === 404;
-    const errMessage =
-      errObj !== null && typeof errObj["error"] === "string"
-        ? errObj["error"]
-        : "Failed to resolve handle. The handle may not exist.";
-    return (
-      <Container>
-        <Paper p="md" withBorder>
-          <Text c={is404 ? "yellow" : "red"} fw={700}>
-            {is404 ? "No Bluesky account found" : "Error"}
-          </Text>
-          <Text>
-            {is404 ? (
-              <>
-                <strong>@{handle}</strong> doesn&apos;t exist on Bluesky. Check the handle and try
-                again.
-              </>
-            ) : (
-              errMessage
-            )}
-          </Text>
-        </Paper>
-      </Container>
+    const { is404, message: errMessage } = describeHandleError(handleError);
+    return is404 ? (
+      <ProfileNotice tone="yellow" title="No Bluesky account found">
+        <strong>@{handle}</strong> doesn&apos;t exist on Bluesky. Check the handle and try again.
+      </ProfileNotice>
+    ) : (
+      <ProfileNotice tone="red" title="Error">
+        {errMessage}
+      </ProfileNotice>
     );
   }
 
-  if (isLoading) {
-    return (
-      <Container>
-        <Skeleton height={28} width={180} radius={999} mb="sm" />
-        <Paper mb="lg" withBorder style={{ borderRadius: 16, overflow: "hidden" }}>
-          <Skeleton height={160} radius={0} />
-          <Box style={{ padding: "0 24px 18px", position: "relative" }}>
-            <Skeleton
-              circle
-              height={84}
-              width={84}
-              style={{
-                position: "absolute",
-                top: -42,
-                left: 16,
-                border: "4px solid var(--mantine-color-body)",
-              }}
-            />
-            <Group justify="space-between" align="flex-start" pt={52}>
-              <Box>
-                <Skeleton height={28} width={180} mb={6} />
-                <Skeleton height={14} width={120} />
-              </Box>
-              <Skeleton height={28} width={130} radius={999} />
-            </Group>
-            <Skeleton height={14} mt="sm" />
-            <Skeleton height={14} mt={6} width="75%" />
-          </Box>
-        </Paper>
-        <Paper
-          style={{
-            borderRadius: 18,
-            padding: 28,
-            background: "var(--nf-grad-mark)",
-            border: "2px solid var(--mantine-color-default-border)",
-          }}
-        >
-          <Skeleton height={26} width="70%" mx="auto" mb="lg" />
-          <Skeleton height={80} radius="md" mb="xs" />
-          <Group justify="flex-end" gap="xs">
-            <Skeleton height={36} width={36} radius="md" />
-            <Skeleton height={36} width={90} radius={999} />
-          </Group>
-        </Paper>
-      </Container>
-    );
-  }
+  if (handleLoading || profileLoading) return <ProfileSkeleton />;
 
   if (did && profileData && !profileData.exists) {
     return (
-      <Container>
-        <Paper p="md" withBorder>
-          <Text c="yellow" fw={700}>
-            Not on Navyfragen
-          </Text>
-          <Text>
-            <strong>@{handle}</strong> has a Bluesky account but hasn&apos;t set up their Navyfragen
-            inbox yet.
-          </Text>
-        </Paper>
-      </Container>
+      <ProfileNotice tone="yellow" title="Not on Navyfragen">
+        <strong>@{handle}</strong> has a Bluesky account but hasn&apos;t set up their Navyfragen
+        inbox yet.
+      </ProfileNotice>
     );
   }
 
+  if (!profile) {
+    return (
+      <ProfileNotice tone="red" title="Error">
+        Failed to load profile information.
+      </ProfileNotice>
+    );
+  }
+
+  const t = getTouchpointTranslations(profileData?.touchpointLocale ?? null);
+  const ownerName = profile.displayName || profile.handle || "";
+  const profileUrl = `https://fragen.navy/${profile.handle}`;
+
   return (
     <Container>
-      {profile ? (
-        <>
-          {/* URL breadcrumb row — pill showing fragen.navy/handle + copy/share actions */}
-          <Group justify="space-between" align="center" mb="sm">
-            <Box
-              component="span"
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 8,
-                background: ghostBg(isDark),
-                border: "1px solid var(--mantine-color-default-border)",
-                padding: "6px 12px 6px 10px",
-                borderRadius: 999,
-                fontFamily: "var(--nf-font-mono)",
-                fontSize: 12,
-                color: "var(--mantine-color-dimmed)",
-              }}
-            >
-              <IconWorld size={12} />
-              fragen.navy/
-              <Text
-                component="span"
-                inherit
-                style={{ color: "var(--mantine-color-text)", fontWeight: 600 }}
-              >
-                {profile.handle}
-              </Text>
-            </Box>
+      <ProfileUrlBar
+        handle={profile.handle!}
+        url={profileUrl}
+        shareTitle={t.shareTitle(ownerName)}
+      />
 
-            <Group gap="xs">
-              <CopyButton value={`https://fragen.navy/${profile.handle}`}>
-                {({ copied, copy }) => (
-                  <Tooltip label={copied ? "Copied!" : "Copy link"} withArrow>
-                    <ActionIcon
-                      onClick={() => {
-                        triggerHaptic();
-                        copy();
-                      }}
-                      variant="subtle"
-                      radius="xl"
-                      size="md"
-                      aria-label="Copy profile link"
-                      style={{
-                        background: ghostBg(isDark),
-                        border: "1px solid var(--mantine-color-default-border)",
-                        color: "var(--mantine-color-dimmed)",
-                      }}
-                    >
-                      <IconClipboard size={14} />
-                    </ActionIcon>
-                  </Tooltip>
-                )}
-              </CopyButton>
+      <ProfileCard profile={profile} />
 
-              {navigator.share && (
-                <ActionIcon
-                  onClick={async () => {
-                    triggerHaptic();
-                    try {
-                      await navigator.share({
-                        title: t.shareTitle(ownerName),
-                        url: `https://fragen.navy/${profile.handle}`,
-                      });
-                    } catch (e) {
-                      if (e instanceof DOMException && e.name === "AbortError") return;
-                      notifications.show({
-                        color: "red",
-                        title: "Share failed",
-                        message: "Could not share link.",
-                      });
-                    }
-                  }}
-                  variant="subtle"
-                  radius="xl"
-                  size="md"
-                  aria-label="Share profile link"
-                  style={{
-                    background: ghostBg(isDark),
-                    border: "1px solid var(--mantine-color-default-border)",
-                    color: "var(--mantine-color-dimmed)",
-                  }}
-                >
-                  <IconShare size={14} />
-                </ActionIcon>
-              )}
-            </Group>
-          </Group>
+      <AskCard
+        gradient={profileCardGradient(profileData?.profileCardTheme ?? null)}
+        headline={profileData?.customPrompt || t.headline(ownerName)}
+        maxLength={MAX_MESSAGE_LENGTH}
+        value={message}
+        onChange={setMessage}
+        onSend={handleSend}
+        sending={sendLoading}
+        // The server sends a real boolean; undefined means the field was absent.
+        open={profileData?.inboxEnabled !== false}
+        error={formError}
+        onDismissError={() => setFormError(null)}
+        translations={t}
+        cardRef={askCardRef}
+        textareaRef={textareaRef}
+      />
 
-          {/* Bluesky-style profile card */}
-          <Paper mb="lg" withBorder style={{ borderRadius: 16, overflow: "hidden" }}>
-            <Box
-              style={{
-                height: 160,
-                background: profile.banner
-                  ? `url(${profile.banner}) center/cover no-repeat`
-                  : "var(--nf-grad-mark)",
-                position: "relative",
-              }}
-            >
-              {/* Subtle overlay on custom banners for readability */}
-              {profile.banner && (
-                <Box
-                  style={{
-                    position: "absolute",
-                    inset: 0,
-                    background: "rgba(0,0,0,0.2)",
-                  }}
-                />
-              )}
-            </Box>
+      <Group gap="xs" mt="md" align="flex-start" style={styles.disclaimer}>
+        <Text size="xs" c="dimmed">
+          {t.disclaimer}
+        </Text>
+      </Group>
 
-            <Box
-              style={{
-                padding: "0 24px 18px",
-                position: "relative",
-                background: ghostBg(isDark),
-              }}
-            >
-              {/* Avatar overlapping the banner */}
-              <Avatar
-                src={profile.avatar}
-                alt={profile.displayName || profile.handle || "User"}
-                size={84}
-                radius="xl"
-                style={{
-                  border: "4px solid var(--mantine-color-body)",
-                  position: "absolute",
-                  top: -42,
-                  left: 16,
-                }}
-              >
-                <WinkMark size={60} sparkle={false} aria-hidden />
-              </Avatar>
-
-              {/* Name row — top-padded to clear the overlapping avatar */}
-              <Group justify="space-between" align="flex-start" pt={48}>
-                <Box>
-                  <Text fw={800} fz={24} style={{ letterSpacing: "-0.02em", lineHeight: 1.1 }}>
-                    {profile.displayName}
-                  </Text>
-                  <Text c="dimmed" mt={2} fz={13}>
-                    @{profile.handle}
-                  </Text>
-                </Box>
-                <Button
-                  component="a"
-                  href={`https://bsky.app/profile/${profile.handle}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  variant="outline"
-                  size="xs"
-                  radius="md"
-                  style={{
-                    flexShrink: 0,
-                    borderColor: "var(--mantine-color-default-border)",
-                    color: "var(--mantine-color-text)",
-                  }}
-                  leftSection={<ExternalLinkIcon />}
-                >
-                  View on Bluesky
-                </Button>
-              </Group>
-
-              {profile.description && (
-                <Text
-                  mt="sm"
-                  fz={14}
-                  style={{
-                    lineHeight: 1.5,
-                    wordBreak: "break-word",
-                    whiteSpace: "pre-wrap",
-                  }}
-                >
-                  {parseRichText(profile.description)}
-                </Text>
-              )}
-            </Box>
-          </Paper>
-
-          {/* Ask card */}
-          <Paper
-            ref={askCardRef}
-            onClick={() => textareaRef.current?.focus()}
-            style={{
-              borderRadius: 18,
-              padding: 28,
-              background: askCardGradient,
-              border: "2px solid var(--mantine-color-default-border)",
-              cursor: "text",
-              position: "relative",
-              overflow: "hidden",
-            }}
-          >
-            {/* WinkMark watermark */}
-
-            <Text
-              fw={700}
-              mb="lg"
-              c="white"
-              ta="center"
-              fz={22}
-              style={{ position: "relative", letterSpacing: "-0.01em" }}
-            >
-              {profileData?.customPrompt || t.headline(ownerName)}
-            </Text>
-
-            <Stack gap="xs">
-              {formError && (
-                <Alert
-                  color="red"
-                  withCloseButton
-                  onClose={() => setFormError(null)}
-                  role="alert"
-                  styles={{
-                    root: {
-                      background: "rgba(220,38,38,0.18)",
-                      border: "1px solid rgba(220,38,38,0.35)",
-                    },
-                    message: { color: "#FCA5A5" },
-                    closeButton: { color: "#FCA5A5" },
-                  }}
-                >
-                  {formError}
-                </Alert>
-              )}
-              {inboxOpen ? (
-                <>
-                  <Textarea
-                    ref={textareaRef}
-                    value={message}
-                    onChange={(e) => {
-                      if (e.target.value.length <= MAX_MESSAGE_LENGTH) {
-                        setMessage(e.target.value);
-                      }
-                    }}
-                    minRows={2}
-                    maxRows={4}
-                    autosize
-                    disabled={sendLoading}
-                    aria-label={t.headline(ownerName)}
-                    placeholder={t.placeholder}
-                    description={`${message.length}/${MAX_MESSAGE_LENGTH}`}
-                    onKeyDown={(e) => {
-                      if (
-                        (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.metaKey) ||
-                        (e.key === "Enter" && e.ctrlKey)
-                      ) {
-                        e.preventDefault();
-                        handleSend();
-                      }
-                    }}
-                    radius="md"
-                    styles={askCardTextareaStyles}
-                  />
-                  <Group justify="flex-end" gap="xs">
-                    <ActionIcon
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        triggerHaptic();
-                        setMessage("");
-                      }}
-                      variant="subtle"
-                      color="white"
-                      size="lg"
-                      radius="md"
-                      aria-label="Clear message"
-                    >
-                      <IconX size={18} />
-                    </ActionIcon>
-                    <Button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        triggerHaptic();
-                        handleSend();
-                      }}
-                      loading={sendLoading}
-                      radius="md"
-                      leftSection={<IconSend size={16} />}
-                      color="sunshine"
-                      variant="filled"
-                      style={{
-                        color: "var(--nf-midnight)",
-                        fontWeight: 700,
-                      }}
-                    >
-                      {t.sendLabel}
-                    </Button>
-                  </Group>
-                </>
-              ) : (
-                <Text c="white" ta="center" fz={15} style={{ opacity: 0.85 }}>
-                  {t.inboxClosed}
-                </Text>
-              )}
-            </Stack>
-          </Paper>
-
-          {/* Anonymity disclaimer */}
-          <Group
-            gap="xs"
-            mt="md"
-            align="flex-start"
-            style={{
-              background: ghostBg(isDark),
-              borderRadius: 12,
-              padding: "12px 14px",
-            }}
-          >
-            <Text size="xs" c="dimmed">
-              {t.disclaimer}
-            </Text>
-          </Group>
-
-          <ConfirmationModal
-            opened={modalOpened}
-            onClose={() => setModalOpened(false)}
-            onConfirm={handleConfirmSend}
-            title="Confirm Anonymous Message"
-            message="Are you sure you want to send this anonymous message? This action cannot be undone."
-            confirmLabel="Send Message"
-            cancelLabel="Cancel"
-          />
-        </>
-      ) : (
-        <Paper p="md" withBorder>
-          <Text c="red" fw={700}>
-            Error
-          </Text>
-          <Text>Failed to load profile information.</Text>
-        </Paper>
-      )}
+      <ConfirmationModal
+        opened={modalOpened}
+        onClose={() => setModalOpened(false)}
+        onConfirm={handleConfirmSend}
+        title="Confirm Anonymous Message"
+        message="Are you sure you want to send this anonymous message? This action cannot be undone."
+        confirmLabel="Send Message"
+        cancelLabel="Cancel"
+      />
     </Container>
   );
+}
+
+function describeHandleError(error: unknown): { is404: boolean; message: string } {
+  const fields = (typeof error === "object" && error !== null ? error : {}) as Record<
+    string,
+    unknown
+  >;
+  return {
+    is404: fields.status === 404,
+    message:
+      typeof fields.error === "string"
+        ? fields.error
+        : "Failed to resolve handle. The handle may not exist.",
+  };
+}
+
+function sendFailureMessage(err: unknown): string {
+  const fields = err as Record<string, unknown>;
+  if (typeof fields?.message === "string") return fields.message;
+  if (typeof fields?.error === "string") return fields.error;
+  return "Failed to send message. Please try again.";
+}
+
+/** Keeps the composer in view when a soft keyboard opens under it. */
+function useFocusScroll(ref: React.RefObject<HTMLTextAreaElement | null>) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const scroll = () => el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.addEventListener("focus", scroll);
+    return () => el.removeEventListener("focus", scroll);
+  }, [ref]);
+}
+
+/** Scrolls the ask card up if a tall banner or bio pushed it off screen. */
+function useRevealAskCard(ref: React.RefObject<HTMLDivElement | null>, ready: boolean) {
+  useEffect(() => {
+    if (!ready || !ref.current) return;
+    if (ref.current.getBoundingClientRect().bottom <= window.innerHeight) return;
+    ref.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [ready, ref]);
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,16 +1,4 @@
-import {
-  Title,
-  Grid,
-  SimpleGrid,
-  Paper,
-  Text,
-  Button,
-  Alert,
-  Skeleton,
-  Loader,
-  Stack,
-  useComputedColorScheme,
-} from "@mantine/core";
+import { Alert, Button, Grid, Loader, Skeleton, Title } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useState } from "react";
 import { useHaptic } from "use-haptic";
@@ -27,19 +15,14 @@ import {
 import { ConfirmationModal } from "../components/ConfirmationModal";
 import { useInstallPrompt } from "../components/InstallPromptContext";
 import { PushNotificationsButton } from "../components/PushNotificationsButton";
+import { AccountOverview, type Stat } from "../components/settings/AccountOverview";
 import { SettingsCard } from "../components/SettingsCard";
 
-// Deliberately unequal, to create visual hierarchy.
-const STAT_SIZE_LARGE = 32;
-const STAT_SIZE_MEDIUM = 22;
-const STAT_SIZE_SMALL = 13;
+const NOTIFICATION_BOT = "https://bsky.app/profile/did:plc:3d4awubjiftylwrhhyp5vl7i";
+const CARD_SPAN = { base: 12, md: 6, lg: 4 };
 
 export default function Settings() {
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);
-  const computedColorScheme = useComputedColorScheme("light", {
-    getInitialValueInEffect: true,
-  });
-  const isDark = computedColorScheme === "dark";
 
   const { data: session, isLoading: sessionLoading } = useSession();
   const {
@@ -49,7 +32,6 @@ export default function Settings() {
     refetch: refetchSettings,
   } = useUserSettings();
   const updateSettings = useUpdateUserSettings({
-    onSuccess: () => {},
     onError: (error: ApiError) => {
       notifications.show({
         title: "Update Failed",
@@ -84,257 +66,182 @@ export default function Settings() {
     </Alert>
   );
 
+  const stats: Stat[] = [
+    { value: userStats?.messageCount ?? "—", label: "Messages in inbox", size: "large" },
+    { value: pdsInfo?.recordCount ?? "—", label: "Answers on PDS", size: "large" },
+    { value: formatMemberSince(userStats?.memberSince), label: "Active since", size: "medium" },
+    {
+      value: pdsInfo?.pdsUrl ? pdsInfo.pdsUrl.replace(/^https?:\/\//, "") : "—",
+      label: "PDS",
+      size: "small",
+      truncate: true,
+    },
+  ];
+
+  if (!session?.isLoggedIn && !sessionLoading) {
+    return (
+      <Alert title="Error" color="red">
+        You cannot access this page without logging in.
+      </Alert>
+    );
+  }
+
   return (
     <>
-      {!session?.isLoggedIn && !sessionLoading ? (
-        <Alert title="Error" color="red">
-          You cannot access this page without logging in.
-        </Alert>
-      ) : (
-        <>
-          <Title order={1} mb="xl" style={{ letterSpacing: "-0.03em" }}>
-            Settings
-          </Title>
+      <Title order={1} mb="xl" style={{ letterSpacing: "-0.03em" }}>
+        Settings
+      </Title>
 
-          <Grid style={{ gap: "var(--mantine-spacing-md)" }}>
-            {/* Account overview — full-width stats panel */}
-            <Grid.Col span={12}>
-              <Paper
-                withBorder
-                style={{
-                  borderRadius: 14,
-                  padding: 24,
-                  background: isDark ? "rgba(255,255,255,0.06)" : "#F2EBFF",
+      <Grid style={{ gap: "var(--mantine-spacing-md)" }}>
+        <Grid.Col span={12}>
+          <AccountOverview loading={statsLoading || pdsLoading} stats={stats} />
+        </Grid.Col>
+
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Install Application"
+            description="Install the app for faster access. Works with almost any device you own, including tablets and laptops. Uninstall the app anytime. On iOS or Android, it will be added to your home screen and run with the same browser."
+          >
+            <Button
+              onClick={handleInstallClick}
+              fullWidth
+              disabled={!installPrompt}
+              title={!installPrompt ? "Refresh the page to enable install" : ""}
+            >
+              Install Navyfragen
+            </Button>
+          </SettingsCard>
+        </Grid.Col>
+
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="PDS Sync"
+            description="By default, Navyfragen syncs your anonymous messages with your Bluesky PDS (Personal Data Server). Disable this if you wish to keep your data on Navyfragen's servers. Will not change your ability to post to Bluesky directly."
+          >
+            {settingsLoading ? (
+              <Loader size="sm" />
+            ) : settingsError ? (
+              settingsLoadError
+            ) : (
+              <Button
+                fullWidth
+                variant={userSettings?.pdsSyncEnabled ? "filled" : "outline"}
+                loading={updateSettings.isPending}
+                onClick={() => {
+                  updateSettings.mutate({
+                    pdsSyncEnabled: !userSettings?.pdsSyncEnabled,
+                    imageTheme: userSettings?.imageTheme || "default",
+                  });
                 }}
               >
-                <Text fw={700} fz={18} mb={18}>
-                  Account Overview
-                </Text>
-                {statsLoading || pdsLoading ? (
-                  <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="xl">
-                    {[0, 1, 2, 3].map((i) => (
-                      <Stack key={i} gap={4}>
-                        <Skeleton height={28} width="60%" radius="sm" />
-                        <Skeleton height={12} width="80%" radius="sm" />
-                      </Stack>
-                    ))}
-                  </SimpleGrid>
-                ) : (
-                  <SimpleGrid
-                    cols={{ base: 2, sm: 4 }}
-                    spacing="xl"
-                    style={{ alignItems: "flex-end" }}
-                  >
-                    <StatItem
-                      value={userStats?.messageCount ?? "—"}
-                      label="Messages in inbox"
-                      size={STAT_SIZE_LARGE}
-                    />
-                    <StatItem
-                      value={pdsInfo?.recordCount ?? "—"}
-                      label="Answers on PDS"
-                      size={STAT_SIZE_LARGE}
-                    />
-                    <StatItem
-                      value={
-                        userStats?.memberSince
-                          ? new Date(userStats.memberSince).toLocaleDateString(undefined, {
-                              year: "numeric",
-                              month: "short",
-                              day: "numeric",
-                            })
-                          : "—"
-                      }
-                      label="Active since"
-                      size={STAT_SIZE_MEDIUM}
-                    />
-                    <StatItem
-                      value={pdsInfo?.pdsUrl ? pdsInfo.pdsUrl.replace(/^https?:\/\//, "") : "—"}
-                      label="PDS"
-                      size={STAT_SIZE_SMALL}
-                      truncate
-                    />
-                  </SimpleGrid>
-                )}
-              </Paper>
-            </Grid.Col>
+                {userSettings?.pdsSyncEnabled ? "PDS Sync Enabled" : "Enable PDS Sync"}
+              </Button>
+            )}
+          </SettingsCard>
+        </Grid.Col>
 
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Install Application"
-                description="Install the app for faster access. Works with almost any device you own, including tablets and laptops. Uninstall the app anytime. On iOS or Android, it will be added to your home screen and run with the same browser."
-                isDark={isDark}
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Push Notifications"
+            description="Receive a push notification of new messages. Accept your browser or phone's notification prompt to enable. Clearing your site data will disable this option. If you have multiple accounts signed in on this device, enabling notifications here turns them on for all of them, and each notification names the account it's for."
+          >
+            <PushNotificationsButton />
+          </SettingsCard>
+        </Grid.Col>
+
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Navyfragen Feed"
+            description="Browse anonymous questions and answers posted by everyone on Navyfragen worldwide. This feed may contain content intended for adults. View at your own discretion."
+          >
+            <Button
+              component="a"
+              href="https://bsky.app/profile/navyfragen.app/feed/navyfragen"
+              target="_blank"
+              rel="noopener noreferrer"
+              fullWidth
+              variant="outline"
+            >
+              Open Feed on Bluesky
+            </Button>
+          </SettingsCard>
+        </Grid.Col>
+
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Daily Notifications"
+            description="Follow the Navyfragen notification bot on Bluesky to receive a daily alert when you have new messages in your inbox."
+          >
+            {sessionLoading || botFollowLoading ? (
+              <Skeleton height={36} radius="sm" />
+            ) : (
+              <Button
+                component="a"
+                href={NOTIFICATION_BOT}
+                target="_blank"
+                rel="noopener noreferrer"
+                fullWidth
+                variant={botFollowData?.following ? "filled" : "outline"}
               >
-                <Button
-                  onClick={handleInstallClick}
-                  fullWidth
-                  disabled={!installPrompt}
-                  title={!installPrompt ? "Refresh the page to enable install" : ""}
-                >
-                  Install Navyfragen
-                </Button>
-              </SettingsCard>
-            </Grid.Col>
+                {botFollowData?.following
+                  ? "Daily Notifications enabled"
+                  : "Follow Notification Bot"}
+              </Button>
+            )}
+          </SettingsCard>
+        </Grid.Col>
 
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="PDS Sync"
-                description="By default, Navyfragen syncs your anonymous messages with your Bluesky PDS (Personal Data Server). Disable this if you wish to keep your data on Navyfragen's servers. Will not change your ability to post to Bluesky directly."
-                isDark={isDark}
-              >
-                {settingsLoading ? (
-                  <Loader size="sm" />
-                ) : settingsError ? (
-                  settingsLoadError
-                ) : (
-                  <Button
-                    fullWidth
-                    variant={userSettings?.pdsSyncEnabled ? "filled" : "outline"}
-                    loading={updateSettings.isPending}
-                    onClick={() => {
-                      updateSettings.mutate({
-                        pdsSyncEnabled: !userSettings?.pdsSyncEnabled,
-                        imageTheme: userSettings?.imageTheme || "default",
-                      });
-                    }}
-                  >
-                    {userSettings?.pdsSyncEnabled ? "PDS Sync Enabled" : "Enable PDS Sync"}
-                  </Button>
-                )}
-              </SettingsCard>
-            </Grid.Col>
+        <Grid.Col span={CARD_SPAN} style={{ display: "flex" }}>
+          <SettingsCard
+            title="Delete my Data"
+            description="Permanently remove all your data from the Navyfragen servers, and Bluesky PDS. This also disables your inbox so you will no longer receive messages. You can always log back in to reregister automatically."
+          >
+            <Button
+              fullWidth
+              radius="md"
+              fw={600}
+              color="crimson"
+              variant="filled"
+              onClick={() => {
+                triggerHaptic();
+                setDeleteModalOpened(true);
+              }}
+            >
+              Delete my Data
+            </Button>
+          </SettingsCard>
+        </Grid.Col>
+      </Grid>
 
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Push Notifications"
-                description="Receive a push notification of new messages. Accept your browser or phone's notification prompt to enable. Clearing your site data will disable this option. If you have multiple accounts signed in on this device, enabling notifications here turns them on for all of them, and each notification names the account it's for."
-                isDark={isDark}
-              >
-                <PushNotificationsButton />
-              </SettingsCard>
-            </Grid.Col>
-
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Navyfragen Feed"
-                description="Browse anonymous questions and answers posted by everyone on Navyfragen worldwide. This feed may contain content intended for adults. View at your own discretion."
-                isDark={isDark}
-              >
-                <Button
-                  component="a"
-                  href="https://bsky.app/profile/navyfragen.app/feed/navyfragen"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  fullWidth
-                  variant="outline"
-                >
-                  Open Feed on Bluesky
-                </Button>
-              </SettingsCard>
-            </Grid.Col>
-
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Daily Notifications"
-                description="Follow the Navyfragen notification bot on Bluesky to receive a daily alert when you have new messages in your inbox."
-                isDark={isDark}
-              >
-                {sessionLoading || botFollowLoading ? (
-                  <Skeleton height={36} radius="sm" />
-                ) : botFollowData?.following ? (
-                  <Button
-                    component="a"
-                    href="https://bsky.app/profile/did:plc:3d4awubjiftylwrhhyp5vl7i"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    fullWidth
-                  >
-                    Daily Notifications enabled
-                  </Button>
-                ) : (
-                  <Button
-                    component="a"
-                    href="https://bsky.app/profile/did:plc:3d4awubjiftylwrhhyp5vl7i"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    fullWidth
-                    variant="outline"
-                  >
-                    Follow Notification Bot
-                  </Button>
-                )}
-              </SettingsCard>
-            </Grid.Col>
-
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} style={{ display: "flex" }}>
-              <SettingsCard
-                title="Delete my Data"
-                description="Permanently remove all your data from the Navyfragen servers, and Bluesky PDS. This also disables your inbox so you will no longer receive messages. You can always log back in to reregister automatically."
-                isDark={isDark}
-              >
-                <Button
-                  fullWidth
-                  radius="md"
-                  fw={600}
-                  color="crimson"
-                  variant="filled"
-                  onClick={() => {
-                    triggerHaptic();
-                    setDeleteModalOpened(true);
-                  }}
-                >
-                  Delete my Data
-                </Button>
-              </SettingsCard>
-            </Grid.Col>
-          </Grid>
-
-          <ConfirmationModal
-            opened={deleteModalOpened}
-            onClose={() => setDeleteModalOpened(false)}
-            onConfirm={async () => {
-              try {
-                document.body.style.pointerEvents = "none";
-                document.body.style.opacity = "0.5";
-                await apiClient.delete("/delete-account");
-                window.location.href = "/";
-              } catch {
-                document.body.style.pointerEvents = "";
-                document.body.style.opacity = "";
-              }
-              setDeleteModalOpened(false);
-            }}
-            title="Delete Account"
-            message="Are you sure you want to delete your account and all data? This cannot be undone."
-            confirmLabel="Delete"
-          />
-        </>
-      )}
+      <ConfirmationModal
+        opened={deleteModalOpened}
+        onClose={() => setDeleteModalOpened(false)}
+        onConfirm={async () => {
+          try {
+            document.body.style.pointerEvents = "none";
+            document.body.style.opacity = "0.5";
+            await apiClient.delete("/delete-account");
+            window.location.href = "/";
+          } catch {
+            document.body.style.pointerEvents = "";
+            document.body.style.opacity = "";
+          }
+          setDeleteModalOpened(false);
+        }}
+        title="Delete Account"
+        message="Are you sure you want to delete your account and all data? This cannot be undone."
+        confirmLabel="Delete"
+        destructive
+      />
     </>
   );
 }
 
-interface StatItemProps {
-  value: string | number;
-  label: string;
-  size: number;
-  truncate?: boolean;
-}
-
-function StatItem({ value, label, size, truncate }: StatItemProps) {
-  return (
-    <Stack gap={2} style={truncate ? { minWidth: 0 } : undefined}>
-      <Text
-        fw={800}
-        c="royal"
-        truncate={truncate}
-        style={{ fontSize: size, letterSpacing: "-0.02em", lineHeight: 1.1 }}
-      >
-        {value}
-      </Text>
-      <Text size="xs" c="dimmed">
-        {label}
-      </Text>
-    </Stack>
-  );
+function formatMemberSince(memberSince: string | null | undefined): string {
+  if (!memberSince) return "—";
+  return new Date(memberSince).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/client/src/styles/tokens.ts
+++ b/client/src/styles/tokens.ts
@@ -1,6 +1,69 @@
-/** Dark: translucent glass over the void background. Light: lavender card. */
-export const surfaceBg = (isDark: boolean): string =>
-  isDark ? "rgba(255,255,255,0.06)" : "#F2EBFF";
+/**
+ * TypeScript handles for the design tokens declared in `src/index.css`.
+ *
+ * Components import from here rather than typing `var(--nf-…)` inline, so a
+ * renamed token is a compile error instead of a colour that silently resolves
+ * to nothing. The values are scheme-aware in CSS, which is why none of these
+ * take an `isDark` argument — the browser picks.
+ */
 
-/** Barely-there tinted surface — one step above transparent. */
-export const ghostBg = (isDark: boolean): string => (isDark ? "rgba(255,255,255,0.03)" : "#FAF7FF");
+/** Card surface sitting on the page background. */
+export const surface = "var(--nf-surface)";
+/** One step above transparent; for inset rows and secondary chrome. */
+export const surfaceGhost = "var(--nf-surface-ghost)";
+/** Radial halo behind the login / OAuth panels. */
+export const surfaceGlow = "var(--nf-surface-glow)";
+/** Keyboard-focus wash on a list row. */
+export const surfaceHighlight = "var(--nf-surface-highlight)";
+
+export const textDimmed = "var(--mantine-color-dimmed)";
+export const textDefault = "var(--mantine-color-text)";
+/** Inline links and other accented body text. */
+export const link = "var(--nf-link)";
+/** Brand-coloured emphasis inside body copy. */
+export const accentText = "var(--nf-accent-text)";
+
+export const border = "1px solid var(--mantine-color-default-border)";
+export const borderColor = "var(--mantine-color-default-border)";
+
+export const dangerFg = "var(--nf-danger-fg)";
+/** Error headings and failure text, tuned to clear AA on page and card surfaces. */
+export const dangerText = "var(--nf-tone-red)";
+export const selectedBg = "var(--nf-selected-bg)";
+export const selectedBorder = "var(--nf-selected-border)";
+
+/** Foreground colours valid only on top of a brand gradient. */
+export const onGrad = "var(--nf-on-grad)";
+export const onGradMuted = "var(--nf-on-grad-muted)";
+export const onGradAccent = "var(--nf-on-grad-accent)";
+export const onGradFaint = "var(--nf-on-grad-faint)";
+export const onGradFill = "var(--nf-on-grad-fill)";
+export const onGradBorder = "var(--nf-on-grad-border)";
+
+/**
+ * The primary brand gradient. Per client/CLAUDE.md this is the background for
+ * every interactive card — login, ask, inbox hero, gradient question cards.
+ */
+export const gradMark = "var(--nf-grad-mark)";
+/** Reserved for the "default" image-export theme preview. Not a UI surface. */
+export const gradDark = "var(--nf-grad-dark)";
+
+export const radiusCard = "var(--nf-radius-card)";
+export const radiusPanel = "var(--nf-radius-panel)";
+export const radiusControl = "var(--nf-radius-control)";
+export const radiusPill = "var(--nf-radius-pill)";
+
+export const fontMono = "var(--nf-font-mono)";
+
+/**
+ * The one gradient pairing for Mantine's `variant="gradient"`. Both shades are
+ * pinned a step deeper than the palette default so white button labels clear AA
+ * at the purple end, where plain `purple` lands at 4.0:1.
+ */
+export const BRAND_GRADIENT = { from: "royal.6", to: "purple.7", deg: 135 } as const;
+
+/** Sunshine call-to-action: yellow fill demands the dark brand ink, not white. */
+export const sunshineButton = {
+  color: "var(--nf-midnight)",
+  fontWeight: 700,
+} as const;

--- a/client/src/tests/Navigation.test.tsx
+++ b/client/src/tests/Navigation.test.tsx
@@ -333,6 +333,32 @@ describe("Navigation", () => {
       expect(screen.getByTestId("location")).toHaveTextContent("/login");
     });
 
+    it("an Alt shortcut with no route bound to it does nothing", () => {
+      mockSession({ isLoggedIn: true, did: TEST_DID });
+      renderWithProviders(
+        <>
+          <Navigation />
+          <LocationDisplay />
+        </>,
+        { route: "/" }
+      );
+      fireEvent.keyDown(document, { key: "X", altKey: true });
+      expect(screen.getByTestId("location")).toHaveTextContent("/");
+    });
+
+    it("Alt+L does not navigate to login when already logged in", () => {
+      mockSession({ isLoggedIn: true, did: TEST_DID });
+      renderWithProviders(
+        <>
+          <Navigation />
+          <LocationDisplay />
+        </>,
+        { route: "/" }
+      );
+      fireEvent.keyDown(document, { key: "L", altKey: true });
+      expect(screen.getByTestId("location")).toHaveTextContent("/");
+    });
+
     it("Alt+M does not navigate when logged out", () => {
       mockSession({ isLoggedIn: false });
       renderWithProviders(

--- a/client/src/tests/lib/formatTimestamp.test.ts
+++ b/client/src/tests/lib/formatTimestamp.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+
+import { formatTimestamp } from "../../lib/formatTimestamp";
+
+describe("formatTimestamp", () => {
+  it("includes the year", () => {
+    expect(formatTimestamp("2024-03-15T14:30:00.000Z")).toContain("2024");
+  });
+
+  it("includes hours and zero-padded minutes", () => {
+    expect(formatTimestamp("2024-03-15T14:30:00.000Z")).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("includes a timezone abbreviation", () => {
+    // e.g. UTC, GMT, EST, EDT, AEST — at least two consecutive uppercase letters
+    expect(formatTimestamp("2024-03-15T14:30:00.000Z")).toMatch(/[A-Z]{2,}/);
+  });
+
+  it("produces different output for different dates", () => {
+    const t1 = formatTimestamp("2023-01-01T00:00:00.000Z");
+    const t2 = formatTimestamp("2024-12-31T23:59:00.000Z");
+    expect(t1).not.toEqual(t2);
+  });
+});

--- a/client/src/tests/lib/navSectionStorage.test.ts
+++ b/client/src/tests/lib/navSectionStorage.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+import { isSectionOpen, setSectionOpen } from "../../lib/navSectionStorage";
+
+const DID = "did:plc:example";
+
+describe("navSectionStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a section the user has never touched as open", () => {
+    expect(isSectionOpen("Moots", DID)).toBe(true);
+  });
+
+  it("round-trips a collapsed section", () => {
+    setSectionOpen("Moots", false, DID);
+    expect(isSectionOpen("Moots", DID)).toBe(false);
+  });
+
+  it("round-trips a re-expanded section", () => {
+    setSectionOpen("Moots", false, DID);
+    setSectionOpen("Moots", true, DID);
+    expect(isSectionOpen("Moots", DID)).toBe(true);
+  });
+
+  it("keeps sections independent of each other", () => {
+    setSectionOpen("Moots", false, DID);
+    expect(isSectionOpen("Oomfs", DID)).toBe(true);
+  });
+
+  it("keeps accounts independent of each other", () => {
+    setSectionOpen("Moots", false, DID);
+    expect(isSectionOpen("Moots", "did:plc:someone-else")).toBe(true);
+  });
+
+  it("falls back to open when the stored value is unparseable", () => {
+    localStorage.setItem(`navyfragen_friends_sections_open_${DID}`, "{not json");
+    expect(isSectionOpen("Moots", DID)).toBe(true);
+  });
+
+  it("falls back to open when storage cannot be read", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    expect(isSectionOpen("Moots", DID)).toBe(true);
+  });
+
+  it("swallows a write failure rather than taking the sidebar down", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => setSectionOpen("Moots", false, DID)).not.toThrow();
+  });
+});

--- a/client/src/tests/pages/Customise.test.tsx
+++ b/client/src/tests/pages/Customise.test.tsx
@@ -145,7 +145,7 @@ describe("Customise page", () => {
     const mutate = mockMutation();
     renderWithProviders(<Customise />);
 
-    fireEvent.click(screen.getByLabelText(/ember theme/i));
+    fireEvent.click(screen.getByRole("button", { name: /ember/i }));
     expect(mutate).toHaveBeenCalledWith({ profileCardTheme: "ember" });
   });
 
@@ -206,7 +206,7 @@ describe("Customise page", () => {
     } as any);
     renderWithProviders(<Customise />);
 
-    expect(screen.getByLabelText(/ember theme/i)).toBeDisabled();
+    expect(screen.getByRole("button", { name: /ember/i })).toBeDisabled();
   });
 
   it("renders correctly in dark mode", () => {

--- a/client/src/tests/pages/Messages.test.tsx
+++ b/client/src/tests/pages/Messages.test.tsx
@@ -7,7 +7,7 @@ import * as authService from "../../api/authService";
 import * as messageService from "../../api/messageService";
 import * as settingsService from "../../api/settingsService";
 import { themes } from "../../lib/themes";
-import Messages, { formatTimestamp } from "../../pages/Messages";
+import Messages from "../../pages/Messages";
 import { renderWithProviders } from "../testUtils";
 
 vi.mock("../../api/authService", async (importOriginal) => {
@@ -82,29 +82,6 @@ function setupMocks(messages = MESSAGES) {
   } as any);
   mockUseUpdateUserSettings.mockReturnValue(noopMutation);
 }
-
-// ── formatTimestamp ──────────────────────────────────────────────────────────
-
-describe("formatTimestamp", () => {
-  it("includes the year", () => {
-    expect(formatTimestamp("2024-03-15T14:30:00.000Z")).toContain("2024");
-  });
-
-  it("includes hours and zero-padded minutes", () => {
-    expect(formatTimestamp("2024-03-15T14:30:00.000Z")).toMatch(/\d{1,2}:\d{2}/);
-  });
-
-  it("includes a timezone abbreviation", () => {
-    // e.g. UTC, GMT, EST, EDT, AEST — at least two consecutive uppercase letters
-    expect(formatTimestamp("2024-03-15T14:30:00.000Z")).toMatch(/[A-Z]{2,}/);
-  });
-
-  it("produces different output for different dates", () => {
-    const t1 = formatTimestamp("2023-01-01T00:00:00.000Z");
-    const t2 = formatTimestamp("2024-12-31T23:59:00.000Z");
-    expect(t1).not.toEqual(t2);
-  });
-});
 
 // ── Messages page ────────────────────────────────────────────────────────────
 
@@ -1057,7 +1034,7 @@ describe("Messages page", () => {
     });
 
     const dangerCircle = Array.from(document.querySelectorAll("svg circle")).find(
-      (c) => c.getAttribute("stroke") === "var(--nf-sunshine)"
+      (c) => c.getAttribute("stroke") === "var(--nf-compose-warn)"
     );
     expect(dangerCircle).toBeTruthy();
   });
@@ -1405,6 +1382,15 @@ describe("Messages page", () => {
     fireEvent.keyDown(card, { key: "Tab" });
 
     expect(screen.queryByRole("textbox", { name: /your response/i })).toBeNull();
+  });
+
+  it("arrow keys do nothing until a card has been focused", () => {
+    setupMocks();
+    renderWithProviders(<Messages />);
+
+    fireEvent.keyDown(document, { key: "ArrowDown" });
+
+    expect(document.getElementById("message-card-msg-1")).not.toBe(document.activeElement);
   });
 
   it("useGradients=false hydrates from localStorage and drives the card's background-color source", async () => {

--- a/client/src/tests/pages/PublicProfile.test.tsx
+++ b/client/src/tests/pages/PublicProfile.test.tsx
@@ -333,6 +333,33 @@ describe("PublicProfile page", () => {
     expect(screen.queryByText(/are you sure/i)).toBeNull();
   });
 
+  it("typing an ordinary key in the textarea does not call handleSend", async () => {
+    setupProfile();
+    renderWithProviders(<PublicProfile />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Hello!" } });
+    fireEvent.keyDown(textarea, { key: "a" });
+    expect(screen.queryByText(/are you sure/i)).toBeNull();
+  });
+
+  it("pressing Alt+Enter in textarea does not call handleSend", async () => {
+    setupProfile();
+    renderWithProviders(<PublicProfile />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Hello!" } });
+    fireEvent.keyDown(textarea, { key: "Enter", altKey: true });
+    expect(screen.queryByText(/are you sure/i)).toBeNull();
+  });
+
+  it("pressing Meta+Enter in textarea does not call handleSend", async () => {
+    setupProfile();
+    renderWithProviders(<PublicProfile />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Hello!" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    expect(screen.queryByText(/are you sure/i)).toBeNull();
+  });
+
   it("clicking the clear button empties the message", async () => {
     setupProfile();
     renderWithProviders(<PublicProfile />);

--- a/client/src/tests/theme/colorMath.ts
+++ b/client/src/tests/theme/colorMath.ts
@@ -1,0 +1,92 @@
+/**
+ * WCAG contrast helpers for `contrast.test.ts`. Lives under `src/tests/` rather
+ * than `src/lib/` because nothing ships it — it exists to check the palette, not
+ * to render with it.
+ */
+
+export type Rgb = [number, number, number];
+
+export function parseColor(value: string): Rgb {
+  const v = value.trim();
+
+  const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(v);
+  if (hexMatch) {
+    const h = hexMatch[1];
+    const full =
+      h.length === 3
+        ? h
+            .split("")
+            .map((c) => c + c)
+            .join("")
+        : h;
+    return [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16)) as Rgb;
+  }
+
+  const rgbMatch = /^rgba?\(([^)]+)\)$/i.exec(v);
+  if (rgbMatch) {
+    const [r, g, b] = rgbMatch[1].split(",").map((p) => parseFloat(p));
+    return [r, g, b];
+  }
+
+  throw new Error(`Unsupported colour: ${value}`);
+}
+
+/** Alpha of an `rgba()` string; 1 for anything opaque. */
+export function alphaOf(value: string): number {
+  const m = /^rgba\(([^)]+)\)$/i.exec(value.trim());
+  if (!m) return 1;
+  const parts = m[1].split(",");
+  return parts.length === 4 ? parseFloat(parts[3]) : 1;
+}
+
+export function composite(fg: Rgb, alpha: number, bg: Rgb): Rgb {
+  return fg.map((v, i) => v * alpha + bg[i] * (1 - alpha)) as Rgb;
+}
+
+/** Flattens a possibly-translucent colour onto an opaque backdrop. */
+export function flatten(value: string, backdrop: Rgb): Rgb {
+  return composite(parseColor(value), alphaOf(value), backdrop);
+}
+
+function luminance([r, g, b]: Rgb): number {
+  const [lr, lg, lb] = [r, g, b].map((v) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+}
+
+export function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Every colour a `linear-gradient(...)` passes through, sampled densely enough
+ * that a mid-ramp dip cannot hide between two stops. Checking only the declared
+ * stops is what let the old cyan/emerald presets look compliant.
+ */
+export function gradientSamples(gradient: string, step = 0.02): Rgb[] {
+  const stops = [...gradient.matchAll(/(#[0-9a-f]{3,6})\s+([\d.]+)%/gi)].map((m) => ({
+    color: parseColor(m[1]),
+    at: parseFloat(m[2]) / 100,
+  }));
+  if (stops.length < 2) throw new Error(`Not a multi-stop gradient: ${gradient}`);
+
+  const samples: Rgb[] = [];
+  for (let t = 0; t <= 1 + 1e-9; t += step) {
+    let i = 0;
+    while (i < stops.length - 2 && t > stops[i + 1].at) i++;
+    const span = stops[i + 1].at - stops[i].at;
+    const f = span === 0 ? 0 : (t - stops[i].at) / span;
+    samples.push(
+      stops[i].color.map((v, k) => v + (stops[i + 1].color[k] - v) * f) as unknown as Rgb
+    );
+  }
+  return samples;
+}
+
+/** The single worst contrast `fg` reaches anywhere along `gradient`. */
+export function worstOnGradient(fg: Rgb, gradient: string): number {
+  return Math.min(...gradientSamples(gradient).map((bg) => contrast(fg, bg)));
+}

--- a/client/src/tests/theme/contrast.test.ts
+++ b/client/src/tests/theme/contrast.test.ts
@@ -1,0 +1,179 @@
+import { readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+
+import navyfragenTheme, { ALERT_TONES } from "../../Theme";
+
+import { contrast, flatten, parseColor, worstOnGradient, type Rgb } from "./colorMath";
+import { declaredTokens, referencedTokens, token, type Scheme } from "./readTokens";
+
+/**
+ * The palette's accessibility rules, executable.
+ *
+ * Every pair below is text-on-background somewhere in the UI, and WCAG AA for
+ * body text is 4.5:1. Lowering a token past that is a failing test rather than a
+ * regression someone notices in a screenshot months later.
+ */
+
+const AA = 4.5;
+/** WCAG's relaxed threshold, for ≥24px or ≥18.66px-bold text only. */
+const AA_LARGE = 3;
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/**
+ * Opaque page background a translucent surface has to be flattened against.
+ * Mantine derives it from the theme (`theme.white` / `dark[7]`), not from
+ * index.css, so it is read from the same place the browser reads it.
+ */
+const BODY: Record<Scheme, Rgb> = {
+  light: parseColor(navyfragenTheme.white!),
+  dark: parseColor(navyfragenTheme.colors!.dark![7]),
+};
+
+function surface(scheme: Scheme): Rgb {
+  return flatten(token("--nf-surface", scheme), BODY[scheme]);
+}
+
+function ratio(fg: string, bg: Rgb, scheme: Scheme): number {
+  return contrast(flatten(token(fg, scheme), bg), bg);
+}
+
+const SCHEMES: Scheme[] = ["light", "dark"];
+
+describe("body text", () => {
+  it.each(SCHEMES)("dimmed text clears AA on the card surface (%s)", (scheme) => {
+    expect(ratio("--mantine-color-dimmed", surface(scheme), scheme)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it.each(SCHEMES)("dimmed text clears AA on the page background (%s)", (scheme) => {
+    expect(ratio("--mantine-color-dimmed", BODY[scheme], scheme)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it.each(SCHEMES)("dimmed text clears AA on the ghost surface (%s)", (scheme) => {
+    const ghost = flatten(token("--nf-surface-ghost", scheme), BODY[scheme]);
+    expect(ratio("--mantine-color-dimmed", ghost, scheme)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it("brand-accented body text clears AA on the light card surface", () => {
+    // The plain `royal` fill is 4.4:1 here, which is why text gets its own token.
+    expect(ratio("--nf-accent-text", surface("light"), "light")).toBeGreaterThanOrEqual(AA);
+  });
+
+  it.each(SCHEMES)("link colour clears AA on the card surface (%s)", (scheme) => {
+    expect(ratio("--nf-link", surface(scheme), scheme)).toBeGreaterThanOrEqual(AA);
+  });
+});
+
+describe("text on brand gradients", () => {
+  const GRADIENTS = ["--nf-grad-mark", "--nf-grad-dark"];
+  const FOREGROUNDS = ["--nf-on-grad", "--nf-on-grad-muted", "--nf-on-grad-accent"];
+
+  it.each(GRADIENTS.flatMap((g) => FOREGROUNDS.map((f) => [g, f])))(
+    "%s carries %s at AA across the whole ramp",
+    (gradient, fg) => {
+      // Alpha-carrying foregrounds are flattened against the gradient's own
+      // lightest stop, the point where they are hardest to read.
+      const grad = token(gradient);
+      const lightest = worstStop(grad);
+      expect(worstOnGradient(flatten(token(fg), lightest), grad)).toBeGreaterThanOrEqual(AA);
+    }
+  );
+
+  it.each(["--nf-grad-aurora", "--nf-grad-ember", "--nf-grad-verdant", "--nf-grad-mark"])(
+    "ask-card preset %s carries white text at AA across the whole ramp",
+    (preset) => {
+      expect(
+        worstOnGradient(parseColor(token("--nf-on-grad")), token(preset))
+      ).toBeGreaterThanOrEqual(AA);
+    }
+  );
+
+  it("the faint on-gradient token is not strong enough for text", () => {
+    // Pinned so nobody promotes it to a Text colour: it exists for rules and
+    // progress-ring tracks, where contrast is not a legibility requirement.
+    const grad = token("--nf-grad-dark");
+    const fg = flatten(token("--nf-on-grad-faint"), worstStop(grad));
+    expect(worstOnGradient(fg, grad)).toBeLessThan(AA_LARGE);
+  });
+});
+
+describe("controls", () => {
+  it("the sunshine call-to-action carries its dark ink at AA", () => {
+    expect(
+      contrast(parseColor(token("--nf-midnight")), parseColor(token("--nf-sunshine")))
+    ).toBeGreaterThanOrEqual(AA);
+  });
+
+  it.each(SCHEMES)("filled primary buttons carry white labels at AA (%s)", (scheme) => {
+    const fill = navyfragenTheme.colors!.royal![navyfragenTheme.primaryShade as number];
+    expect(contrast(parseColor(navyfragenTheme.white!), parseColor(fill))).toBeGreaterThanOrEqual(
+      AA
+    );
+    expect(scheme).toBeTruthy();
+  });
+
+  it("destructive buttons carry white labels at AA", () => {
+    expect(
+      contrast(parseColor(navyfragenTheme.white!), parseColor(navyfragenTheme.colors!.crimson![6]))
+    ).toBeGreaterThanOrEqual(AA);
+  });
+
+  it.each(SCHEMES)("the active nav item is legible on its own tint (%s)", (scheme) => {
+    const bg = flatten(token("--nf-nav-active-bg", scheme), BODY[scheme]);
+    expect(ratio("--nf-nav-active-color", bg, scheme)).toBeGreaterThanOrEqual(AA);
+  });
+});
+
+describe("alert tones", () => {
+  const cases = SCHEMES.flatMap((scheme) =>
+    Object.entries(ALERT_TONES).map(([name, tone]) => [scheme, name, tone] as const)
+  );
+
+  it.each(cases)("%s: the %s title is legible on its own tint", (scheme, _name, tone) => {
+    const tint = flatten(`rgba(${tone.rgb},0.09)`, BODY[scheme]);
+    expect(ratio(tone.title, tint, scheme)).toBeGreaterThanOrEqual(AA);
+  });
+});
+
+describe("token hygiene", () => {
+  it("declares no --nf-* token that nothing references", async () => {
+    const sources = await collectSources(SRC);
+    const used = referencedTokens(sources);
+    const orphans = declaredTokens().filter((name) => !used.has(name));
+    expect(orphans).toEqual([]);
+  });
+
+  it("references no --nf-* token that nothing declares", async () => {
+    const declared = new Set(declaredTokens());
+    const sources = await collectSources(SRC);
+    const undeclared = [...referencedTokens(sources)].filter((name) => !declared.has(name));
+    expect(undeclared).toEqual([]);
+  });
+});
+
+/** The gradient stop where a translucent foreground has the least to work with. */
+function worstStop(gradient: string): Rgb {
+  const stops = [...gradient.matchAll(/#[0-9a-f]{3,6}/gi)].map((m) => parseColor(m[0]));
+  return stops.reduce((lightest, stop) =>
+    contrast(parseColor("#FFFFFF"), stop) < contrast(parseColor("#FFFFFF"), lightest)
+      ? stop
+      : lightest
+  );
+}
+
+async function collectSources(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await collectSources(path)));
+    } else if (/\.(tsx?|css)$/.test(entry.name)) {
+      out.push(readFileSync(path, "utf8"));
+    }
+  }
+  return out;
+}

--- a/client/src/tests/theme/readTokens.ts
+++ b/client/src/tests/theme/readTokens.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Reads the design tokens back out of `src/index.css`.
+ *
+ * The stylesheet is the source of truth, so the contrast suite parses it rather
+ * than re-listing the hexes in TypeScript — a duplicated palette would drift and
+ * the tests would keep passing against values the app no longer uses.
+ */
+
+const CSS_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "../../index.css");
+
+export type Scheme = "light" | "dark";
+
+const SELECTORS: Record<Scheme, string[]> = {
+  light: [":root", ':root[data-mantine-color-scheme="light"]'],
+  dark: [':root[data-mantine-color-scheme="dark"]'],
+};
+
+/**
+ * Merges every rule block whose selector is exactly the scheme's, in source
+ * order. Selector and body are captured together so back-to-back blocks both
+ * match — anchoring on the preceding `}` swallows it and drops the next one.
+ */
+function declarationsFor(css: string, scheme: Scheme): Map<string, string> {
+  const source = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const out = new Map<string, string>();
+  for (const block of source.matchAll(/([^{}]*)\{([^{}]*)\}/g)) {
+    if (!SELECTORS[scheme].includes(block[1].trim())) continue;
+    for (const decl of block[2].matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+      out.set(decl[1], decl[2].replace(/\s+/g, " ").trim());
+    }
+  }
+  return out;
+}
+
+const css = readFileSync(CSS_PATH, "utf8");
+const declarations: Record<Scheme, Map<string, string>> = {
+  light: declarationsFor(css, "light"),
+  dark: declarationsFor(css, "dark"),
+};
+
+/**
+ * Resolves a token to a literal colour, following `var()` indirection. Dark
+ * lookups fall back to the light block, mirroring the cascade: the dark selector
+ * only overrides what actually differs.
+ */
+export function token(name: string, scheme: Scheme = "light"): string {
+  const seen = new Set<string>();
+  let value = name;
+
+  while (value.startsWith("--") || value.startsWith("var(")) {
+    const key = value.startsWith("var(") ? /var\((--[\w-]+)\)/.exec(value)![1] : value;
+    if (seen.has(key)) throw new Error(`Cyclic token reference at ${key}`);
+    seen.add(key);
+
+    const next =
+      (scheme === "dark" ? declarations.dark.get(key) : undefined) ?? declarations.light.get(key);
+    if (next === undefined) throw new Error(`Undefined token ${key} (${scheme})`);
+    value = next;
+  }
+  return value;
+}
+
+/** Every `--nf-*` token declared anywhere in the stylesheet. */
+export function declaredTokens(): string[] {
+  return [...new Set([...declarations.light.keys(), ...declarations.dark.keys()])].filter((k) =>
+    k.startsWith("--nf-")
+  );
+}
+
+/** Every `--nf-*` token *referenced* from TS/TSX/CSS sources. */
+export function referencedTokens(sources: string[]): Set<string> {
+  const used = new Set<string>();
+  for (const source of sources) {
+    for (const m of source.matchAll(/var\((--nf-[\w-]+)\)/g)) used.add(m[1]);
+  }
+  return used;
+}
+
+export const stylesheet = css;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -77,6 +77,11 @@ export default defineConfig({
         "src/Theme.tsx",
         "src/vite-env.d.ts",
         "src/styles/tokens.ts",
+        // `*.styles.ts` modules hold CSS objects and the pure functions that
+        // select between them — no behaviour, nothing an assertion could pin
+        // that reading the file would not tell you more directly. Rendering
+        // logic stays in the `.tsx` beside them, which is measured.
+        "src/**/*.styles.ts",
         "src/pushPayload.ts",
         "src/index.css",
       ],

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -133,33 +133,52 @@ These client sites carried `/* v8 ignore */` markers that istanbul does not need
 
 **What it would take to test:** Same approach as `profileService.ts` — call `refetch()` on the hook rendered with a null argument; React Query v5 invokes `queryFn` regardless of `enabled` on explicit refetch.
 
-### `client/src/pages/PublicProfile.tsx` — defensive max-length guard in `handleSend`
+### `client/src/pages/PublicProfile.tsx` — defensive max-length guard in `handleSend` (removed)
 
-**Lines:** lines 86–89 (`if (message.length > MAX_MESSAGE_LENGTH) { setFormError(...); return; }`).
-
-**Why ignored:** The `<Textarea>` component's `onChange` handler unconditionally rejects any value longer than `MAX_MESSAGE_LENGTH` (`if (e.target.value.length <= MAX_MESSAGE_LENGTH) setMessage(...)`). As a result, the React `message` state can never exceed the limit through the UI, making the `handleSend` guard permanently unreachable in practice.
-
-**What it would take to test:** Export `handleSend` for direct unit testing, or access the component's internal state setter to bypass the `onChange` guard. Neither is practical without refactoring the component.
+**Status: gone.** The guard existed because the textarea's `onChange` rejected any
+value over `MAX_MESSAGE_LENGTH` outright, so `handleSend` could never see an
+over-long message. The frontend refactor moved the composer into
+`components/profile/AskCard.tsx`, whose `onChange` truncates
+(`value.slice(0, maxLength)`) instead of rejecting — pasting a long string now
+keeps the first 150 characters rather than nothing. With the invariant enforced by
+construction at the only entry point, the second check in `handleSend` had nothing
+left to defend and was deleted along with its marker.
 
 ### `client/src/pages/Messages.tsx` — collapsed reply Box/Button handlers (correction to a prior note)
 
 A previous version of this note claimed the collapsed `↩ Reply` Box's `stopPropagation` handler and the collapsed Button's `onClick` body were uncovered due to a Vitest/v8 source-map alignment bug with arrow functions nested in the non-first branch of a JSX ternary. That diagnosis was wrong. The real cause: `screen.getAllByRole("button", { name: /reply/i })` matches **both** the outer message-card `<Paper role="button">` (whose aggregated accessible name includes the nested "↩ Reply" text) **and** the actual nested `<button>` element. `.find((b) => b.textContent?.includes("↩"))` picked the first DOM-order match, which is the outer Paper card — so those "collapsed button" tests were actually clicking the card itself (which has its own unguarded `onClick` that produces the same visible outcome), never the real nested Box/Button. Querying with an **exact** name match (e.g. `screen.getAllByRole("button", { name: "↩ Reply" })`, exact matching excludes the Paper since its full accessible name is longer) or `document.querySelectorAll("button")` reliably isolates the real element and exercises these handlers normally — no ignore annotation or tooling workaround is needed. See `Messages.test.tsx` for the corrected tests ("collapsed reply Box wrapper stops click propagation…", "collapsed reply Button (exact match) opens the response box…", "collapsed reply Button does nothing when blocked…").
 
-### `client/src/pages/Messages.tsx` — six structurally-unreachable defensive guards
+### `client/src/pages/Messages.tsx` — six structurally-unreachable defensive guards (five removed)
 
-**Lines (as of this writing):** `handleDeleteRequest`'s `if (threadRootTid === tid) return;`; `handleConfirmDelete`'s `if (messageIdToDelete) performDelete(...)`; `handlePrepareResponse`'s `if (idx !== -1) setFocusedCardIndex(idx);`; the `if (el) setTimeout(...)` in the respondingTid scroll-into-view `useEffect`; the `newestCard ?? messagesTopRef.current` fallback plus its `if (target)` guard in the auto-scroll `useEffect`; and the `if (idx !== -1) messageCardRefs.current[idx]?.focus();` in the global Escape-key handler.
+**Status: one left.** These were six guards whose unhappy arm could not be reached
+given the call graph — the kind of suppression that is correct but accumulates. The
+frontend refactor removed the _reason_ for five of them rather than re-annotating
+them, which is the preferred outcome:
 
-**Why ignored:** All six are defensive guards whose "unhappy" arm can never be reached given the app's actual call graph:
-- `handleDeleteRequest`'s guard duplicates a check the trash `ActionIcon`'s `onClick` already performs (`if (isPinned) return;`) before ever calling the handler — by the time `handleDeleteRequest` runs, `threadRootTid === tid` is already known false.
-- `handleConfirmDelete`'s guard: `messageIdToDelete` is always set in the same state update that opens the confirmation modal, and the only element that invokes this handler (the modal's Confirm button) doesn't exist in the DOM unless the modal is open.
-- `handlePrepareResponse`'s `idx` lookup: every call site passes a `tid` taken directly from a `sortedMessages` entry (the same array being searched), so the entry is always found.
-- The scroll-into-view effect's `el` lookup: `respondingTid` is only ever set (via `handlePrepareResponse`) to the tid of a card that is already rendered in the same commit, so `document.getElementById` always finds it.
-- The auto-scroll effect's `newestCard` lookup: whenever the guarding `messages?.[0]` check passes, that message's card is rendered in the same commit, so `newestCard` is always truthy, making both the `??` fallback and the `if (target)` guard's false arm dead.
-- The Escape-key handler's `idx` lookup: same reasoning as `handlePrepareResponse` — `respondingTid` always corresponds to a `sortedMessages` entry.
+- `handleDeleteRequest`'s `if (threadRootTid === tid) return;` — deleted. It
+  duplicated a check the trash `ActionIcon` already performs, and that button now
+  lives in `QuestionCard`, where the check is visibly adjacent to the affordance.
+- `handleConfirmDelete`'s `if (messageIdToDelete)` — deleted. The modal's
+  `onConfirm` asserts non-null (`performDelete(messageIdToDelete!, true)`), which
+  states the same invariant to the type system instead of to the coverage tool.
+- `handlePrepareResponse`'s `if (idx !== -1)` — deleted. `QuestionGrid` maps over
+  the message list, so expanding a card already knows its index; there is no lookup
+  to fail.
+- The auto-scroll effect's `newestCard ?? messagesTopRef.current` fallback and its
+  `if (target)` guard — collapsed to a single early return. The spare ref that
+  existed only as a fallback target is gone too.
+- The global Escape handler's `if (idx !== -1)` — deleted. `useCardKeyboardNav`
+  receives `expandedIndex` as a prop and already gates on `!== -1` before using it,
+  so the inner re-check was the same condition twice.
 
-Each is annotated in place with the narrowest istanbul hint for its shape — `/* istanbul ignore if */` where the guard body is unreachable, `/* istanbul ignore else */` where the guard always passes — plus an inline comment explaining the reachability argument. The scroll-into-view effect additionally needs `/* istanbul ignore next */` on the `setTimeout` callback, which the suite's fake timers never run.
+What remains is the `setTimeout` callback in the expand-scroll effect
+(`QuestionGrid.tsx`), which the suite's fake timers never run, plus a
+`/* istanbul ignore next */` on `if (!newest) return;` in `useScrollToNewMessages`,
+where a message present in the list always has a card rendered in the same commit.
 
-**What it would take to test:** Each would require calling the relevant internal function directly with an argument that violates the invariant enforced by its sole caller (e.g. a `tid` not present in `sortedMessages`, or firing the modal's `onConfirm` with `messageIdToDelete` forced to `null`) — not reachable by driving the rendered UI, since every caller already enforces the invariant before invoking these functions.
+**What it would take to test:** for the timer, run the suite with real timers and a
+`scrollIntoView` spy; for the `newest` lookup, render a message list whose first
+entry has no corresponding DOM node, which no code path produces.
 
 ## V8 JIT Module-Scope Artifacts
 
@@ -174,6 +193,7 @@ Each is annotated in place with the narrowest istanbul hint for its shape — `/
 **Lines:** 1–4 (the opening comment lines and function declaration).
 
 **Why suppressed with `/* v8 ignore start/stop */`:** V8's block-coverage format creates two structurally-unreachable branch ranges for every module:
+
 1. The **module-scope "not-initialized" branch** — V8 records an implicit branch at offset 0 for "was this module's wrapper function not entered". Since Node.js always fully executes the module wrapper on import, the "not entered" arm is never taken. This maps back to the first line of the source file.
 2. The **function-declaration branch** — V8 tracks whether a named function was compiled via the JIT fast-path or deferred. The "deferred/not-compiled" arm never fires for a function that is actually called. This maps to `pdsRegion(` on the `export function` line.
 
@@ -188,6 +208,7 @@ These branches are V8 JIT internals; no user-written test can reach them. The sa
 **Lines:** line 1 (module-scope artifact) and the last `}` of the class (class-declaration artifact).
 
 **Why suppressed with `/* v8 ignore start/stop */` and `/* v8 ignore next 1 */`:** The same two V8 JIT artifact branches appear in every module. For class-based modules:
+
 1. The **module-scope "not-initialized" branch** maps to line 1 — suppressed by `/* v8 ignore start */` as the very first line of each file, with `/* v8 ignore stop */` placed right after the constructor close so that all method bodies are still measured normally.
 2. The **class-declaration branch** maps to the closing `}` of the class — suppressed by `/* v8 ignore next 1 */` placed on the line immediately before the final `}`.
 
@@ -263,12 +284,12 @@ The mock now spreads the real module (`exports: { ...realSessionAgent, initializ
 
 The following "uncovered" lines are not executable TypeScript — they are blank lines, type annotations, or closing punctuation of multi-line expressions that tsx maps back to the wrong source position. The underlying code **is** executed and tested; only V8's source-map alignment is imprecise.
 
-| File | Lines | Kind |
-|------|-------|------|
-| `server/src/services/auth-service.ts` | 77 | `const cryptr = new Cryptr(secret)` in `decryptDid` — identical structure to `encryptDid` above it; tsx maps both to the same JS position |
-| `server/src/services/message-service.ts` | 80, 106, 162, 297, 303 | Blank lines, TypeScript parameter-type annotations, and closing-parenthesis lines of multi-line `logger.error(...)` calls |
-| `server/src/services/settings-service.ts` | 128 | Blank line between `getUserSettings` call and `if (!existingSettings)` inside `updateSettings` |
-| `server/src/lib/image-generator.ts` | 144, 454–459 | TypeScript return-type annotation on `generateThemeSpecificHtml` (line 144); static CSS string content inside a multi-hundred-line template literal in `generateTwitterHtml` (lines 454–459) — V8 does not track every line within a template literal |
+| File                                      | Lines                  | Kind                                                                                                                                                                                                                                                  |
+| ----------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/src/services/auth-service.ts`     | 77                     | `const cryptr = new Cryptr(secret)` in `decryptDid` — identical structure to `encryptDid` above it; tsx maps both to the same JS position                                                                                                             |
+| `server/src/services/message-service.ts`  | 80, 106, 162, 297, 303 | Blank lines, TypeScript parameter-type annotations, and closing-parenthesis lines of multi-line `logger.error(...)` calls                                                                                                                             |
+| `server/src/services/settings-service.ts` | 128                    | Blank line between `getUserSettings` call and `if (!existingSettings)` inside `updateSettings`                                                                                                                                                        |
+| `server/src/lib/image-generator.ts`       | 144, 454–459           | TypeScript return-type annotation on `generateThemeSpecificHtml` (line 144); static CSS string content inside a multi-hundred-line template literal in `generateTwitterHtml` (lines 454–459) — V8 does not track every line within a template literal |
 
 No `/* v8 ignore */` annotations are added for these because the underlying logic IS reached by tests; the gaps are purely a source-map rendering artefact.
 
@@ -290,10 +311,10 @@ Work has raised `internal/shim` package coverage from 78.8% to 95.3%, across `ca
 - **`cache.go` — `writeMeta`'s `json.Marshal` failure branch.** Marshaling `struct{ MimeType string }` with a plain Go string field cannot fail; there is no invalid state reachable through `Store`'s public API that would make it error.
 - **`cache.go` — `evictIfNeeded`'s `e.Info()` error branch in the second (eviction) loop.** `DirEntry.Info()` fails only on a TOCTOU race — the entry disappearing between `os.ReadDir` and the `.Info()` call — not reproducible deterministically in a single-process test.
 - **`generate.go` — `Generate`'s `!ok` type-assertion guard** on the singleflight return value. `generateOnce` (the only function ever passed to `group.Do`) always returns `(GenerateResult, error)`, so the failed-assertion arm is unreachable without changing that contract. The source comment already documents this as defense against "a future refactor"; `TestGenerate_TypeAssertionGuard` exercises the happy path to confirm the guard doesn't false-positive, but cannot reach the guard itself.
-- **`handler.go` — `NewHandler`'s `newCaddyProxy` error branch.** `newCaddyProxy` fails only if the process-wide embedded Caddy engine (`ensureCaddyEngine`, guarded by a `sync.Once`) fails to start. Once any test in the package successfully constructs a `Handler` (nearly all of `handler_test.go` does, via `newIntegrationHandler`), the engine is up for the rest of the test binary's life — there is no way to force a fresh failure afterward without restructuring the engine lifecycle away from `sync.Once`. The same reasoning applies to `caddyproxy.go`'s `ensureCaddyEngine` itself (its `net.Listen`/`adapter.Adapt`/`caddy.Load` failure branches) and the remainder of `newCaddyProxy` — none of these can be exercised without either forcing the *first* engine start in the whole test binary to fail (impossible to target at just one test given `sync.Once` and Go's parallel/ordered test execution within a package) or restructuring the engine lifecycle. `IsErrServerClosed` and `proxyErrorHandler`, the two functions in `caddyproxy.go` that don't depend on the engine, are fully tested (100%) in `caddyproxy_test.go`.
+- **`handler.go` — `NewHandler`'s `newCaddyProxy` error branch.** `newCaddyProxy` fails only if the process-wide embedded Caddy engine (`ensureCaddyEngine`, guarded by a `sync.Once`) fails to start. Once any test in the package successfully constructs a `Handler` (nearly all of `handler_test.go` does, via `newIntegrationHandler`), the engine is up for the rest of the test binary's life — there is no way to force a fresh failure afterward without restructuring the engine lifecycle away from `sync.Once`. The same reasoning applies to `caddyproxy.go`'s `ensureCaddyEngine` itself (its `net.Listen`/`adapter.Adapt`/`caddy.Load` failure branches) and the remainder of `newCaddyProxy` — none of these can be exercised without either forcing the _first_ engine start in the whole test binary to fail (impossible to target at just one test given `sync.Once` and Go's parallel/ordered test execution within a package) or restructuring the engine lifecycle. `IsErrServerClosed` and `proxyErrorHandler`, the two functions in `caddyproxy.go` that don't depend on the engine, are fully tested (100%) in `caddyproxy_test.go`.
 - **`response.go` — `AbsoluteImageURL`'s second `if imageURL == "" { return base }` check.** This is dead code: the function's first statement already returns `""` when `imageURL == ""` (line 64-66), so by the time execution reaches line 77 `imageURL` cannot be empty. Left as-is (not deleted) since removing it is a source-behavior change outside the scope of a test-coverage pass, not a test gap to close.
 - **`renderer.go` — `Render`'s `json.Marshal` failure branch.** Same reasoning as `writeMeta` above: `renderRequest{Source: htmlSrc, Format: "png", Options: map[string]any{...}}` always contains a Go string and two ints, none of which `encoding/json` can fail to marshal (invalid UTF-8 in `htmlSrc` is replaced with U+FFFD, not an error).
-- **`renderer.go` — `Render`'s `if wait <= 0 { break }` branch**, distinct from the (tested) `if remaining <= 0 { break }` check earlier in the same loop iteration. Reaching it requires the retry deadline to expire specifically *during* the `r.attempt(...)` call — after the top-of-loop check saw time remaining, but before the post-attempt wait calculation. `attempt`'s own bounded context makes this a single-digit-millisecond window that depends on OS scheduling jitter; not reliably forceable in a single-process test without also risking flaking on slower CI runners. `TestRender_ZeroWaitBudgetBreaksRetryLoop` exercises the same short-timeout-retry shape and confirms the loop still exits cleanly with `ErrRenderFailed`, without being able to pin down which of the two break points fired.
+- **`renderer.go` — `Render`'s `if wait <= 0 { break }` branch**, distinct from the (tested) `if remaining <= 0 { break }` check earlier in the same loop iteration. Reaching it requires the retry deadline to expire specifically _during_ the `r.attempt(...)` call — after the top-of-loop check saw time remaining, but before the post-attempt wait calculation. `attempt`'s own bounded context makes this a single-digit-millisecond window that depends on OS scheduling jitter; not reliably forceable in a single-process test without also risking flaking on slower CI runners. `TestRender_ZeroWaitBudgetBreaksRetryLoop` exercises the same short-timeout-retry shape and confirms the loop still exits cleanly with `ErrRenderFailed`, without being able to pin down which of the two break points fired.
 - **`shim.go` — `firstGlyph`'s `if len(r) == 0 { return "" }` check.** Dead code: the function already returns early when `strings.TrimSpace(s) == ""` (two lines above), so `[]rune(s)` on a string that passed that check can never be empty.
 
 ## `html-to-image/app.js`
@@ -302,7 +323,7 @@ This service runs on Bun (#314 — migrated from Node). CI (`html-to-image-tests
 
 **Entry-point bootstrap block:** the `if (process.argv[1] === fileURLToPath(import.meta.url)) { ... }` block at the bottom of `app.js` (server listen + `SIGINT`/`SIGTERM` handlers) only runs when the file is executed directly, never when `app.test.js` imports it — the same rationale as excluding `server/src/index.ts` on the server side. Under Node this region was wrapped in `/* node:coverage disable */`/`/* node:coverage enable */` markers, which Node's reporter honored. Bun does **not** honor per-block coverage markers (same limitation documented for the server in #287), so the markers were removed in #314 and the gate is the import-meta path check alone — structurally unreachable under the test harness, just not suppressed from a coverage report.
 
-**`waitForVisualReadiness`'s in-page callbacks (`page.evaluate`'s fonts-ready check, `page.waitForFunction`'s image-completeness predicate) are exercised by calling the captured function directly** in the relevant tests (`"evaluate callback waits on document.fonts.ready when present"`, `"waitForFunction predicate checks every image is complete..."`), with a fake `document` global standing in for the real page's — these functions are serialized by Puppeteer and actually execute in the browser page context, not in the Bun process, so the mock `page.evaluate`/`page.waitForFunction` in `app.test.js` only *record* the function reference; a test has to invoke it explicitly to get real coverage and verify its logic.
+**`waitForVisualReadiness`'s in-page callbacks (`page.evaluate`'s fonts-ready check, `page.waitForFunction`'s image-completeness predicate) are exercised by calling the captured function directly** in the relevant tests (`"evaluate callback waits on document.fonts.ready when present"`, `"waitForFunction predicate checks every image is complete..."`), with a fake `document` global standing in for the real page's — these functions are serialized by Puppeteer and actually execute in the browser page context, not in the Bun process, so the mock `page.evaluate`/`page.waitForFunction` in `app.test.js` only _record_ the function reference; a test has to invoke it explicitly to get real coverage and verify its logic.
 
 **Remaining branch gap, accepted without a test:** the `browserPromise ?? startBrowser()` fallback on the final line of `getBrowser()` (the `?? startBrowser()` half) requires a concurrent caller to observe `browserPromise` as `null` at that exact point — i.e., a third overlapping `getBrowser()`/`closeBrowser()` racing in between a second caller's "someone else already relaunched" check and its own fallback read. `"a second caller racing a crash reuses the relaunch the first caller already started"` covers the more common two-way race (second caller sees the relaunch already in flight and reuses it), but forcing the three-way race deterministically would require reaching into the pool's internal timing rather than testing its public behavior. Same category as the Express generic error-handler's `err.status || 500` / `err.message || 'Internal server error'` fallbacks in `createApp` — every `next(err)` call in this file's own validation middleware always supplies both fields, so those defaults only guard against a genuinely unexpected error escaping from somewhere outside this codebase (e.g. body-parser or the rate limiter throwing a bare error) and are not reachable through this app's own code paths.
 
@@ -311,6 +332,7 @@ This service runs on Bun (#314 — migrated from Node). CI (`html-to-image-tests
 The following files are excluded from coverage metrics entirely. See the root-level notes in `CLAUDE.md` under "Coverage Exclusions".
 
 **Server** (excluded via `coveragePathIgnorePatterns` in `server/bunfig.toml`):
+
 - `src/lexicon/**` — auto-generated AT Protocol types
 - `src/index.ts` — Hono app + Bun.serve boot + signal handlers
 - `src/auth/client.ts`, `src/auth/storage.ts`, `src/auth/session.ts` — OAuth wiring
@@ -321,15 +343,55 @@ The following files are excluded from coverage metrics entirely. See the root-le
 - `src/hono/session-middleware.ts` — signed-cookie session I/O; covered by the E2E suite (real cookies), not unit tests
 
 **Client** (excluded via `coverage.exclude` in `vite.config.ts`):
+
 - `src/tests/**`, `src/main.tsx`, `src/Theme.tsx` — test infra and entry point
 - `src/vite-env.d.ts` — ambient declarations
 - `src/styles/tokens.ts` — pure style constants
+- `src/**/*.styles.ts` — per-component style modules (see below)
+
+### Client `*.styles.ts` modules
+
+The frontend refactor split rendering from styling: a component's CSS objects live
+in a sibling `Thing.styles.ts` that the `.tsx` imports as a namespace. These files
+export style constants and the pure functions that select between them
+(`card({ gradient, pinned, focused })` → a `CSSProperties`), so they are the same
+category as `src/styles/tokens.ts` — declarative values with no behaviour, where an
+assertion could only restate the literal it is reading.
+
+The exclusion is a glob rather than a per-file list so the convention scales, and it
+carries an obligation: nothing but visual mapping may live in one. If a style
+function ever needs to know a business rule, that is the signal to move the decision
+back into the component or a hook, where it is measured.
+
+**What it would take to test:** snapshot the returned objects. That would pin the
+literals against themselves and fail on every deliberate visual change, which is the
+noise the exclusion exists to avoid. The colours these files reference are covered
+differently and more usefully — see below.
+
+### Client theme contrast (`src/tests/theme/`)
+
+`contrast.test.ts` is not excluded; it is the reason several of these files can be.
+It parses `client/src/index.css`, resolves `var()` indirection per colour scheme, and
+asserts WCAG AA on every text/background pair the UI actually renders — including
+alpha-composited surfaces, every sampled point along each gradient ramp (not just the
+declared stops, which is how the old cyan and emerald ask-card presets looked
+compliant at 2.4:1), and every `Alert` tone against its own tint in both schemes.
+
+It also enforces token hygiene in both directions: a declared `--nf-*` token that no
+source references fails, and a referenced token that nothing declares fails. The
+second direction caught `--nf-font-mono`, which two components had been asking for
+without it ever having been defined.
+
+Its helpers (`colorMath.ts`, `readTokens.ts`) live under `src/tests/` rather than
+`src/lib/` because nothing ships them — they exist to check the palette, not to
+render with it, so they fall under the existing `src/tests/**` exclusion.
 
 ## SQLite driver (`server/src/database/db.ts`)
 
 `db.ts` is excluded from coverage (it's the Kysely migration runner). The SQLite driver is `bun:sqlite` (`bun:sqlite` resolves only under the Bun runtime; `@types/bun` provides its types), bridged onto Kysely's stock `SqliteDialect` via a small `BunSqliteDatabase`/`BunSqliteStatement` adapter added in #263. `better-sqlite3` (the former Node driver) was removed entirely in #288 when the Node code path was retired — there is no runtime gate left, `bun:sqlite` is used unconditionally. The adapter is exercised by the `Probe SQLite data layer` step in `.github/workflows/Tests.yml`, which runs the real `createDb` → `migrateToLatest` → insert/select path and gates on `OK`.
 
 The two API deltas the adapter bridges (both verified locally under Bun):
+
 - `bun:sqlite`'s `Statement` has no `reader` flag — derived as `columnNames.length > 0`, the same rule `better-sqlite3` used internally to set its `reader` flag.
 - `bun:sqlite`'s `Statement.all/run/iterate` take variadic params, not an array — the adapter spreads the params array Kysely passes.
 
@@ -401,14 +463,14 @@ Every worker throws, the run finishes in ~6s instead of ~20s, and the summary re
 
 The gate did not get weaker:
 
-| | v8 (before, on Node) | istanbul (now, on Bun) |
-| --- | --- | --- |
-| statements | 100% (1228/1228) | 100% (1246/1246) |
-| branches | 100% (937/937) | 100% (952/952) |
-| functions | 100% (380/380) | 100% (382/382) |
-| lines | 100% (1146/1146) | 100% (1160/1160) |
-| enforced by | Coveralls threshold only | `coverage.thresholds` in `vite.config.ts` + Coveralls |
-| lcov branch records | yes | yes (`BRDA`) |
+|                     | v8 (before, on Node)     | istanbul (now, on Bun)                                |
+| ------------------- | ------------------------ | ----------------------------------------------------- |
+| statements          | 100% (1228/1228)         | 100% (1246/1246)                                      |
+| branches            | 100% (937/937)           | 100% (952/952)                                        |
+| functions           | 100% (380/380)           | 100% (382/382)                                        |
+| lines               | 100% (1146/1146)         | 100% (1160/1160)                                      |
+| enforced by         | Coveralls threshold only | `coverage.thresholds` in `vite.config.ts` + Coveralls |
+| lcov branch records | yes                      | yes (`BRDA`)                                          |
 
 istanbul's denominators are larger because it instruments defensive branches v8 folds away. Reaching 100% on them was annotation work, not new tests: 29 sites were uncovered on the first istanbul run, and all 29 already carried a `/* v8 ignore */` marker that istanbul does not honor. See "Coverage Suppression Markers" above for the conversion and for the placement rule that bit two of them.
 
@@ -426,10 +488,10 @@ Zod v4's entrypoint does `import * as z from "./v4/classic/external.js"; export 
 
 Isolating the layer, since the fix belongs at the narrowest one:
 
-| path | Node | Bun |
-| --- | --- | --- |
-| `import("zod")` directly | `z` present | `z` present |
-| `viteServer.ssrLoadModule("zod")` | `z` present | `z` present |
+| path                                 | Node        | Bun               |
+| ------------------------------------ | ----------- | ----------------- |
+| `import("zod")` directly             | `z` present | `z` present       |
+| `viteServer.ssrLoadModule("zod")`    | `z` present | `z` present       |
 | Vitest module runner (happy-dom env) | `z` present | **`z` undefined** |
 
 Only the last combination breaks, so this is Vitest's module runner over the prebundled dependency on Bun, not Bun's ESM loader and not Vite's transform. The namespace import is the form zod's own docs use, costs nothing, and sidesteps it. The regression guard is CI running the suite on Bun: reverting to `import { z }` fails it immediately. The probe script deliberately does not assert this, since a bare `import("zod")` inside the probe passes on both runtimes and would give false assurance.
@@ -463,10 +525,10 @@ Not worth pursuing. Microsoft does not support Bun as a Playwright runtime, the 
 
 ### Remaining Node in the repo
 
-| Location | What | Why it stays |
-| --- | --- | --- |
-| `.github/workflows/E2E.yml` | `actions/setup-node@v4` | Playwright, see above |
-| root `package.json` | `test:e2e`, `test:e2e:ui` | Playwright, same |
+| Location                    | What                      | Why it stays          |
+| --------------------------- | ------------------------- | --------------------- |
+| `.github/workflows/E2E.yml` | `actions/setup-node@v4`   | Playwright, see above |
+| root `package.json`         | `test:e2e`, `test:e2e:ui` | Playwright, same      |
 
 That is the whole list. Every other script in every workspace routes through `bunx --bun` or is Bun-native, all five Dockerfiles are `FROM oven/bun`, and `Tests.yml` sets up no Node in any job. The `tsx` loader was dropped from `server/` (Bun runs the lexicon-publishing script's TypeScript directly) and the html-to-image CI job now uses `bunx puppeteer browsers install chrome` instead of `npx`.
 

--- a/e2e/web/customise.spec.ts
+++ b/e2e/web/customise.spec.ts
@@ -117,7 +117,7 @@ test("message language selector changes locale and is restored afterwards", asyn
 });
 
 test("profile card colour swatch changes theme and is restored afterwards", async ({ page }) => {
-  const ember = page.getByRole("button", { name: /ember theme/i });
+  const ember = page.getByRole("button", { name: /^ember$/i });
   await expect(ember).toBeVisible({ timeout: 10_000 });
   await expect(ember).toBeEnabled({ timeout: 10_000 });
 


### PR DESCRIPTION
## Summary

Three changes that turned out to be one change: break up the oversized components, move styling out of the JSX, then audit the theming that was now visible in one place. The audit found real bugs, so it is the largest part of this.

No behaviour changes beyond the contrast fixes and two small UX improvements noted below.

## Related issue

Closes #

## Scope

- [x] client
- [ ] server
- [ ] opengraph-service
- [ ] docker / infra (caddy, anubis)
- [x] docs

## Changes

### Component decomposition

`Messages.tsx` was 1447 lines holding a page, four cards, a keyboard-nav controller and three image-theme mockups. It is now 386 lines of page plus eight components under `components/messages/` and three hooks. `PublicProfile`, `Login`, `Navigation`, `AppHeader`, `Settings`, `Customise` and `Home` got the same treatment.

| File | Before | After |
|---|---|---|
| `pages/Messages.tsx` | 1447 | 386 |
| `pages/PublicProfile.tsx` | 600 | 207 |
| `pages/Login.tsx` | 519 | 149 |
| `Navigation.tsx` | 409 | 159 |
| `components/AppHeader.tsx` | 335 | 147 |

New hooks: `useMessagePreferences` (five localStorage toggles behind one record), `useThreadRoot` (pin state, thread links, and the reply-order rule that was previously spelled out inline in three places), `useCardKeyboardNav`, `useNavShortcuts`, `useHandleSearch`.

Duplication that got merged rather than moved: `ThemeCard` and `ProfileThemeSwatches` were two visual pickers that disagreed on selection chrome and on whether they announced themselves, now one `SwatchButton`. The home page and the Messages theme panel had two copies of the shortcut list that disagreed on type sizes and on whether the modifier read `Alt/Cmd` or `Alt/⌘`, now one `ShortcutList`. The login and OAuth-callback panels share an `AuthPanel`.

### Rendering vs styling

A `.tsx` describes structure and behaviour; the CSS objects it needs live in a sibling `*.styles.ts`, imported as a namespace. Anything computed from props is a named function there (`card({ gradient, pinned, focused })`) rather than a ternary inline in JSX. Style modules are coverage-excluded on the same rationale as the existing `src/styles/tokens.ts`, with the obligation written down in `docs/testing-notes.md`: nothing but visual mapping goes in one.

### Theming

`index.css` is now layered: brand primitives, scheme-aware semantic tokens, and on-gradient tokens (which are deliberately *not* scheme-aware, because the brand gradients are dark in both schemes). Because the semantic layer flips in CSS, nine components stopped needing `useComputedColorScheme` and `SettingsCard` lost its `isDark` prop entirely.

### Contrast bugs found and fixed

- **Question card body text was invisible.** It rendered `c="white"` unconditionally while the background was only a gradient when "Gradient backgrounds" was on. With that preference off in light mode the text was white on `#F2EBFF`, ratio 1.07:1. Cards now publish `--nf-card-fg`/`--nf-card-fg-muted` and their children read those, so the choice is made once.
- **Every card description was below AA in light mode.** Mantine's default dimmed (gray-6) is 2.9:1 on the light card surface. Now `#5B5680`, which was already defined in the stylesheet as `--nf-text-muted` and unused.
- **Three of the four ask-card presets failed.** The `profileCardThemes` doc comment promised white text stays legible on every option. Aurora bottomed out at 2.3:1, verdant 2.4:1, ember 3.4:1. All three restopped darker.
- **The light-mode Mantine overrides had never applied.** `--mantine-color-body` and `--mantine-color-default-border` sat at specificity (0,1,0) against Mantine's `:root[data-mantine-color-scheme="light"]` at (0,2,0), so the intended cream page background has been plain white. Body now comes from `theme.white`; the border override matches the selector.
- **`--nf-font-mono` was referenced by two components and defined nowhere.**
- **Dark-mode filled primary buttons** were white on royal-4, 3.6:1. `primaryShade` is flat 6 now.
- **The composer's char ring** drew its track in `rgba(253,248,255,0.15)` on a white panel, and its warning state in `--nf-sunshine` at 1.7:1. Both are composer-local tokens now.
- **`ConfirmationModal`'s confirm button was blue** for deletes. It takes a `destructive` prop, and `crimson` is a real palette entry rather than a bare CSS colour name that happened to resolve.

Two small UX changes fell out: the ask-card textarea truncates a long paste instead of rejecting it outright, and the collapsible panel headers are real buttons rather than click-handling `div`s.

### Contrast is a test, not a comment

`src/tests/theme/contrast.test.ts` parses `index.css`, resolves `var()` per colour scheme, and asserts AA on every text/background pair the UI renders. It samples the full ramp of each gradient rather than just the declared stops, which is how the old cyan and emerald presets looked compliant. It also fails on a declared `--nf-*` token nothing references and on a referenced token nothing declares, which is what surfaced the missing font token.

## Testing

- [x] Unit/integration tests pass locally (593 tests, 38 files)
- [ ] E2E (Playwright) passes for affected flows
- [x] Docker smoke test passes if server/infra changed (n/a, client only)
- [ ] Manually verified against a real Bluesky/AT Protocol account

Coverage stays at 100% on all four metrics. Five `istanbul ignore` suppressions in `Messages.tsx` and `PublicProfile.tsx` are gone because the refactor removed the unreachable guards rather than re-annotating them; the catalogue in `docs/testing-notes.md` is updated to say so. Six new boundary tests cover branches the decomposition exposed.

One E2E selector changed: `customise.spec.ts` looked up the ember swatch by `aria-label="Ember theme"`, and the shared `SwatchButton` takes its accessible name from the visible caption, so it is now `/^ember$/i`. E2E has not been run here (needs a live PDS).

Verified visually in Chromium at both colour schemes, with gradients on and off, on Home, Login and Messages.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens (`useThreadRoot` keeps the NF-message ↔ Bluesky-post link in localStorage only, per the architecture note in CLAUDE.md)
- [x] Docs updated if user-facing behavior or setup changed (`client/CLAUDE.md` styling section rewritten, `docs/testing-notes.md` exclusions and suppression catalogue updated)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TMh9brRSWBUGBXXsXwYK8S)_