### PR TITLE
fix(anubis): stop challenging static assets, and refuse to cache the interstitial

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -396,6 +396,25 @@ jobs:
       - name: Check doc links resolve
         run: bun run check:doc-links
 
+  bot-policy:
+    name: Anubis Bot Policy
+    runs-on: ubuntu-latest
+
+    # The policy allowed /site.webmanifest long after vite-plugin-pwa started
+    # emitting /manifest.webmanifest, so the real file was challenged while the
+    # rule sat there looking correct. Nothing caught it because nothing read the
+    # policy and the client build together.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Check the policy allows what the client ships
+        run: bun run test:bot-policy
+
   coveralls-finish:
     name: Coveralls Finish
     needs: [client-tests, server-tests]

--- a/anubis/botPolicy.json
+++ b/anubis/botPolicy.json
@@ -1,48 +1,18 @@
 {
   "bots": [
     {
-      "name": "favicon",
-      "path_regex": "^/favicon.ico$",
+      "name": "static-assets",
+      "path_regex": "^/(assets/.*|[^/]+\\.(css|ico|js|json|mjs|png|svg|txt|webmanifest|webp|woff|woff2|xml))$",
       "action": "ALLOW"
     },
     {
-      "name": "robots-txt",
-      "path_regex": "^/robots.txt$",
-      "action": "ALLOW"
-    },
-    {
-      "name": "client-metadata-json",
-      "path_regex": "^/client-metadata.json$",
-      "action": "ALLOW"
-    },
-    {
-      "name": "service-worker",
-      "path_regex": "^/sw.js$",
-      "action": "ALLOW"
-    },
-    {
-      "name": "webmanifest",
-      "path_regex": "^/site.webmanifest$",
-      "action": "ALLOW"
-    },
-    {
-      "name": "sitemap",
-      "path_regex": "^/sitemap.xml$",
-      "action": "ALLOW"
-    },
-    {
-      "name": "chrome-icons",
-      "path_regex": "^/android-chrome-\\d+x\\d+\\.png$",
-      "action": "ALLOW"
-    },
-    {
-      "name": "apple-touch-icon",
-      "path_regex": "^/apple-touch-icon.png$",
+      "name": "app-shell",
+      "path_regex": "^/index\\.html$",
       "action": "ALLOW"
     },
     {
       "name": "summary-html",
-      "path_regex": "^/summary.html$",
+      "path_regex": "^/summary\\.html$",
       "action": "ALLOW"
     },
     {

--- a/client/src/lib/wafInterstitial.ts
+++ b/client/src/lib/wafInterstitial.ts
@@ -1,0 +1,25 @@
+/**
+ * Anubis, the WAF in front of this app, serves its challenge interstitial as
+ * HTML under HTTP 200 (`status_codes.CHALLENGE` in `anubis/botPolicy.json`), so
+ * `response.ok` cannot distinguish a real asset from a challenge and workbox
+ * caches anything ok. A challenge stored under a bundle URL then serves HTML as
+ * JavaScript, and Caddy stamps `immutable` on `/assets/*`, so the entry survives
+ * until the user clears site data by hand.
+ *
+ * Content type read against the URL's own extension is the only signal that
+ * survives the proxy: the challenge carries no distinguishing header, and Caddy
+ * rewrites Cache-Control on the way out.
+ *
+ * `anubis/botPolicy.json` allowing these paths is the primary fix; this is the
+ * guard for the next time a generated filename stops matching that policy.
+ *
+ * @see [wafInterstitial.test.ts](../tests/lib/wafInterstitial.test.ts): pins an
+ * HTML body under an asset URL as rejected and the same body under a document
+ * URL as allowed.
+ */
+const NON_HTML_ASSET = /\.(css|ico|js|json|mjs|png|svg|webmanifest|webp|woff|woff2)$/i;
+
+export function isWafInterstitial(url: string, contentType: string | null): boolean {
+  if (!contentType?.toLowerCase().includes("text/html")) return false;
+  return NON_HTML_ASSET.test(new URL(url).pathname);
+}

--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -1,13 +1,20 @@
 /// <reference lib="webworker" />
 
-import { precacheAndRoute } from "workbox-precaching";
+import { addPlugins, precacheAndRoute } from "workbox-precaching";
 import { registerRoute, NavigationRoute } from "workbox-routing";
 import { NetworkFirst, CacheFirst } from "workbox-strategies";
 
+import { isWafInterstitial } from "./lib/wafInterstitial";
 import type { PushPayload } from "./pushPayload";
 
 declare const self: ServiceWorkerGlobalScope;
 
+const rejectWafInterstitials = {
+  cacheWillUpdate: async ({ request, response }: { request: Request; response: Response }) =>
+    isWafInterstitial(request.url, response.headers.get("content-type")) ? null : response,
+};
+
+addPlugins([rejectWafInterstitials]);
 precacheAndRoute(self.__WB_MANIFEST);
 
 // Only ever skip waiting on request. Calling skipWaiting() at parse time takes
@@ -37,6 +44,7 @@ const navigationRoute = new NavigationRoute(
   new NetworkFirst({
     cacheName: CACHE_STATIC,
     networkTimeoutSeconds: 10,
+    plugins: [rejectWafInterstitials],
   })
 );
 registerRoute(navigationRoute);
@@ -44,7 +52,7 @@ registerRoute(navigationRoute);
 registerRoute(
   ({ request, url }) =>
     url.origin === SW_ORIGIN && ["script", "style", "image", "font"].includes(request.destination),
-  new CacheFirst({ cacheName: CACHE_STATIC })
+  new CacheFirst({ cacheName: CACHE_STATIC, plugins: [rejectWafInterstitials] })
 );
 
 const APP_ICON = "/android-chrome-192x192.png";

--- a/client/src/tests/lib/wafInterstitial.test.ts
+++ b/client/src/tests/lib/wafInterstitial.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+import { isWafInterstitial } from "../../lib/wafInterstitial";
+
+const ORIGIN = "https://navyfragen.app";
+const CHALLENGE_TYPE = "text/html; charset=utf-8";
+
+describe("isWafInterstitial", () => {
+  // The pair that matters: on 2026-08-11 Anubis answered a precache fetch for
+  // /assets/index-DeIhOTij.js with 200 text/html, and workbox cached the
+  // challenge page as the app bundle. A navigation getting HTML is the normal
+  // case and must stay cacheable.
+  it("rejects an HTML body served for an asset URL", () => {
+    expect(isWafInterstitial(`${ORIGIN}/assets/index-DeIhOTij.js`, CHALLENGE_TYPE)).toBe(true);
+  });
+
+  it("accepts an HTML body served for a document URL", () => {
+    expect(isWafInterstitial(`${ORIGIN}/messages`, CHALLENGE_TYPE)).toBe(false);
+  });
+
+  it("accepts an asset URL served with its own content type", () => {
+    expect(isWafInterstitial(`${ORIGIN}/assets/index-DeIhOTij.js`, "text/javascript")).toBe(false);
+  });
+
+  it.each([
+    ["stylesheet", "/assets/index-CyAS1slt.css"],
+    ["web manifest", "/manifest.webmanifest"],
+    ["service worker", "/sw.js"],
+    ["icon", "/android-chrome-192x192.png"],
+    ["json", "/client-metadata.json"],
+    ["font", "/assets/inter.woff2"],
+  ])("rejects an HTML body served for a %s", (_label, path) => {
+    expect(isWafInterstitial(`${ORIGIN}${path}`, CHALLENGE_TYPE)).toBe(true);
+  });
+
+  it("treats the app shell as a document, since HTML is what it should return", () => {
+    expect(isWafInterstitial(`${ORIGIN}/index.html`, CHALLENGE_TYPE)).toBe(false);
+  });
+
+  it("ignores a query string when reading the extension", () => {
+    expect(isWafInterstitial(`${ORIGIN}/sw.js?v=2`, CHALLENGE_TYPE)).toBe(true);
+  });
+
+  it("matches the content type case-insensitively", () => {
+    expect(isWafInterstitial(`${ORIGIN}/sw.js`, "TEXT/HTML")).toBe(true);
+  });
+
+  it("accepts a response with no content type at all", () => {
+    expect(isWafInterstitial(`${ORIGIN}/sw.js`, null)).toBe(false);
+  });
+});

--- a/client/src/tests/sw.test.ts
+++ b/client/src/tests/sw.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const precacheAndRouteMock = vi.fn();
+const addPluginsMock = vi.fn();
 const registerRouteMock = vi.fn();
 const networkFirstCtor = vi.fn();
 const cacheFirstCtor = vi.fn();
@@ -8,6 +9,7 @@ const navigationRouteCtor = vi.fn();
 
 vi.mock("workbox-precaching", () => ({
   precacheAndRoute: (...args: unknown[]) => precacheAndRouteMock(...args),
+  addPlugins: (...args: unknown[]) => addPluginsMock(...args),
 }));
 vi.mock("workbox-routing", () => ({
   registerRoute: (...args: unknown[]) => registerRouteMock(...args),
@@ -61,6 +63,7 @@ async function loadServiceWorker() {
 describe("sw.ts", () => {
   beforeEach(async () => {
     precacheAndRouteMock.mockClear();
+    addPluginsMock.mockClear();
     registerRouteMock.mockClear();
     networkFirstCtor.mockClear();
     cacheFirstCtor.mockClear();
@@ -102,8 +105,54 @@ describe("sw.ts", () => {
   it("registers the network-only, navigation, and static-asset routes", () => {
     expect(registerRouteMock).toHaveBeenCalledTimes(3);
     expect(networkFirstCtor).toHaveBeenCalled();
-    expect(cacheFirstCtor).toHaveBeenCalledWith({ cacheName: "nf-static-v2" });
+    expect(cacheFirstCtor).toHaveBeenCalledWith({
+      cacheName: "nf-static-v2",
+      plugins: [expect.objectContaining({ cacheWillUpdate: expect.any(Function) })],
+    });
     expect(navigationRouteCtor).toHaveBeenCalled();
+  });
+
+  describe("WAF interstitial guard", () => {
+    // Anubis answers a challenged request with its interstitial under HTTP 200,
+    // so every caching path here has to refuse it explicitly. Precaching is the
+    // one that actually bit on 2026-08-11: it fetches the whole asset manifest
+    // outside any page context, and each fetch was challenged in turn.
+    function plugin() {
+      return addPluginsMock.mock.calls[0][0][0] as {
+        cacheWillUpdate: (arg: {
+          request: Request;
+          response: Response;
+        }) => Promise<Response | null>;
+      };
+    }
+
+    function fakeExchange(url: string, contentType: string) {
+      return {
+        request: { url } as Request,
+        response: { headers: new Headers({ "content-type": contentType }) } as Response,
+      };
+    }
+
+    it("drops a challenge page fetched under an asset URL", async () => {
+      const exchange = fakeExchange("https://nf.example.com/assets/app.js", "text/html");
+
+      await expect(plugin().cacheWillUpdate(exchange)).resolves.toBeNull();
+    });
+
+    it("keeps the real asset", async () => {
+      const exchange = fakeExchange("https://nf.example.com/assets/app.js", "text/javascript");
+
+      await expect(plugin().cacheWillUpdate(exchange)).resolves.toBe(exchange.response);
+    });
+
+    it("guards the precache, the navigation route, and the static-asset cache alike", () => {
+      const guard = plugin();
+
+      expect(networkFirstCtor).toHaveBeenCalledWith(
+        expect.objectContaining({ plugins: [guard], networkTimeoutSeconds: 10 })
+      );
+      expect(cacheFirstCtor).toHaveBeenCalledWith(expect.objectContaining({ plugins: [guard] }));
+    });
   });
 
   describe("network-only route matcher", () => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "check:doc-links": "bun scripts/check-doc-links.mjs",
-    "test:doc-links": "bun test scripts/check-doc-links.test.ts"
+    "test:doc-links": "bun test scripts/check-doc-links.test.ts",
+    "test:bot-policy": "bun test scripts/bot-policy.test.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",

--- a/scripts/bot-policy.test.ts
+++ b/scripts/bot-policy.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "bun:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const policy = JSON.parse(readFileSync(join(repoRoot, "anubis", "botPolicy.json"), "utf8"));
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36";
+
+/**
+ * Anubis walks `bots` in order and takes the first rule that matches, so a test
+ * that only checked "is there an ALLOW regex for this" would pass even when an
+ * earlier CHALLENGE shadowed it. The `import` entry pulls in upstream's default
+ * config, which only classifies non-Mozilla agents, so skipping it does not
+ * change the verdict for a browser.
+ */
+function verdict(path: string, userAgent = BROWSER_UA): string {
+  for (const rule of policy.bots) {
+    if (rule.import) continue;
+    if (rule.path_regex && !new RegExp(rule.path_regex).test(path)) continue;
+    if (rule.user_agent_regex && !new RegExp(rule.user_agent_regex).test(userAgent)) continue;
+    if (!rule.path_regex && !rule.user_agent_regex) continue;
+    return rule.action;
+  }
+  return "ALLOW";
+}
+
+describe("anubis bot policy", () => {
+  // The incident: a service worker precaching the build manifest had every
+  // asset fetch challenged in turn. Each challenge issued its own Set-Cookie,
+  // clobbering the previous one, and the challenge was then solved twice and
+  // rejected the second time with double_spend.
+  describe("static assets versus documents", () => {
+    test("allows a content-hashed bundle", () => {
+      assert.equal(verdict("/assets/index-DeIhOTij.js"), "ALLOW");
+      assert.equal(verdict("/assets/index-CyAS1slt.css"), "ALLOW");
+    });
+
+    test("challenges an app route", () => {
+      assert.equal(verdict("/"), "CHALLENGE");
+      assert.equal(verdict("/messages"), "CHALLENGE");
+    });
+
+    test("allows the precached app shell", () => {
+      assert.equal(verdict("/index.html"), "ALLOW");
+    });
+
+    test("challenges a profile path, which is what the OG shim answers", () => {
+      assert.equal(verdict("/profile/someone.bsky.social"), "CHALLENGE");
+    });
+  });
+
+  // The rot that caused this: the policy allowed /site.webmanifest, but
+  // vite-plugin-pwa emits /manifest.webmanifest, so the real file was
+  // challenged for as long as the stale rule sat there looking correct.
+  describe("generated filenames", () => {
+    test("allows the manifest vite-plugin-pwa actually emits", () => {
+      assert.equal(verdict("/manifest.webmanifest"), "ALLOW");
+    });
+
+    test("allows the service worker", () => {
+      assert.equal(verdict("/sw.js"), "ALLOW");
+    });
+  });
+
+  test("allows every file shipped in client/public", () => {
+    const publicDir = join(repoRoot, "client", "public");
+    const challenged = readdirSync(publicDir).filter(
+      (name) => verdict(`/${name}`) !== "ALLOW" && !name.endsWith(".html")
+    );
+
+    assert.deepEqual(challenged, []);
+  });
+
+  test("still allows the Bluesky card crawler by user agent", () => {
+    assert.equal(verdict("/profile/someone.bsky.social", "Bluesky Cardyb/1.1"), "ALLOW");
+  });
+
+  test("keeps serving challenges as 200, which the SW guard depends on", () => {
+    assert.equal(policy.status_codes.CHALLENGE, 200);
+  });
+});


### PR DESCRIPTION
Clicking the header's Update button produced `Internal server error: please contact the administrator and ask them to look for the logs around: double_spend`.

Root cause is the bot policy, not the retry path #309 fixed.

## Root Cause

`botPolicy.json` ALLOWs a short list of literal filenames and nothing else, so `/assets/*`, `/index.html` and `/manifest.webmanifest` all fell through to `generic-browser` CHALLENGE. When the Update button activates the waiting worker, `precacheAndRoute` fetches the whole build manifest, and each fetch drew its own challenge (all three with `Referer: /sw.js`, `Sec-Fetch-Mode: cors`):

| Time | Path | Challenge |
|---|---|---|
| 12:48:34.129 | `/index.html` | `019ff0de-1551` |
| 12:48:34.259 | `/assets/index-DeIhOTij.js` | `019ff0de-15d3` |
| 12:48:34.381 | `/assets/index-CyAS1slt.css` | `019ff0de-164d` |

Three `Set-Cookie`s in 270ms, each clobbering the last. The document then solved `...1551` and submitted twice:

| Time | id | response | nonce | elapsedTime | Status |
|---|---|---|---|---|---|
| 12:48:40.062 | `019ff0de-1551` | `00004f9b…` | 9156 | **191** | 302 |
| 12:48:40.532 | `019ff0de-1551` | `00004f9b…` | 9156 | **200** | 500 `double_spend` |

Same id, same response, same nonce, different `elapsedTime`. A Caddy retry replays the URI byte-for-byte, so these are two independent client-side solves. Anubis's own `sha256-webcrypto.mjs` and `en.json` were each fetched twice in the same window, which corroborates two solver instances. Caddy is running #309 and is not involved.

Anubis logged `user has cookies disabled, this is not an anubis bug` 25 seconds later on the same path. Same cookie clobbering, one step further along.

## Cache Poisoning

`status_codes.CHALLENGE` is 200, so the interstitial came back as `200 text/html` under the bundle URLs (3917 bytes for the JS, 3924 for the CSS). workbox caches anything `.ok`, and Caddy's `@assets` rule stamps `public, max-age=31536000, immutable` on top of Anubis's `no-store`, so the challenge page gets stored as the app's JS and CSS until site data is cleared by hand. That is the "clearing cookies fixes it" symptom in #306.

## Changes

**`anubis/botPolicy.json`** — one extension-based `static-assets` rule replaces the per-file list, plus `app-shell` for `/index.html`. Strictly a superset of what was allowed before, so nothing that worked stops working. It also picks up nine files that had no rule at all, including `navyfragen-og.png` and every favicon.

Three of the old rules pointed at files that do not exist: `/favicon.ico` (we ship `favicon.svg` and `navyfragen.ico`), `/site.webmanifest` (vite-plugin-pwa emits `/manifest.webmanifest`), and there was no rule for `/favicon-{16,32}x{16,32}.png`.

**`client/src/lib/wafInterstitial.ts`** — a `cacheWillUpdate` plugin on the precache, the navigation route and the static-asset cache drops an HTML body served for a non-HTML asset URL. The policy is the fix; this is the guard for the next time a generated filename stops matching it, which is exactly how `/site.webmanifest` rotted.

## Tests

The rot was a rule nothing enforced, so each half gets a boundary pair:

- `scripts/bot-policy.test.ts` evaluates the policy first-match-wins (an ALLOW regex shadowed by an earlier CHALLENGE would otherwise pass) and asserts every file in `client/public` is allowed, alongside `/manifest.webmanifest` and `/sw.js`. **Fails 4 tests against the old policy.** New `Anubis Bot Policy` job in `Tests.yml`.
- `wafInterstitial.test.ts` pins both directions: HTML under an asset URL rejected, HTML under a document URL kept.
- `sw.test.ts` pins that all three caching paths carry the guard.

## Verification

617 client tests pass, `tsc` clean, doc links resolve. The client branch gate reads 99.87% locally because `client/.env` sets `VITE_API_URL` and makes `apiClient.ts`'s `|| ""` fallback unreachable. Identical on a clean `main`, and CI has no `.env`.

## Remaining Questions

- Why the challenge script bootstrapped twice in one document is not fully nailed down. `Sec-Purpose: prefetch;prerender` appears on the `/api/*` requests in the same window, so a Chrome prerender is the likely second instance. It stops mattering once the assets are allowed, but if `double_spend` recurs after this ships, that is where to look.
- `/index.html` being ALLOW means a bot can fetch the app shell without a challenge. Deliberate: it is a static file with no data in it, `/` is still challenged, and all data is behind `/api/*`, which never reaches Anubis.

Refs #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkV7SXCiw1wfmGyBeZAE1k
