### PR TITLE
Match the OG card to the app's ProfileCard

### DIFF
--- a/opengraph-service/internal/shim/template.go
+++ b/opengraph-service/internal/shim/template.go
@@ -57,7 +57,16 @@ const (
 	// fixed number the test can assert, not a function of what is behind them.
 	ogChipBG   = "#2C2560"
 	ogHairline = "#332B6B"
+
+	// The flat darken over a user banner, copied from ProfileCard.styles.ts's
+	// bannerScrim. It exists to keep the avatar ring readable on a bright photo,
+	// not to make text legible — no text sits on the banner.
+	ogBannerScrim = "rgba(0,0,0,0.2)"
 )
+
+// ogFontMono mirrors --nf-font-mono, the face ProfileUrlBar sets the share
+// link in.
+const ogFontMono = `ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Consolas, monospace`
 
 // ogSurfaces / ogTextColors enumerate the palette for the contrast test: every
 // text colour must clear AA against every surface it can land on.
@@ -94,79 +103,62 @@ const ogFontLink = `<link href="https://fonts.googleapis.com/css2?family=Inter:w
 // grows over the footer. [TestOGGeometry_VerticalBandsFitTheCanvas] adds them
 // up, so a future type-scale tweak fails a test instead of shipping a collision.
 const (
-	bannerHeight = 180
-	gutter       = 64
-	avatarSize   = 136
-	// The avatar straddles the banner seam the way it does on a profile page.
-	avatarOverlap = 52
+	bannerHeight  = 170
+	gutter        = 64
+	avatarSize    = 124
 	contentPadBot = 44
 
 	nameFontSize   = 50
 	nameLineBox    = 55 // nameFontSize * 1.1
+	nameGap        = 14 // avatar bottom → display name
 	handleFontSize = 27
 	handleLineBox  = 37 // handleFontSize * 1.35
 
-	promptGap      = 30
+	promptGap      = 28
 	promptFontSize = 56
 	promptLineBox  = 65 // promptFontSize * 1.15
 	// A prompt longer than this is ellipsised by -webkit-line-clamp rather than
 	// allowed to push into the footer.
-	promptMaxLines = 3
+	promptMaxLines = 2
 
 	footerPadTop  = 26
 	footerBorder  = 2
-	footerRowBox  = 52 // chip: 24px line + 14px padding top and bottom
+	footerRowBox  = 52 // pill: 24px line + 14px padding top and bottom
 	markSize      = 44
 	chipRadiusPx  = 999
 	hairlineWidth = footerBorder
 )
 
-// identityRowHeight is the taller of the avatar and the name/handle column. The
-// column is the taller one: .meta is padded down by avatarOverlap so its text
-// clears the banner seam and stays on the surface whose contrast is asserted.
-var identityRowHeight = maxInt(avatarSize, avatarOverlap+nameLineBox+handleLineBox)
+// The avatar overhangs the banner by half its height and the name sits *below*
+// it, matching ProfileCard.styles.ts (`top: -AVATAR_SIZE / 2`, then `pt={48}`
+// on the name row) rather than sitting beside it.
+const avatarOverlap = avatarSize / 2
+
+// avatarRadius keeps Mantine's `radius="xl"` proportion — the theme sets xl to
+// 22px and ProfileCard renders an 84px avatar, so the app's avatar is a rounded
+// square, not a circle. Scaling the ratio keeps that shape at OG size.
+//
+// [TestOGGeometry_AvatarIsARoundedSquareNotACircle] pins it.
+const avatarRadius = avatarSize * 22 / 84
+
+// ogVerticalBands is the stack of bands down the canvas, in order. The avatar
+// is pulled up into the banner, so it only occupies the half below the seam.
+var ogVerticalBands = []int{
+	bannerHeight,
+	avatarSize - avatarOverlap,
+	nameGap,
+	nameLineBox,
+	handleLineBox,
+	promptGap,
+	promptMaxLines * promptLineBox,
+	footerPadTop + footerBorder + footerRowBox,
+	contentPadBot,
+}
 
 // promptMaxHeight is the clamp's hard ceiling. -webkit-line-clamp alone counts
 // lines, not pixels, so a font that renders taller than promptLineBox would
 // still overrun; this bounds it either way.
 const promptMaxHeight = promptMaxLines * promptLineBox
-
-// ogVerticalBands is the stack of bands down the canvas, in order. The identity
-// row is pulled up into the banner by avatarOverlap, so it only occupies the
-// remainder below the seam.
-var ogVerticalBands = []int{
-	bannerHeight,
-	identityRowHeight - avatarOverlap,
-	promptGap,
-	promptMaxHeight,
-	footerPadTop + footerBorder + footerRowBox,
-	contentPadBot,
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-// transparentOf turns "#rrggbb" into the same colour at zero alpha, for the
-// far end of a fade-to-surface gradient. Spelling the rgba() out by hand would
-// be a second copy of the surface colour that drifts the day the first one is
-// retuned; a literal `transparent` is not equivalent, because engines that
-// interpolate un-premultiplied fade through transparent *black* and leave a
-// grey haze over the banner.
-//
-// [TestTransparentOf] pins the conversion.
-func transparentOf(hex string) string {
-	var r, g, b int
-	if _, err := fmt.Sscanf(strings.TrimPrefix(hex, "#"), "%02x%02x%02x", &r, &g, &b); err != nil {
-		// Unreachable for the package's own constants, which the palette test
-		// parses as #rrggbb; `transparent` is the closest safe stand-in.
-		return "transparent"
-	}
-	return fmt.Sprintf("rgba(%d,%d,%d,0)", r, g, b)
-}
 
 // shareDomain is the short domain the app hands out for a profile — the form
 // PublicProfile.tsx builds and ProfileUrlBar.tsx displays. The OG card shows
@@ -213,8 +205,8 @@ const ogTemplate = `<!DOCTYPE html>
     flex-direction: column;
   }
 
-  /* Banner strip. Fixed height, clipped, with the surface colour feathered in
-     at the bottom so the seam reads as a fade rather than a cut. */
+  /* Banner strip, ending in a hard edge — the app's ProfileCard cuts here too,
+     and a fade would read as a blur over the user's photo. */
   .banner {
     position: relative;
     height: {{BANNER_H}}px;
@@ -227,16 +219,19 @@ const ogTemplate = `<!DOCTYPE html>
     object-fit: cover; object-position: center;
     display: block;
   }
+  /* Flat 20% darken, the same scrim ProfileCard.styles.ts applies, and for the
+     same reason: it keeps the avatar's ring readable on a bright photo. It is
+     deliberately not a gradient — no text sits here, so nothing needs more. */
   .banner::after {
     content: "";
     position: absolute; inset: 0;
-    background: linear-gradient(180deg, {{SURFACE_TOP_CLEAR}} 55%, {{SURFACE_TOP}} 100%);
+    background: {{BANNER_SCRIM}};
   }
 
   /* Positioned so it paints above .banner. .banner is position:relative for its
-     ::after feather, which puts it in the positioned layer — an in-flow
-     .content would render underneath it and the avatar's overlap would be
-     clipped by the banner's own overflow:hidden. */
+     ::after scrim, which puts it in the positioned layer — an in-flow .content
+     would render underneath it and the avatar's overhang would be clipped by
+     the banner's own overflow:hidden. */
   .content {
     position: relative;
     z-index: 1;
@@ -246,30 +241,28 @@ const ogTemplate = `<!DOCTYPE html>
     padding: 0 {{GUTTER}}px {{PAD_BOT}}px;
   }
 
+  /* The avatar overhangs the banner by half its height and the name stacks
+     underneath, the arrangement ProfileCard uses. */
   .identity {
-    display: flex;
-    align-items: center;
-    gap: 26px;
     margin-top: -{{AVATAR_OVERLAP}}px;
+    min-width: 0;
   }
   .avatar {
     width: {{AVATAR}}px; height: {{AVATAR}}px;
-    border-radius: 50%;
+    /* A rounded square, not a circle — Mantine radius="xl" on ProfileCard's
+       Avatar. */
+    border-radius: {{AVATAR_RADIUS}}px;
     object-fit: cover;
-    flex-shrink: 0;
     background: {{GRAD_MARK}};
     border: 6px solid {{SURFACE_TOP}};
-    box-shadow: 0 10px 30px rgba(0,0,0,0.35);
     /* Glyph fallback shares this box, so it centres its letter. */
     display: flex; align-items: center; justify-content: center;
     color: {{TEXT}};
-    font-size: 62px; font-weight: 800; line-height: 1;
+    font-size: 58px; font-weight: 800; line-height: 1;
   }
-  /* The identity row is pushed up into the banner, so its text has to clear the
-     avatar's overlap to stay on the surface where contrast is guaranteed. */
   .meta {
     min-width: 0;
-    padding-top: {{AVATAR_OVERLAP}}px;
+    padding-top: {{NAME_GAP}}px;
   }
   .name {
     font-size: {{NAME_FS}}px; font-weight: 800; line-height: 1.1;
@@ -315,18 +308,21 @@ const ogTemplate = `<!DOCTYPE html>
   }
   .wordmark span { color: {{TEXT_ACCENT}}; }
   /* The share link, in the same "fragen.navy/<handle>" pill the profile page
-     uses (client/src/components/profile/ProfileUrlBar.tsx): domain muted, the
-     handle emphasised, because the handle is the part a reader has to retype. */
+     uses (client/src/components/profile/ProfileUrlBar.tsx): monospace, bordered,
+     domain muted and the handle emphasised, because the handle is the part a
+     reader has to retype. */
   .chip {
     min-width: 0;
     background: {{CHIP_BG}};
+    border: 2px solid {{HAIRLINE}};
     color: {{TEXT_MUTED}};
-    font-size: 24px; font-weight: 600; line-height: 1;
-    padding: 14px 22px;
+    font-family: {{FONT_MONO}};
+    font-size: 24px; font-weight: 400; line-height: 1;
+    padding: 12px 22px;
     border-radius: {{CHIP_RADIUS}}px;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .chip b { color: {{TEXT_ACCENT}}; font-weight: 700; }
+  .chip b { color: {{TEXT}}; font-weight: 700; }
 </style>
 </head>
 <body>
@@ -390,7 +386,6 @@ func BuildOGTemplate(in OGInput) string {
 		"{{H}}", fmt.Sprint(OGHeight),
 		"{{GRAD_MARK}}", ogGradMark,
 		"{{SURFACE_TOP}}", ogSurfaceTop,
-		"{{SURFACE_TOP_CLEAR}}", transparentOf(ogSurfaceTop),
 		"{{SURFACE_BOTTOM}}", ogSurfaceBottom,
 		"{{TEXT}}", ogText,
 		"{{TEXT_MUTED}}", ogTextMuted,
@@ -401,6 +396,10 @@ func BuildOGTemplate(in OGInput) string {
 		"{{GUTTER}}", fmt.Sprint(gutter),
 		"{{AVATAR}}", fmt.Sprint(avatarSize),
 		"{{AVATAR_OVERLAP}}", fmt.Sprint(avatarOverlap),
+		"{{AVATAR_RADIUS}}", fmt.Sprint(avatarRadius),
+		"{{NAME_GAP}}", fmt.Sprint(nameGap),
+		"{{BANNER_SCRIM}}", ogBannerScrim,
+		"{{FONT_MONO}}", ogFontMono,
 		"{{PAD_BOT}}", fmt.Sprint(contentPadBot),
 		"{{NAME_FS}}", fmt.Sprint(nameFontSize),
 		"{{HANDLE_FS}}", fmt.Sprint(handleFontSize),

--- a/opengraph-service/internal/shim/template_theme_test.go
+++ b/opengraph-service/internal/shim/template_theme_test.go
@@ -82,20 +82,6 @@ func TestOGTemplate_NoTextSitsOnTheBanner(t *testing.T) {
 	}
 }
 
-func TestTransparentOf(t *testing.T) {
-	if got := transparentOf(ogSurfaceTop); got != "rgba(27,23,71,0)" {
-		t.Fatalf("transparentOf(%s) = %q", ogSurfaceTop, got)
-	}
-	if got := transparentOf("#FFFFFF"); got != "rgba(255,255,255,0)" {
-		t.Fatalf("transparentOf(#FFFFFF) = %q", got)
-	}
-	// The fade must carry the surface's own hue, not black — otherwise an engine
-	// interpolating un-premultiplied leaves a grey haze across the banner.
-	if got := transparentOf(ogSurfaceTop); got == "rgba(0,0,0,0)" || got == "transparent" {
-		t.Fatalf("fade end lost the surface hue: %q", got)
-	}
-}
-
 // ── Font stack ───────────────────────────────────────────────────────────────
 
 // 'Noto Color Emoji' gives U+0020 a 1.25em advance. Anywhere but last in the
@@ -184,20 +170,82 @@ func TestOGGeometry_BandsUseMostOfTheCanvas(t *testing.T) {
 	}
 }
 
-func TestOGGeometry_AvatarOverlapsTheBannerSeam(t *testing.T) {
-	if avatarOverlap <= 0 {
-		t.Fatal("avatar must straddle the banner seam to read as a profile header")
+// ProfileCard.styles.ts positions the avatar at `top: -AVATAR_SIZE / 2`, so it
+// hangs exactly half over the banner. Matching that is what makes the OG card
+// read as the same component.
+func TestOGGeometry_AvatarHangsHalfOverTheBanner(t *testing.T) {
+	if avatarOverlap != avatarSize/2 {
+		t.Fatalf("avatar overhang is %dpx of a %dpx avatar; ProfileCard hangs it by exactly half",
+			avatarOverlap, avatarSize)
 	}
-	if avatarOverlap >= avatarSize {
-		t.Fatalf("avatarOverlap %d swallows the whole %dpx avatar", avatarOverlap, avatarSize)
+	// Half an avatar has to fit inside the banner, or it hangs off the top edge.
+	if avatarOverlap > bannerHeight {
+		t.Fatalf("avatar overhang %dpx exceeds the %dpx banner", avatarOverlap, bannerHeight)
 	}
-	// The name/handle column is pushed down by the same overlap so it clears the
-	// seam; if it were not, the text would sit on the banner and escape the
-	// contrast guarantee asserted above.
-	if identityRowHeight < avatarOverlap+nameLineBox+handleLineBox {
-		t.Fatalf("identity row %dpx does not account for meta pushed down by %dpx",
-			identityRowHeight, avatarOverlap)
+}
+
+// The app's avatar is a rounded square, not a circle: Mantine's theme sets
+// radius xl to 22px and ProfileCard renders an 84px Avatar with radius="xl".
+// A 50% radius here would be the single most visible mismatch with the app.
+func TestOGGeometry_AvatarIsARoundedSquareNotACircle(t *testing.T) {
+	if avatarRadius >= avatarSize/2 {
+		t.Fatalf("avatar radius %d on a %dpx avatar is a circle; the app uses a rounded square",
+			avatarRadius, avatarSize)
 	}
+	if avatarRadius <= 0 {
+		t.Fatalf("avatar radius %d has no rounding at all", avatarRadius)
+	}
+	// Same proportion as the app's 22px radius on an 84px avatar, within a pixel
+	// of rounding.
+	want := avatarSize * 22 / 84
+	if avatarRadius != want {
+		t.Fatalf("avatar radius %d does not keep the app's 22/84 proportion (want %d)", avatarRadius, want)
+	}
+	css := between(BuildOGTemplate(OGInput{Handle: "a.bsky.social"}), "<style>", "</style>")
+	if rule := between(css, ".avatar {", "}"); strings.Contains(rule, "border-radius: 50%") {
+		t.Fatalf(".avatar is rendered as a circle:\n%s", rule)
+	}
+}
+
+// "no blur or anything": the banner ends in a hard cut, and its scrim is the
+// app's flat darken rather than a fade into the surface. A gradient here reads
+// as a blur over the user's photo.
+func TestOGTemplate_BannerHasNoFadeOrBlur(t *testing.T) {
+	css := between(BuildOGTemplate(OGInput{
+		Handle: "a.bsky.social",
+		Banner: "https://cdn.bsky.app/b.jpg",
+	}), "<style>", "</style>")
+	scrim := between(css, ".banner::after {", "}")
+	if strings.Contains(scrim, "gradient") {
+		t.Errorf(".banner::after fades into the surface; the banner should end in a hard cut\n%s", scrim)
+	}
+	if !strings.Contains(scrim, ogBannerScrim) {
+		t.Errorf(".banner::after should carry ProfileCard's flat scrim %q\n%s", ogBannerScrim, scrim)
+	}
+	// Scanned across every .banner rule — the element, its image, and the scrim.
+	// An earlier version of this test only looked at .banner and .banner::after,
+	// and a `filter: blur()` on `.banner img` sailed straight past it.
+	for _, selector := range bannerSelectors(css) {
+		rule := between(css, selector+" {", "}")
+		for _, banned := range []string{"blur", "filter", "backdrop"} {
+			if strings.Contains(rule, banned) {
+				t.Errorf("%s uses %q; the banner photo must render sharp\n%s", selector, banned, rule)
+			}
+		}
+	}
+}
+
+// bannerSelectors returns every rule head in css that styles the banner, so a
+// blur added to a new sub-element is caught rather than missed.
+func bannerSelectors(css string) []string {
+	var out []string
+	for _, line := range strings.Split(css, "\n") {
+		head, _, ok := strings.Cut(strings.TrimSpace(line), " {")
+		if ok && strings.HasPrefix(head, ".banner") {
+			out = append(out, head)
+		}
+	}
+	return out
 }
 
 func TestOGTemplate_PromptIsClampedNotAllowedToGrow(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #368. The card had the right idea but not the app's *shape*, so a shared link and the page it points at still didn't read as the same component.

Three things were off. All three are now taken from `client/src/components/profile/ProfileCard.styles.ts` rather than eyeballed:

- **The avatar was a circle.** The app renders it with Mantine `radius="xl"`, and `Theme.tsx` sets `xl` to 22px on an 84px `Avatar` — so the app's avatar is a **rounded square**. `avatarRadius` keeps that 22/84 proportion at OG size. This was the single most visible mismatch.
- **The avatar sat beside the name.** `ProfileCard` hangs it at `top: -AVATAR_SIZE / 2` and stacks the name *underneath*. The overhang is now exactly half the avatar, with the name below it.
- **The banner faded into the surface.** `ProfileCard` cuts hard and lays a flat `rgba(0,0,0,0.2)` over the photo — enough to keep the avatar ring readable and nothing more, since no text sits there. The gradient feather read as a blur over the user's own banner, so it's gone, along with the `transparentOf` helper that existed only to feed it.

The share link also picks up `ProfileUrlBar`'s treatment: monospace, bordered, domain muted and the handle emphasised.

## Related issue

Follow-up to #366 / #368 — no new issue.

## Scope

- [ ] client
- [ ] server
- [x] opengraph-service
- [ ] docker / infra (caddy, anubis)
- [ ] docs

## Changes

- Avatar: rounded square at the app's radius proportion, overhanging the banner by exactly half its height, name stacked below.
- Banner: hard cut, flat scrim, no gradient and no blur anywhere.
- Share link pill: `--nf-font-mono`, bordered, matching `ProfileUrlBar`.
- **Prompt clamp drops from 3 lines to 2.** That's what pays for the taller identity stack. The vertical-budget test adds the bands up either way, so this had to be a deliberate trade rather than something discovered in production.
- `transparentOf` and its `SURFACE_TOP_CLEAR` slot deleted — dead once the feather went.

### One test was weaker than it looked

`TestOGTemplate_BannerHasNoFadeOrBlur` originally checked only `.banner` and `.banner::after`. Mutation testing caught that a `filter: blur()` on `.banner img` sailed straight past it — the exact thing the test exists to prevent. It now enumerates every `.banner*` rule head in the stylesheet, so a blur added to a new sub-element is caught too.

## Testing

- [x] Unit/integration tests pass locally — `go test ./...` green, `gofmt`/`go vet` clean, doc links resolve.
- [ ] E2E (Playwright) passes for affected flows — not run; no E2E covers the crawler path.
- [ ] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account — not possible from this environment; verified by rendering the real template through headless Chromium.

Rendered every case at 1200×630: banner+avatar, no banner, no avatar, neither, long display name, long handle, CJK + emoji, and an over-length prompt (clamps clear of the footer).

Five mutations each turn the matching test red: making the avatar a circle, restoring the gradient fade, shrinking the avatar overhang off half, `filter: blur()` on the banner image, and `backdrop-filter` on the banner.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes reviewed with that lens — none; this is presentation only, and the `safeImageURL` escaping from #368 is untouched
- [x] Docs updated if user-facing behavior or setup changed — no setup change; the app-matching rules live in tests, per the CLAUDE.md comment ladder

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPyemvC6TchN6F8ZMqwdc7)_