### PR TITLE
Wait on the in-flight render before serving the OG fallback

### DIFF
--- a/opengraph-service/RAILWAY.md
+++ b/opengraph-service/RAILWAY.md
@@ -18,9 +18,9 @@ Everything else is proxied to `FRONTEND_URL` unchanged.
 | Route | Behaviour |
 |---|---|
 | `GET /healthz` | `200 {}`. |
-| `GET /og-cache/<safe-did>.png` | The cached render (`max-age=86400`). A DID with no render yet gets the branded fallback card under `max-age=60`, so the crawler comes back once the render lands. A malformed or traversing name is `404`. |
+| `GET /og-cache/<safe-did>.png` | The cached render (`max-age=86400`). A DID whose render is still in flight parks for up to `OG_PENDING_RENDER_WAIT` and serves the render if it lands; past that — or with no render in flight at all — it gets the branded fallback under `no-store`. A malformed or traversing name is `404`. |
 | `POST /og-warm/<handle>` | `202 {"warming":true\|false}`, fire-and-forget. Resolves the handle on the request, then schedules a background render only if the profile is not already cached. `false` means no render started: already fresh, the handle did not resolve, or the render cap shed it. Any other method is `405`, an empty/multi-segment handle is `404`. Unauthenticated by design — the work it can trigger is bounded by the same render cap as the crawler path, and a warm with nothing to do takes no slot. |
-| `GET /profile/<handle>` with the `Bluesky Cardyb` UA | The synthesized OG HTML, answered from the resolved DID alone. A cache miss never blocks the crawler: the render runs in the background and this crawl's image fetch gets the fallback. |
+| `GET /profile/<handle>` with the `Bluesky Cardyb` UA | The synthesized OG HTML, answered from the resolved DID alone. A cache miss never blocks the HTML: the render runs in the background and the crawl's image fetch waits on it instead. |
 
 `POST /og-warm/` is called by the client's share/copy handlers and is
 same-origin in production (the shim fronts the SPA), so it needs no CORS.
@@ -50,6 +50,7 @@ That's it for a working deploy. `PORT` is auto-injected by Railway; all `OG_*`,
 | `OG_CACHE_TTL` | `720h` (~30 days) | How long a cached image is served before a fresh indigo+render round-trip. Go duration string (`720h`, `168h`, etc.). Accepted staleness tradeoff — see issue #227. |
 | `OG_CACHE_MAX_ENTRIES` | `10000` | Max entries before LRU eviction. `0` = built-in default. One entry = one user (keyed by DID). |
 | `OG_RENDER_TIMEOUT` | `30s` | Deadline for a single `html-to-image` render. Go duration string. |
+| `OG_PENDING_RENDER_WAIT` | `3s` | How long a `/og-cache/` request holds the crawler's connection waiting on a render already in flight before serving the fallback. Go duration string; the ceiling that matters is Cardyb's own (unpublished) timeout, so shorten this if cards start failing outright rather than falling back. |
 
 ## Volume
 

--- a/opengraph-service/cmd/shim/main.go
+++ b/opengraph-service/cmd/shim/main.go
@@ -39,6 +39,7 @@ func main() {
 		cacheTTL    = flag.String("cache-ttl", envOr("OG_CACHE_TTL", "720h"), "cache TTL (Go duration; ~1 month)")
 		cacheMaxStr = flag.String("cache-max-entries", envOr("OG_CACHE_MAX_ENTRIES", "0"), "max cache entries; 0 = built-in default")
 		renderTO    = flag.String("render-timeout", envOr("OG_RENDER_TIMEOUT", "30s"), "html-to-image render deadline")
+		pendingWait = flag.String("pending-render-wait", envOr("OG_PENDING_RENDER_WAIT", ""), "how long /og-cache/ waits on an in-flight render; empty = built-in default")
 		origin      = flag.String("origin", envOr("PUBLIC_URL", "https://navyfragen.app"), "public site origin for absolute OG URLs")
 		addr        = flag.String("addr", normalizeAddr(envOr("PORT", "8080")), "listen address")
 	)
@@ -65,6 +66,10 @@ func main() {
 	backgroundCtx, stopBackground := context.WithCancel(context.Background())
 	defer stopBackground()
 	handler.BackgroundCtx = backgroundCtx
+	// Tunable because the ceiling that matters is Cardyb's own timeout, which is
+	// not published: the wait has to be shortened from the outside if a card ever
+	// starts failing outright rather than falling back.
+	handler.PendingRenderWait = parseDurationOr(*pendingWait, shim.DefaultPendingRenderWait)
 
 	log.Printf("opengraph-service shim listening on %s, proxying to %s (cache %s, ttl %s)",
 		*addr, *frontendURL, *cacheDir, ttl)

--- a/opengraph-service/internal/shim/handler.go
+++ b/opengraph-service/internal/shim/handler.go
@@ -26,6 +26,10 @@ type Handler struct {
 	// Zero means DefaultMaxConcurrentGenerate; negative disables the cap, for
 	// tests only.
 	MaxConcurrentGenerate int
+	// PendingRenderWait bounds how long an /og-cache/ request parks on a render
+	// that is already in flight before serving the fallback. Zero means
+	// DefaultPendingRenderWait; negative disables the wait.
+	PendingRenderWait time.Duration
 	// BackgroundCtx is the lifetime of fire-and-forget renders rather than any
 	// one request's context: main cancels it on shutdown so a render that has
 	// not started yet gives up instead of outliving the server. Nil means
@@ -34,6 +38,7 @@ type Handler struct {
 
 	genSem     chan struct{}
 	background sync.WaitGroup
+	pending    pendingRenders
 }
 
 // DefaultMaxConcurrentGenerate is sized to protect a single html-to-image
@@ -43,6 +48,15 @@ const DefaultMaxConcurrentGenerate = 4
 
 // DefaultGenTimeout bounds one background render when GenTimeout is unset.
 const DefaultGenTimeout = 45 * time.Second
+
+// DefaultPendingRenderWait bounds how long an image fetch parks on a render
+// that is already in flight. It is a fraction of DefaultGenTimeout on purpose:
+// the wait is spent holding the crawler's own connection, and Cardyb fetches
+// the card image exactly once — the bytes it gets are uploaded as a blob into
+// the post record, so there is no later fetch to hand a warm cache to. That
+// makes waiting worth it, and makes overrunning the crawler's timeout the one
+// outcome worse than serving the fallback.
+const DefaultPendingRenderWait = 3 * time.Second
 
 // Route prefixes the handler owns outright — they are matched before Classify,
 // so neither the Cardyb UA check nor the proxy fast path can shadow them.
@@ -54,12 +68,15 @@ const (
 	WarmPathPrefix = "/og-warm/"
 )
 
-// Cache-Control for the two things the cache route can serve. The fallback's
-// max-age is deliberately short: a crawler that caught it must come back soon
-// for the real render, which is at most seconds behind it.
+// Cache-Control for the two things the cache route can serve. The fallback is
+// no-store rather than briefly cacheable: it is a placeholder for a render that
+// did not land in time, so any consumer willing to ask again must be allowed to
+// rather than be pinned to the generic card by a header of ours. Cardyb does
+// not re-fetch either way, which is why the wait below — not this header — is
+// what actually saves a first share.
 const (
 	renderedImageCacheControl = "public, max-age=86400"
-	fallbackImageCacheControl = "public, max-age=60"
+	fallbackImageCacheControl = "no-store"
 )
 
 // NewHandler wires the handler against an upstream client URL and the injected
@@ -140,12 +157,14 @@ func (h *Handler) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 }
 
 // handleGenerate answers a crawler from the resolved DID alone. A render never
-// blocks the response: on a cache miss the same HTML goes out immediately, the
-// render runs in the background, this crawl's image fetch gets the branded
-// fallback, and the next crawl finds a warm cache. Only the handle resolution
-// can fail the request — a 404 for an unresolvable handle, a 502 for an indigo
-// failure. A failure here must NOT panic or hang the hot path; the proxy fast
-// path is unaffected.
+// blocks the HTML response: on a cache miss the same HTML goes out immediately
+// and the render runs in the background. The crawl's image fetch is where a
+// cold profile is won or lost — serveCacheFile parks it on that render for a
+// bounded wait — so the HTML going out first is a head start for the render,
+// not a decision to serve the fallback. Only the handle resolution can fail the
+// request — a 404 for an unresolvable handle, a 502 for an indigo failure. A
+// failure here must NOT panic or hang the hot path; the proxy fast path is
+// unaffected.
 //
 // [TestHandler_CacheMiss_RespondsWithoutAwaitingTheRender] and
 // [TestHandler_CacheMiss_BackgroundRenderWarmsTheNextRequest] pin both halves.
@@ -166,9 +185,7 @@ func (h *Handler) handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !resolved.Cached {
-		h.spawnRender(handle, func(ctx context.Context) error {
-			return h.Generator.EnsureRendered(ctx, resolved.DID)
-		})
+		h.spawnRender(handle, resolved.DID)
 	}
 	h.writeOGResponse(w, handle, resolved.DID)
 }
@@ -246,12 +263,10 @@ func (h *Handler) warmProfile(reqCtx context.Context, handle string) bool {
 	if resolved.Cached {
 		return false
 	}
-	return h.spawnRender(handle, func(ctx context.Context) error {
-		return h.Generator.EnsureRendered(ctx, resolved.DID)
-	})
+	return h.spawnRender(handle, resolved.DID)
 }
 
-// spawnRender runs work in a joinable background goroutine under the render
+// spawnRender renders did in a joinable background goroutine under the render
 // cap, reporting whether it started. Both entry points to html-to-image are
 // unauthenticated (a spoofable Cardyb UA, and the warm route), and singleflight
 // only dedups per DID, so an attacker rotating handles could otherwise drive
@@ -259,10 +274,15 @@ func (h *Handler) warmProfile(reqCtx context.Context, handle string) bool {
 // a slot is dropped, never queued — queueing would move the unbounded growth
 // into memory and hand the crawler a stale render minutes later anyway.
 //
+// The render is registered as pending before the goroutine starts, not inside
+// it, so the image fetch that follows this crawl's HTML response can never
+// arrive in a window where the render exists but is not yet waitable.
+//
 // [TestHandler_RenderCap_RunsBackgroundRenderWhenASlotIsFree] and
 // [TestHandler_RenderCap_DropsBackgroundRenderWhenSaturated] pin both sides of
-// the bound.
-func (h *Handler) spawnRender(handle string, work func(context.Context) error) bool {
+// the bound; [TestHandler_DroppedRender_DoesNotParkTheImageFetch] pins that a
+// render the cap shed leaves nothing behind to wait on.
+func (h *Handler) spawnRender(handle, did string) bool {
 	if err := h.backgroundContext().Err(); err != nil {
 		return false
 	}
@@ -271,13 +291,15 @@ func (h *Handler) spawnRender(handle string, work func(context.Context) error) b
 			handle, cap(h.genSem))
 		return false
 	}
+	donePending := h.pending.begin(SafeDID(did))
 	h.background.Add(1)
 	go func() {
 		defer h.background.Done()
 		defer h.releaseRenderSlot()
+		defer donePending()
 		ctx, cancel := context.WithTimeout(h.backgroundContext(), h.genTimeout())
 		defer cancel()
-		if err := work(ctx); err != nil {
+		if err := h.Generator.EnsureRendered(ctx, did); err != nil {
 			log.Printf("opengraph-service: background render for %s failed: %v", handle, err)
 		}
 	}()
@@ -296,6 +318,13 @@ func (h *Handler) genTimeout() time.Duration {
 		return h.GenTimeout
 	}
 	return DefaultGenTimeout
+}
+
+func (h *Handler) pendingRenderWait() time.Duration {
+	if h.PendingRenderWait == 0 {
+		return DefaultPendingRenderWait
+	}
+	return h.PendingRenderWait
 }
 
 func (h *Handler) acquireRenderSlot() bool {
@@ -318,12 +347,13 @@ func (h *Handler) releaseRenderSlot() {
 }
 
 // serveCacheFile streams the stored PNG for an /og-cache/:did.png request. A
-// DID whose render has not landed yet is not an error — one is in flight behind
-// it — so a miss serves the branded fallback under a short max-age instead of
-// handing the crawler a 404. A malformed path is a bad request rather than a
-// pending render and still 404s.
+// DID whose render has not landed yet is not an error — one is usually in
+// flight behind it — so a miss waits briefly for that render and, if it does
+// not arrive, serves the branded fallback rather than handing the crawler a
+// 404. A malformed path is a bad request rather than a pending render and still
+// 404s.
 //
-// [TestHandler_OgCacheMiss_ServesFallbackWithShortMaxAge],
+// [TestHandler_OgCacheMiss_ServesFallbackAsNoStore],
 // [TestHandler_OgCacheHit_ServesRenderWithLongMaxAge] and
 // [TestHandler_OgCacheMalformedName_Returns404NotFallback] pin all three.
 func (h *Handler) serveCacheFile(w http.ResponseWriter, r *http.Request) {
@@ -332,12 +362,55 @@ func (h *Handler) serveCacheFile(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	entry, err := h.Cache.LoadByPath(filepath.Join(h.Cache.Dir(), name))
+	path := filepath.Join(h.Cache.Dir(), name)
+	entry, err := h.Cache.LoadByPath(path)
+	if err != nil && h.awaitPendingRender(r.Context(), pendingKey(name)) {
+		entry, err = h.Cache.LoadByPath(path)
+	}
 	if err != nil {
 		writeImage(w, "image/png", FallbackOGImage(), fallbackImageCacheControl)
 		return
 	}
 	writeImage(w, entry.MimeType, entry.Bytes, renderedImageCacheControl)
+}
+
+// awaitPendingRender parks the request on the render already in flight for key,
+// reporting whether it finished within the wait and the cache is therefore
+// worth a second look. This is what stops a first share of a cold profile from
+// baking the generic fallback into the post record: Cardyb fetches the card
+// image once, so the only chance to give it the profile card is while it is
+// still holding this connection.
+//
+// It never starts a render. A DID nobody is rendering answers immediately with
+// the fallback, which keeps the wait off requests that could only ever time out
+// — including the ones an unauthenticated caller can invent by the thousand.
+//
+// [TestHandler_OgCacheMiss_WaitsForTheInFlightRenderAndServesIt] pins the win,
+// [TestHandler_OgCacheMiss_RenderOutlastsTheWait_ServesFallback] pins the cap,
+// [TestHandler_OgCacheMiss_NothingInFlight_ServesFallbackImmediately] pins that
+// nothing else waits, [TestHandler_OgCacheMiss_ClientDisconnects_StopsWaiting]
+// pins the hangup, and
+// [TestHandler_NegativePendingRenderWait_ServesFallbackImmediately] pins the
+// off switch.
+func (h *Handler) awaitPendingRender(ctx context.Context, key string) bool {
+	wait := h.pendingRenderWait()
+	if wait <= 0 {
+		return false
+	}
+	done := h.pending.watch(key)
+	if done == nil {
+		return false
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // cacheFileName returns the on-disk filename an /og-cache/ request maps to, or
@@ -355,6 +428,10 @@ func (h *Handler) cacheFileName(path string) string {
 	}
 	return ""
 }
+
+// pendingKey maps a validated /og-cache/ filename back to the key spawnRender
+// registered the render under, which is the SafeDID the file is named for.
+func pendingKey(name string) string { return strings.TrimSuffix(name, ".png") }
 
 func writeImage(w http.ResponseWriter, mimeType string, body []byte, cacheControl string) {
 	w.Header().Set("Content-Type", mimeType)

--- a/opengraph-service/internal/shim/handler_test.go
+++ b/opengraph-service/internal/shim/handler_test.go
@@ -439,11 +439,12 @@ type sentinelErr struct{ msg string }
 
 func (e *sentinelErr) Error() string { return e.msg }
 
-// TestHandler_OgCacheMiss_ServesFallbackWithShortMaxAge pins the inverse fix for
-// the crawler: a DID with no render yet is a pending render, not an error, so
-// the route answers with the branded card under a short max-age that expires
-// long before a real render's — the crawler comes back and gets the real image.
-func TestHandler_OgCacheMiss_ServesFallbackWithShortMaxAge(t *testing.T) {
+// TestHandler_OgCacheMiss_ServesFallbackAsNoStore pins the inverse fix for the
+// crawler: a DID with no render is not an error, so the route answers with the
+// branded card rather than a 404 — and answers it uncacheable, so a consumer
+// that would come back for the real render is never held to the generic card by
+// a header of ours.
+func TestHandler_OgCacheMiss_ServesFallbackAsNoStore(t *testing.T) {
 	fetcher, renderer := defaultStubs()
 	h := newIntegrationHandler(t, fetcher, renderer)
 
@@ -462,8 +463,228 @@ func TestHandler_OgCacheMiss_ServesFallbackWithShortMaxAge(t *testing.T) {
 	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
 		t.Fatalf("Content-Type = %q, want image/png", ct)
 	}
-	if cc := rec.Header().Get("Cache-Control"); cc != fallbackImageCacheControl {
-		t.Fatalf("Cache-Control = %q, want %q", cc, fallbackImageCacheControl)
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store — the fallback must never be cached as the profile's card", cc)
+	}
+}
+
+// TestHandler_OgCacheMiss_WaitsForTheInFlightRenderAndServesIt is the fix for
+// the cache poisoning in #371: Cardyb fetches the card image exactly once and
+// uploads those bytes into the post record, so a first share of a cold profile
+// used to pin the generic fallback permanently. The image fetch now parks on the
+// render already running behind the OG HTML and serves it when it lands.
+//
+// The 40ms release is one-directional: a scheduler slow enough to let the render
+// finish first makes this test prove less, never fail.
+func TestHandler_OgCacheMiss_WaitsForTheInFlightRenderAndServesIt(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	started, release := make(chan struct{}, 4), make(chan struct{})
+	blocked := &blockingRenderer{FakeRenderer: renderer, startedCh: started, releaseCh: release}
+	h := newIntegrationHandler(t, fetcher, blocked)
+	h.PendingRenderWait = 5 * time.Second
+
+	if rec := do(t, h, CardybUA, "/profile/integration.test"); rec.Code != http.StatusOK {
+		t.Fatalf("crawl: status %d", rec.Code)
+	}
+	<-started
+	if c := atomic.LoadInt32(&renderer.Calls); c != 0 {
+		t.Fatalf("renderer completed %d times before the image fetch — nothing was left to wait on", c)
+	}
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		close(release)
+	}()
+
+	imgRec := do(t, h, "Mozilla/5.0", "/og-cache/did-plc-integration.png")
+
+	if imgRec.Code != http.StatusOK {
+		t.Fatalf("cache serve: status %d, want 200", imgRec.Code)
+	}
+	if got := imgRec.Body.String(); got != string(renderer.PNG) {
+		t.Fatalf("served %q, want the render this fetch waited for %q", got, renderer.PNG)
+	}
+	if cc := imgRec.Header().Get("Cache-Control"); cc != renderedImageCacheControl {
+		t.Fatalf("Cache-Control = %q, want %q (a real render, not the fallback)", cc, renderedImageCacheControl)
+	}
+}
+
+// TestHandler_OgCacheMiss_RenderOutlastsTheWait_ServesFallback is the cap on the
+// wait: a render still running past PendingRenderWait gives the fallback, so a
+// cold Railway wake plus a Chromium launch cannot hold the crawler's connection
+// past its own timeout and turn a fallback card into no card at all.
+func TestHandler_OgCacheMiss_RenderOutlastsTheWait_ServesFallback(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	started, release := make(chan struct{}, 4), make(chan struct{})
+	blocked := &blockingRenderer{FakeRenderer: renderer, startedCh: started, releaseCh: release}
+	h := newIntegrationHandler(t, fetcher, blocked)
+	h.PendingRenderWait = 20 * time.Millisecond
+	defer close(release)
+
+	if rec := do(t, h, CardybUA, "/profile/integration.test"); rec.Code != http.StatusOK {
+		t.Fatalf("crawl: status %d", rec.Code)
+	}
+	<-started
+
+	imgRec := do(t, h, "Mozilla/5.0", "/og-cache/did-plc-integration.png")
+
+	if imgRec.Code != http.StatusOK {
+		t.Fatalf("cache serve: status %d, want 200 (the fallback)", imgRec.Code)
+	}
+	if !bytes.Equal(imgRec.Body.Bytes(), FallbackOGImage()) {
+		t.Fatal("a render that outlasts the wait must fall back, not hold the crawler")
+	}
+}
+
+// TestHandler_OgCacheMiss_NothingInFlight_ServesFallbackImmediately keeps the
+// wait off every request it could not possibly help. The route is
+// unauthenticated and takes an arbitrary DID, so parking on one nobody is
+// rendering would let anyone hold connections open a wait at a time.
+func TestHandler_OgCacheMiss_NothingInFlight_ServesFallbackImmediately(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	h := newIntegrationHandler(t, fetcher, renderer)
+	// Long enough that taking the wait is unmistakable rather than a slow machine.
+	h.PendingRenderWait = time.Minute
+
+	start := time.Now()
+	rec := do(t, h, "Mozilla/5.0", "/og-cache/did-plc-nobody-is-rendering.png")
+	elapsed := time.Since(start)
+
+	if !bytes.Equal(rec.Body.Bytes(), FallbackOGImage()) {
+		t.Fatal("a DID with no render in flight must get the fallback")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("waited %s on a render that does not exist", elapsed)
+	}
+}
+
+// TestHandler_OgCacheMiss_ClientDisconnects_StopsWaiting releases the wait when
+// the crawler hangs up. Serving a fallback nobody will read costs a goroutine;
+// holding it for the rest of the wait costs one for every crawler that gave up.
+func TestHandler_OgCacheMiss_ClientDisconnects_StopsWaiting(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	started, release := make(chan struct{}, 4), make(chan struct{})
+	blocked := &blockingRenderer{FakeRenderer: renderer, startedCh: started, releaseCh: release}
+	h := newIntegrationHandler(t, fetcher, blocked)
+	h.PendingRenderWait = time.Minute
+	defer close(release)
+
+	if rec := do(t, h, CardybUA, "/profile/integration.test"); rec.Code != http.StatusOK {
+		t.Fatalf("crawl: status %d", rec.Code)
+	}
+	<-started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	req := httptest.NewRequest(http.MethodGet, "/og-cache/did-plc-integration.png", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	h.ServeHTTP(rec, req)
+	elapsed := time.Since(start)
+	cancel()
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("kept waiting %s after the client went away", elapsed)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), FallbackOGImage()) {
+		t.Fatal("an abandoned wait must still resolve to the fallback, not hang or 404")
+	}
+}
+
+// TestHandler_NegativePendingRenderWait_ServesFallbackImmediately pins the
+// escape hatch. If the wait ever turns out to overrun Cardyb's own timeout —
+// which is not published, so this is a guess until production says otherwise —
+// a negative value reverts the route to answering every miss immediately, with
+// a render in flight for that exact DID.
+func TestHandler_NegativePendingRenderWait_ServesFallbackImmediately(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	started, release := make(chan struct{}, 4), make(chan struct{})
+	blocked := &blockingRenderer{FakeRenderer: renderer, startedCh: started, releaseCh: release}
+	h := newIntegrationHandler(t, fetcher, blocked)
+	h.PendingRenderWait = -1
+	defer close(release)
+
+	if rec := do(t, h, CardybUA, "/profile/integration.test"); rec.Code != http.StatusOK {
+		t.Fatalf("crawl: status %d", rec.Code)
+	}
+	<-started
+
+	rec := do(t, h, "Mozilla/5.0", "/og-cache/did-plc-integration.png")
+
+	if !bytes.Equal(rec.Body.Bytes(), FallbackOGImage()) {
+		t.Fatal("a disabled wait must serve the fallback rather than park on the render")
+	}
+}
+
+// TestHandler_DroppedRender_DoesNotParkTheImageFetch joins the wait to the
+// render cap: a render the cap shed was never registered, so the image fetch
+// behind it answers immediately instead of waiting out a render that will never
+// run.
+func TestHandler_DroppedRender_DoesNotParkTheImageFetch(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	started, release := make(chan struct{}, 8), make(chan struct{})
+	blocked := &blockingRenderer{FakeRenderer: renderer, startedCh: started, releaseCh: release}
+	h := newHandlerOn(t, newTempCache(t), &handleDIDFetcher{FakeFetcher: fetcher}, blocked)
+	h.MaxConcurrentGenerate = 1
+	h.initSem()
+	h.PendingRenderWait = time.Minute
+	defer close(release)
+
+	// Leader: parked inside the renderer, holding the only slot.
+	if rec := do(t, h, CardybUA, "/profile/leader.test"); rec.Code != http.StatusOK {
+		t.Fatalf("leader: status %d", rec.Code)
+	}
+	<-started
+	// Follower: a different DID, so its render is shed rather than coalesced.
+	if rec := do(t, h, CardybUA, "/profile/follower.test"); rec.Code != http.StatusOK {
+		t.Fatalf("follower: status %d", rec.Code)
+	}
+
+	start := time.Now()
+	rec := do(t, h, "Mozilla/5.0", "/og-cache/did-plc-follower-test.png")
+	elapsed := time.Since(start)
+
+	if !bytes.Equal(rec.Body.Bytes(), FallbackOGImage()) {
+		t.Fatal("a shed render must leave the fallback in place")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("waited %s on a render the cap dropped", elapsed)
+	}
+}
+
+// TestHandler_WarmThenCrawl_ImageFetchWaitsOnTheWarmsRender is the sequence a
+// share actually produces: the client warms on copy, Cardyb crawls moments
+// later. The crawl's image fetch has to park on the warm's render — it is the
+// same DID, so singleflight means there is only ever one render to wait for.
+func TestHandler_WarmThenCrawl_ImageFetchWaitsOnTheWarmsRender(t *testing.T) {
+	fetcher, renderer := defaultStubs()
+	started, release := make(chan struct{}, 4), make(chan struct{})
+	blocked := &blockingRenderer{FakeRenderer: renderer, startedCh: started, releaseCh: release}
+	h := newIntegrationHandler(t, fetcher, blocked)
+	h.PendingRenderWait = 5 * time.Second
+
+	if rec := doMethod(t, h, http.MethodPost, "", "/og-warm/integration.test"); rec.Code != http.StatusAccepted {
+		t.Fatalf("warm: status %d", rec.Code)
+	}
+	<-started
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		close(release)
+	}()
+
+	if rec := do(t, h, CardybUA, "/profile/integration.test"); rec.Code != http.StatusOK {
+		t.Fatalf("crawl: status %d", rec.Code)
+	}
+	imgRec := do(t, h, "Mozilla/5.0", "/og-cache/did-plc-integration.png")
+
+	if got := imgRec.Body.String(); got != string(renderer.PNG) {
+		t.Fatalf("served %q, want the warm's render %q", got, renderer.PNG)
+	}
+	h.WaitBackground()
+	if c := atomic.LoadInt32(&renderer.Calls); c != 1 {
+		t.Fatalf("renderer called %d times, want 1 (the crawl must join the warm's render)", c)
 	}
 }
 

--- a/opengraph-service/internal/shim/pending.go
+++ b/opengraph-service/internal/shim/pending.go
@@ -1,0 +1,76 @@
+package shim
+
+import "sync"
+
+// pendingRenders tracks the in-flight renders an image fetch is allowed to wait
+// on, keyed by the SafeDID that names the cache file.
+//
+// It exists because the render is no longer in front of the response. Without
+// it, the image fetch that follows the OG HTML cannot tell "a render for this
+// DID is a second away" from "nothing is coming", and has to answer both with
+// the fallback — which for Cardyb is permanent, since it fetches the card image
+// once and bakes those bytes into the post record.
+//
+// Entries are reference counted. A share-time warm and the crawl behind it each
+// begin a render for the same profile (singleflight coalesces them downstream
+// into one html-to-image call), and a waiter must stay parked until the last of
+// them is done rather than being woken by whichever finishes first.
+//
+// [TestPendingRenders_SecondBeginKeepsWaitersParkedUntilBothRelease] pins the
+// refcount and [TestPendingRenders_WatchWithNothingInFlight_ReturnsNil] pins
+// the nothing-to-wait-for answer that keeps a fallback serve immediate.
+type pendingRenders struct {
+	mu sync.Mutex
+	m  map[string]*pendingRender
+}
+
+type pendingRender struct {
+	done chan struct{}
+	refs int
+}
+
+// begin registers an in-flight render for key and returns the release that
+// closes it out. The caller MUST call the returned func exactly once when the
+// render finishes: skipping it parks every later waiter for its full wait on a
+// render that is already over.
+func (p *pendingRenders) begin(key string) func() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.m == nil {
+		p.m = make(map[string]*pendingRender)
+	}
+	entry, ok := p.m[key]
+	if !ok {
+		entry = &pendingRender{done: make(chan struct{})}
+		p.m[key] = entry
+	}
+	entry.refs++
+	return func() { p.release(key, entry) }
+}
+
+func (p *pendingRenders) release(key string, entry *pendingRender) {
+	p.mu.Lock()
+	entry.refs--
+	last := entry.refs == 0
+	if last {
+		delete(p.m, key)
+	}
+	p.mu.Unlock()
+	if last {
+		close(entry.done)
+	}
+}
+
+// watch returns the channel that closes when the in-flight render for key
+// finishes, or nil when there is no render to wait for — the caller must not
+// park in that case, or every request for a DID nobody is rendering would hold
+// a connection for the full wait.
+func (p *pendingRenders) watch(key string) <-chan struct{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	entry, ok := p.m[key]
+	if !ok {
+		return nil
+	}
+	return entry.done
+}

--- a/opengraph-service/internal/shim/pending_test.go
+++ b/opengraph-service/internal/shim/pending_test.go
@@ -1,0 +1,77 @@
+package shim
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPendingRenders_SecondBeginKeepsWaitersParkedUntilBothRelease pins the
+// refcount. A share-time warm and the crawl behind it both begin a render for
+// one profile; waking waiters when the first of them returns would hand the
+// crawler a cache the surviving render has not written yet.
+func TestPendingRenders_SecondBeginKeepsWaitersParkedUntilBothRelease(t *testing.T) {
+	var p pendingRenders
+
+	releaseWarm := p.begin("did-plc-x")
+	releaseCrawl := p.begin("did-plc-x")
+	done := p.watch("did-plc-x")
+	if done == nil {
+		t.Fatal("watch returned nil while two renders were in flight")
+	}
+
+	releaseWarm()
+	select {
+	case <-done:
+		t.Fatal("waiters woken with a render still in flight")
+	default:
+	}
+
+	releaseCrawl()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waiters still parked after the last render released")
+	}
+	if p.watch("did-plc-x") != nil {
+		t.Fatal("the key must be cleared once the last render finished, or later fetches wait on a closed render")
+	}
+}
+
+// TestPendingRenders_WatchWithNothingInFlight_ReturnsNil pins the answer that
+// keeps a fallback serve immediate: a key nobody is rendering — never begun, or
+// already released — has nothing to wait for.
+func TestPendingRenders_WatchWithNothingInFlight_ReturnsNil(t *testing.T) {
+	var p pendingRenders
+
+	if p.watch("did-plc-never-begun") != nil {
+		t.Fatal("watch on an unknown key must report nothing to wait for")
+	}
+
+	p.begin("did-plc-done")()
+	if p.watch("did-plc-done") != nil {
+		t.Fatal("watch on a finished render must report nothing to wait for")
+	}
+}
+
+// TestPendingRenders_SeparateKeysDoNotShareAWait pins that one profile's render
+// never wakes — or holds — another's.
+func TestPendingRenders_SeparateKeysDoNotShareAWait(t *testing.T) {
+	var p pendingRenders
+
+	releaseA := p.begin("did-plc-a")
+	p.begin("did-plc-b")
+
+	releaseA()
+	if p.watch("did-plc-a") != nil {
+		t.Fatal("a finished render must not stay watchable")
+	}
+	doneB := p.watch("did-plc-b")
+	if doneB == nil {
+		t.Fatal("b's render must survive a's finishing")
+	}
+	select {
+	case <-doneB:
+		t.Fatal("b's waiters were woken by a's render finishing")
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

A crawl of a cold profile served the OG HTML before any render existed, so the image fetch behind it always missed the cache and got `FallbackOGImage()`. Cardyb fetches that image exactly once and uploads the bytes into the post record as a blob, so a first share pinned the generic card permanently. "The next crawl finds a warm cache" was never going to happen.

`/og-cache/` now parks a miss on the render already running behind it, capped at `OG_PENDING_RENDER_WAIT` (default 3s), and serves that render if it lands. Past the cap, or with no render in flight at all, it falls back exactly as before. The HTML response still never blocks, so the wait is spent on the fetch that actually decides the card, and the HTML round-trip is a head start for the render rather than a write-off.

The fallback also drops from `max-age=60` to `no-store`, the second half of the issue's leaning.

## Related issue

Closes #371

## Scope

- [ ] client
- [ ] server
- [x] opengraph-service
- [ ] docker / infra (caddy, anubis)
- [x] docs

## Changes

- `internal/shim/pending.go`: a refcounted registry of in-flight renders keyed by SafeDID. Refcounted because a share-time warm and the crawl behind it both begin a render for one profile (singleflight coalesces them into one html-to-image call downstream), and a waiter must stay parked until the last of them is done.
- `spawnRender` registers the render **before** the goroutine starts, so the image fetch that follows the HTML response cannot land in a window where the render exists but is not yet waitable. It also takes a DID rather than a work closure now, since both call sites always rendered a DID.
- `serveCacheFile` retries the cache load once, after `awaitPendingRender`. That never starts a render: a DID nobody is rendering answers immediately, which keeps the wait off requests that could only time out anyway, including the ones an unauthenticated caller can invent by the thousand. A render the cap shed registers nothing, so shedding still means an immediate fallback.
- The wait releases on client hangup as well as on the cap, so an abandoned crawl does not hold a goroutine for the remainder.
- `OG_PENDING_RENDER_WAIT` is tunable because the ceiling that matters is Cardyb's own timeout, which is not published. A negative value disables the wait entirely.
- `RAILWAY.md`: route table and optional-variables table updated.

## Open question this does not answer

Cardyb's fetch timeout is not documented anywhere I could find, so 3s is a guess sized well under any plausible value. If cards ever start failing outright rather than falling back, that is the number to shorten, hence the env var. The issue's other question (how often the first crawl is the only crawl) is now moot: the blob upload means the first crawl is the only one that can matter, whatever the logs say.

Option 3 from the issue (warm on profile page load instead of copy/share) is not included. It is still worth doing if the 3s cap turns out to be too short for a cold Railway wake, but it is a separate change.

## Testing

- [x] Unit/integration tests pass locally (`go test -race -count=1 ./...`, plus `go vet` and `bun run check:doc-links`)
- [ ] E2E (Playwright) passes for affected flows
- [ ] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account

New tests: the wait serving the render, the cap falling back, nothing-in-flight answering immediately, client disconnect, a shed render not parking the fetch, the warm-then-crawl sequence a real share produces, the off switch, and the registry's refcount and key isolation. `TestHandler_OgCacheMiss_ServesFallbackWithShortMaxAge` is renamed to `...ServesFallbackAsNoStore`.

Not manually verified against a real account: that needs a deploy, and the thing to watch after one is whether first shares of cold profiles come back with profile cards.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens
- [x] Docs updated if user-facing behavior or setup changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01DE2f26hiiwmpirWSNLcPKJ)_