### PR TITLE
Point the E2E toggle specs at the new switches

### DIFF
--- a/e2e/web/customise.spec.ts
+++ b/e2e/web/customise.spec.ts
@@ -42,7 +42,7 @@ test("customise page renders the wired cards", async ({ page }) => {
 });
 
 test("inbox toggle flips and is restored afterwards", async ({ page }) => {
-  const toggle = page.getByRole("switch", { name: /accepting messages/i });
+  const toggle = page.getByRole("switch", { name: "Inbox" });
   await expect(toggle).toBeVisible({ timeout: 10_000 });
   await expect(toggle).toBeEnabled({ timeout: 10_000 });
   const initiallyChecked = await toggle.isChecked();
@@ -62,7 +62,7 @@ test("inbox toggle flips and is restored afterwards", async ({ page }) => {
 });
 
 test("profanity filter toggle flips and is restored afterwards", async ({ page }) => {
-  const toggle = page.getByRole("switch", { name: /filter enabled/i });
+  const toggle = page.getByRole("switch", { name: "Profanity filter" });
   await expect(toggle).toBeVisible({ timeout: 10_000 });
   await expect(toggle).toBeEnabled({ timeout: 10_000 });
   const initiallyChecked = await toggle.isChecked();

--- a/e2e/web/settings.spec.ts
+++ b/e2e/web/settings.spec.ts
@@ -1,9 +1,15 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.use({ storageState: "e2e/.auth/user.json" });
 
 // The PDS-sync toggle writes through to the server, so each test restores the
 // original value — the account is shared with the other spec files.
+
+async function pdsSyncEnabled(page: Page) {
+  const res = await page.request.get("/api/settings");
+  expect(res.ok(), "GET /api/settings succeeded").toBeTruthy();
+  return Boolean(((await res.json()) as { pdsSyncEnabled?: boolean }).pdsSyncEnabled);
+}
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/settings");
@@ -21,25 +27,18 @@ test("settings page renders key cards", async ({ page }) => {
   await expect(page.getByText("Push Notifications", { exact: true })).toBeVisible();
 });
 
-test("PDS sync toggle flips label and is restored afterwards", async ({ page }) => {
-  const sync = page.getByRole("button", { name: /pds sync/i });
+test("PDS sync toggle flips and is restored afterwards", async ({ page }) => {
+  const sync = page.getByRole("switch", { name: "PDS Sync" });
   await expect(sync).toBeVisible({ timeout: 10_000 });
   await expect(sync).toBeEnabled({ timeout: 10_000 });
-  const enabledLabel = page.getByRole("button", { name: "PDS Sync Enabled" });
-  const disabledLabel = page.getByRole("button", { name: "Enable PDS Sync" });
-  const initiallyEnabled = await enabledLabel.isVisible();
+  const initiallyChecked = await sync.isChecked();
 
   await sync.click();
-  if (initiallyEnabled) {
-    await expect(disabledLabel).toBeVisible({ timeout: 10_000 });
-  } else {
-    await expect(enabledLabel).toBeVisible({ timeout: 10_000 });
-  }
+  // The switch follows the settings query, so wait for the server value first.
+  await expect.poll(async () => pdsSyncEnabled(page), { timeout: 10_000 }).toBe(!initiallyChecked);
+  await expect(sync).toBeChecked({ checked: !initiallyChecked });
 
   await sync.click();
-  if (initiallyEnabled) {
-    await expect(enabledLabel).toBeVisible({ timeout: 10_000 });
-  } else {
-    await expect(disabledLabel).toBeVisible({ timeout: 10_000 });
-  }
+  await expect.poll(async () => pdsSyncEnabled(page), { timeout: 10_000 }).toBe(initiallyChecked);
+  await expect(sync).toBeChecked({ checked: initiallyChecked });
 });


### PR DESCRIPTION
## Summary

E2E on #373 fails with 3 of 34 tests red. The switch-for-toggle-button change renamed the controls the suite drives, and the specs still look for the old ones. Merges into `settings-control-affordances`, so #373 goes green.

## Related issue

Closes #

## Scope

- [ ] client
- [ ] server
- [ ] opengraph-service
- [ ] docker / infra (caddy, anubis)
- [ ] docs
- [x] e2e

## Changes

`SettingsToggle` takes the card title as its accessible name, so the old switch labels no longer exist, and PDS Sync is now a switch rather than a Button whose label carried the state.

| Spec | Old locator | New locator |
|---|---|---|
| `customise.spec.ts:44` | `switch` / `accepting messages` | `switch` / `Inbox` |
| `customise.spec.ts:64` | `switch` / `filter enabled` | `switch` / `Profanity filter` |
| `settings.spec.ts:24` | `button` / `pds sync`, asserting on `PDS Sync Enabled` vs `Enable PDS Sync` | `switch` / `PDS Sync`, asserting on checked state |

The PDS sync test now follows the same shape as the two customise toggle tests: read the switch's checked state, flip it, poll `/api/settings` for the server value, assert the switch caught up, then flip back. It keeps the restore-what-you-changed property the old label-flipping version had, since the account is shared across spec files.

## Testing

- [ ] Unit/integration tests pass locally
- [ ] E2E (Playwright) passes for affected flows
- [ ] Docker smoke test passes if server/infra changed
- [ ] Manually verified against a real Bluesky/AT Protocol account

Not run locally: the E2E stack needs Docker plus real Bluesky credentials, neither of which exists in this environment. The role and accessible names are the ones the client unit tests on #373 already query (`getByRole("switch", { name: /pds sync/i })` and friends), so the locators match what Mantine renders. CI on this branch is the real check.

## Checklist

- [x] No secrets, DIDs, tokens, or `.env` values committed
- [x] Security-sensitive changes (auth, DM handling, moderation) reviewed with that lens
- [x] Docs updated if user-facing behavior or setup changed

Test-only change, no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9PHcZSNtxzfvhZEPQvsNV)_